### PR TITLE
feat: speed up search via Compacting Index

### DIFF
--- a/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
+++ b/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
@@ -100,6 +100,11 @@ namespace CorpusSearch
             indexWriter.Flush(triggerMerge: false, applyAllDeletes: false);
         }
 
+        public void Compact()
+        {
+            indexWriter.ForceMerge(1);
+        }
+
         public ScanResult Scan(SpanQuery query)
         {
             using var reader = indexWriter.GetReader(applyAllDeletes: true);

--- a/CorpusSearch/Dependencies/Searcher.cs
+++ b/CorpusSearch/Dependencies/Searcher.cs
@@ -144,6 +144,11 @@ namespace CorpusSearch.Dependencies
             }
         }
 
+        internal void OnAllDocumentsAdded()
+        {
+            luceneSearch.Compact();
+        }
+
         internal void AddDocument(IDocument document, IEnumerable<DocumentLine> data)
         {
             this.luceneSearch.Add(document, data);

--- a/CorpusSearch/Startup.cs
+++ b/CorpusSearch/Startup.cs
@@ -156,6 +156,10 @@ namespace CorpusSearch
             {
                 Console.WriteLine($"Failed loading documents: {e}");
             }
+
+            var stopWatch = System.Diagnostics.Stopwatch.StartNew();
+            searcher.OnAllDocumentsAdded();
+            Console.WriteLine($"compacted in {stopWatch.ElapsedMilliseconds}");
         }
 
         private static void AddDocuments(List<Document> documents, WorkService workService, Searcher searcher)


### PR DESCRIPTION
Force merging down to 1 segment makes sense on a static index

Took about a second off the reference implementation.

I expect this will be a massive performance gain in PROD which has a lot more documents

