### PR TITLE
fix: back button handling

### DIFF
--- a/CorpusSearch/ClientApp/src/components/Home.js
+++ b/CorpusSearch/ClientApp/src/components/Home.js
@@ -154,6 +154,7 @@ export class Home extends Component {
     }
 
     handleChange(event) {
+        this.props.history.replace(`/?q=${event.target.value}`)
         this.setState({ value: event.target.value }, () => this.populateData());
     }
 }


### PR DESCRIPTION
Previously, selecting "back" inside the browser would blank the query
if it came from the first time the site was used