### PR TITLE
feat: Anonymous Analytics with Segment

### DIFF
--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using CorpusSearch.Utils;
 
 namespace CorpusSearch.Controllers
 {
@@ -130,6 +131,7 @@ namespace CorpusSearch.Controllers
         public async Task<QueryDocumentSearchResult> SearchCorpus(string query, bool manx = true, bool english = true, int minDate = 1600, int maxDate = 2100)
         {
             var sw = Stopwatch.StartNew();
+            AnonymousAnalytics.Track("Search Corpus");
             QueryDocumentSearchResult ret = new QueryDocumentSearchResult()
             {
                 Query = query,

--- a/CorpusSearch/CorpusSearch.csproj
+++ b/CorpusSearch/CorpusSearch.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Analytics" Version="3.8.1" />
     <PackageReference Include="CsvHelper" Version="21.3.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.33" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00014" />

--- a/CorpusSearch/Startup.cs
+++ b/CorpusSearch/Startup.cs
@@ -13,10 +13,11 @@ using CorpusSearch.Model;
 using CorpusSearch.Dependencies.csly;
 using CorpusSearch.Dependencies;
 using CorpusSearch.Service;
+using CorpusSearch.Utils;
 
 namespace CorpusSearch
 {
-    public partial class Startup
+    public class Startup
     {
         public static Dictionary<string, IList<string>> EnglishToManxDictionary { get; set; }
         public static Dictionary<string, IList<string>> ManxToEnglishDictionary { get; set; }
@@ -66,7 +67,11 @@ namespace CorpusSearch
                 app.UseHsts();
             }
 
-
+            if (!AnonymousAnalytics.Init())
+            {
+                Console.WriteLine("Failed to init anonymous analytics. Was CORPUS_SEARCH_SEGMENT_KEY set?");
+            }
+            
 
             SetupDatabase(workService, searcher);
 

--- a/CorpusSearch/Utils/AnonymousAnalytics.cs
+++ b/CorpusSearch/Utils/AnonymousAnalytics.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace CorpusSearch.Utils;
+
+public static class AnonymousAnalytics
+{
+    private static bool _hasInit;
+    public static bool Init()
+    {
+        var key = Environment.GetEnvironmentVariable("CORPUS_SEARCH_SEGMENT_KEY");
+
+        if (key == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            Segment.Analytics.Initialize(key);
+            _hasInit = true;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static void Track(string eventName)
+    {
+        if (!_hasInit)
+        {
+            return;
+        }
+        Segment.Analytics.Client.Track("Anon", eventName);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ To add/modify documents, see: [manx-search-data](https://github.com/david-alliso
 
 Deployable on a $5 DigitalOcean droplet. See GitHub actions
 
+## Analytics
+
+* Uses https://app.segment.com/ anonymously - tracking the count of searches
+
 ## Server requirements
 
 - git


### PR DESCRIPTION
Optional (for servers) and anonymous

I want to track the number of searches to measure usage over time

Sadly, proving usage will be useful for obtaining funding

Needs an environment variable `CORPUS_SEARCH_SEGMENT_KEY` set for this to work