### PR TITLE
fix: pressing back should not search for `*` by default

### DIFF
--- a/CorpusSearch/ClientApp/src/components/FetchDataDocument.tsx
+++ b/CorpusSearch/ClientApp/src/components/FetchDataDocument.tsx
@@ -134,7 +134,7 @@ export const FetchDataDocument = () => {
 
     return (
         <div>
-            <h1 id="tabelLabel" ><Link to={`/?q=${value}`} style={{ textDecoration: "none" }}>⇦</Link>  { title }</h1>
+            <h1 id="tabelLabel" ><Link to={`/?q=${q?.toString() ?? ""}`} style={{ textDecoration: "none" }}>⇦</Link>  { title }</h1>
 
             <div style={{display: "flex", flex: 1, flexGrow: 2}}>
                 <input size={5} id="corpus-search-box" style={{flexGrow: 1, marginRight: 12}} placeholder="Enter search term" type="text" value={value} onChange={(x) => setValue(x.target.value)} />


### PR DESCRIPTION
Browse -> Document -> View In Corpus -> Back

Instead of searching for "*", it now searches for "": much faster