### PR TITLE
fix: widths of 'search work'

### DIFF
--- a/CorpusSearch/ClientApp/src/components/FetchDataDocument.tsx
+++ b/CorpusSearch/ClientApp/src/components/FetchDataDocument.tsx
@@ -248,12 +248,12 @@ const ComparisonTable = (props: {
         return (
             <>
             <div>
-                <table className='table table-striped' aria-labelledby="tabelLabel">
+                <table className='table table-striped' style={{tableLayout: "fixed"}} aria-labelledby="tabelLabel">
                     <thead>
                     <tr>
                         <th>{originalManx ? "Manx" : "English"}</th>
                         <th>{originalManx ? "English" : "Manx"}</th>
-                        <th>Link</th>
+                        <th style={{width: 45}}>Link</th>
                     </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
Manx is now same size as English

Tested using chrome's responsive mode and it works well on phones