### PR TITLE
fix: home screen on Firefox

### DIFF
--- a/CorpusSearch/ClientApp/src/components/Home.tsx
+++ b/CorpusSearch/ClientApp/src/components/Home.tsx
@@ -136,8 +136,7 @@ export const HomeFC = () => {
 
             {hasNoSearch && <span style={{marginTop: 10, fontSize: "large", display: "flex", flexDirection: "column", alignContent: "center"}}>
                 <span style={{display: "inline"}}>Please enter a search term, or&nbsp;<a href={"/Browse"}>Browse</a>&nbsp;all content</span>
-                <br/>
-                <span style={{display: "inline"}}>Support our revitalisation efforts by signing up for our <a href={"/MailingList"}>mailing list</a>. We'll email once in a while with updates to the corpus & other projects.</span>
+                <span style={{display: "inline", marginTop: "1em"}}>Support our revitalisation efforts by signing up for our <a href={"/MailingList"}>mailing list</a>. We'll email once in a while with updates to the corpus & other projects.</span>
             </span>}
             {!hasNoSearch && hasError && <span style={{marginTop: 10, fontSize: "large", display: "flex", justifyContent: "center"}}>
                 Something went wrong, please try again


### PR DESCRIPTION
`<br>` wasn't handled