### PR TITLE
Remove mailing list from the top nav

### DIFF
--- a/CorpusSearch/ClientApp/src/components/NavMenu.tsx
+++ b/CorpusSearch/ClientApp/src/components/NavMenu.tsx
@@ -49,9 +49,6 @@ export class NavMenu extends Component<unknown, State> {
                         <NavItem>
                             <a className="text-dark nav-link" href="/Browse">Browse All</a>
                         </NavItem>
-                        <NavItem>
-                            <a className="text-dark nav-link" href="/MailingList">Mailing List</a>
-                        </NavItem>
                     </ul>
                     </Collapse>
                 </Container>


### PR DESCRIPTION
The UX of the mailing list page doesn't merchandise enough

Literally click link -> Form, if they click the link, we want to explain why we want people to subscribe.

This is done on the main page, we can rethink having this on the nav later.