### PR TITLE
Comparison table improvements

### DIFF
--- a/CorpusSearch/ClientApp/src/assets/index.d.ts
+++ b/CorpusSearch/ClientApp/src/assets/index.d.ts
@@ -1,3 +1,3 @@
-declare module '*.png' {
-    export default "" as string;
+declare module "*.png" {
+    export default "" as string
 }

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -156,6 +156,8 @@ export const ComparisonTable = (props: {
     const rightVisible = languageVisibility.englishVisible && originalManx || languageVisibility.manxVisible && !originalManx
     // TODO: optimise this - no need to iterate each render
     const linkVisible = response.gitHubLink || response.results.filter(x => x.page != null && (response.pdfLink || response.googleBooksId)).length > 0
+    const leftLang = originalManx ? "gv" : "en"
+    const rightLang = originalManx ? "en" : "gv"
     return (
         <>
             <div>
@@ -184,10 +186,10 @@ export const ComparisonTable = (props: {
                                     player.current.seek(line.subStart)
                                 }
                                 }}>▶️</td>}
-                                {leftVisible && <td>
+                                {leftVisible && <td lang={leftLang}>
                                     {originalManx ? manxText : englishText}
                                 </td>}
-                                {rightVisible && <td>
+                                {rightVisible && <td lang={rightLang}>
                                     {originalManx ? englishText : manxText }
                                 </td>}
                                 {linkVisible && <td>

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -154,6 +154,8 @@ export const ComparisonTable = (props: {
     const languageVisibility = useLanguageVisibility()
     const leftVisible = languageVisibility.manxVisible && originalManx || languageVisibility.englishVisible && !originalManx
     const rightVisible = languageVisibility.englishVisible && originalManx || languageVisibility.manxVisible && !originalManx
+    // TODO: optimise this - no need to iterate each render
+    const linkVisible = response.gitHubLink || response.results.filter(x => x.page != null && (response.pdfLink || response.googleBooksId)).length > 0
     return (
         <>
             <div>
@@ -166,7 +168,7 @@ export const ComparisonTable = (props: {
                         {isVideo && <th>{""}</th>}
                         {leftVisible && <th>{originalManx ? "Manx" : "English"}</th>}
                         {rightVisible && <th>{originalManx ? "English" : "Manx"}</th>}
-                        <th style={{width: 45}}>Link</th>
+                        {linkVisible && <th style={{width: 45}}>Link</th>}
                     </tr>
                     </thead>
                     <tbody>
@@ -188,7 +190,7 @@ export const ComparisonTable = (props: {
                                 {rightVisible && <td>
                                     {originalManx ? englishText : manxText }
                                 </td>}
-                                <td>
+                                {linkVisible && <td>
                                     {line.page != null && response.pdfLink &&
                                         <><a href={response.pdfLink + "#page=" + line.page} target="_blank" rel="noreferrer">p{line.page}</a>{" "}</> }
                                     {line.page != null && response.googleBooksId &&
@@ -196,7 +198,7 @@ export const ComparisonTable = (props: {
                                     {response.gitHubLink && <a href={`${response.gitHubLink}#L${line.csvLineNumber}`}>
                                         edit
                                     </a>}
-                                </td>
+                                </td>}
                             </tr>
                                 {line.notes ? <tr><td colSpan={3} className="noteRow">{line.notes}</td></tr> : null}
                             </>

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -10,6 +10,7 @@ import {diffChars} from "diff"
 import YouTuber, {Player} from "./YouTuber"
 import useInterval from "../vendor/use-interval/UseInterval"
 import "./ComparisonTable.css"
+import {useLanguageVisibility} from "../hooks/LanguageVisibility"
 
 function escapeRegex(s: string) {
     return s.replace(/[/\-\\^$*+?.()|[\]{}]/g, "\\$&")
@@ -149,7 +150,10 @@ export const ComparisonTable = (props: {
             maxHeight: "400px"
         }
     }
-    
+
+    const languageVisibility = useLanguageVisibility()
+    const leftVisible = languageVisibility.manxVisible && originalManx || languageVisibility.englishVisible && !originalManx
+    const rightVisible = languageVisibility.englishVisible && originalManx || languageVisibility.manxVisible && !originalManx
     return (
         <>
             <div>
@@ -160,8 +164,8 @@ export const ComparisonTable = (props: {
                     <thead>
                     <tr>
                         {isVideo && <th>{""}</th>}
-                        <th>{originalManx ? "Manx" : "English"}</th>
-                        <th>{originalManx ? "English" : "Manx"}</th>
+                        {leftVisible && <th>{originalManx ? "Manx" : "English"}</th>}
+                        {rightVisible && <th>{originalManx ? "English" : "Manx"}</th>}
                         <th style={{width: 45}}>Link</th>
                     </tr>
                     </thead>
@@ -178,12 +182,12 @@ export const ComparisonTable = (props: {
                                     player.current.seek(line.subStart)
                                 }
                                 }}>▶️</td>}
-                                <td>
+                                {leftVisible && <td>
                                     {originalManx ? manxText : englishText}
-                                </td>
-                                <td>
+                                </td>}
+                                {rightVisible && <td>
                                     {originalManx ? englishText : manxText }
-                                </td>
+                                </td>}
                                 <td>
                                     {line.page != null && response.pdfLink &&
                                         <><a href={response.pdfLink + "#page=" + line.page} target="_blank" rel="noreferrer">p{line.page}</a>{" "}</> }

--- a/CorpusSearch/ClientApp/src/hooks/LanguageVisibility.ts
+++ b/CorpusSearch/ClientApp/src/hooks/LanguageVisibility.ts
@@ -1,0 +1,36 @@
+import {useEffect, useState} from "react"
+
+export type LanguageVisibility = { manxVisible: boolean, englishVisible: boolean}
+export const useLanguageVisibility = (): LanguageVisibility => {
+    const [manxVisible, setManxVisible] = useState(true)
+    const [englishVisible, setEnglishVisible] = useState(true)
+    
+    // rare issue, tapping too quickly can hide both
+    if (!manxVisible && !englishVisible) {
+        setManxVisible(true)
+    }
+    
+    useEffect(() => {
+        function handleKeyDown(e: KeyboardEvent) {
+            if (e.key?.toLowerCase() == "e") {
+                if (!manxVisible && englishVisible) {
+                    // the user is making English invisible. Show the Manx
+                    setManxVisible(true)
+                }
+                setEnglishVisible(x => !x)
+                
+            } else if (e.key?.toLowerCase() == "m") {
+                if (!englishVisible && manxVisible) {
+                    // the user is making Manx invisible. Show the English
+                    setEnglishVisible(true)
+                } 
+                setManxVisible(x => !x)
+            }
+        }
+
+        document.addEventListener("keyup", handleKeyDown)
+        return () => document.removeEventListener("keyup", handleKeyDown)
+    }, [englishVisible, manxVisible])
+
+    return { manxVisible, englishVisible }
+}

--- a/CorpusSearch/Docs/keyboard_shortcuts.md
+++ b/CorpusSearch/Docs/keyboard_shortcuts.md
@@ -1,0 +1,6 @@
+## Viewing a document
+
+Either column can be hidden:
+
+* `m`: Toggle Manx
+* `e`: Toggle English


### PR DESCRIPTION
* keyboard shortcuts
* Hide 'link' if unused
* use `lang="gv"` for Manx content