### PR TITLE
chore(ci): improve docker scripts

### DIFF
--- a/CorpusSearch/Dockerfile
+++ b/CorpusSearch/Dockerfile
@@ -3,6 +3,10 @@ RUN apt-get update && apt-get install -y curl jq git
 # set in init.sh
 #USER $APP_UID
 WORKDIR /app
+
+VOLUME /var/corpus-search/dictionaries
+VOLUME /var/corpus-search/open-data
+VOLUME /var/corpus-search/closed-data
 EXPOSE 8080
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build

--- a/CorpusSearch/docker-compose.yml
+++ b/CorpusSearch/docker-compose.yml
@@ -1,8 +1,10 @@
 version: '3.7'
+# to execute: `docker-compose up --build`
 services:
   corpus-search:
-    build:
-      dockerfile: Dockerfile
+    image: "ghcr.io/david-allison/manx-corpus-search:master"
+#    build: # builds locally
+#      dockerfile: Dockerfile
     ports:
       - '127.0.0.1:7266:8080'
     volumes:

--- a/CorpusSearch/docker-compose.yml
+++ b/CorpusSearch/docker-compose.yml
@@ -7,13 +7,3 @@ services:
 #      dockerfile: Dockerfile
     ports:
       - '127.0.0.1:7266:8080'
-    volumes:
-      - dictionaries:/var/corpus-search/dictionaries
-      - manx-search-data:/var/corpus-search/open-data
-      - corpus-search-data-private:/var/corpus-search/closed-data
-
-volumes:
-  dictionaries:
-  manx-search-data:
-  corpus-search-data-private:
-   


### PR DESCRIPTION
Moving volumes out of compose removes the chance of user error