### PR TITLE
build: fix flaky build

### DIFF
--- a/CorpusSearch.Test/CorpusSearch.Test.csproj
+++ b/CorpusSearch.Test/CorpusSearch.Test.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
 
     <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
 
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
`dotnet publish` wanted to build tests even though they were not necessary

This started occurring after moving to net8.0

* Fixes #207