### PR TITLE
chore: remove .net 8 references

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.1.0
-      - run: dotnet test --framework net8.0
-      - run: dotnet publish --framework net8.0 
+      - run: dotnet test
+      - run: dotnet publish
       
       

--- a/CorpusSearch/Dockerfile
+++ b/CorpusSearch/Dockerfile
@@ -27,7 +27,7 @@ RUN dotnet build "CorpusSearch.csproj" -c $BUILD_CONFIGURATION -o /app/build
 WORKDIR /src
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN source ~/.nvm/nvm.sh && dotnet publish "CorpusSearch/CorpusSearch.csproj" -c $BUILD_CONFIGURATION -f net8.0 -o /app/publish /p:UseAppHost=false
+RUN source ~/.nvm/nvm.sh && dotnet publish "CorpusSearch/CorpusSearch.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
We only publish for .net 8, so this is no longer necessary