### PR TITLE
feat(browse): "Original" on left side

### DIFF
--- a/CorpusSearch/Controllers/BrowseController.cs
+++ b/CorpusSearch/Controllers/BrowseController.cs
@@ -31,6 +31,7 @@ public class BrowseController(DocumentSearchService documentSearchService, WorkS
         ViewData["GitHubLink"] = document.GetGitHubLink();
         ViewData["DownloadText"] = document.GetDownloadTextLink();
         ViewData["DownloadMetadata"] = document.GetDownloadMetadataLink();
+        ViewData["OriginalLanguage"] = document.Original;
         ViewData["docId"] = documentId;
         ViewData["lines"] = lines;
         return View("~/Views/Browse/Browse.cshtml");

--- a/CorpusSearch/Model/IDocument.cs
+++ b/CorpusSearch/Model/IDocument.cs
@@ -26,6 +26,11 @@ public interface IDocument
     string Notes { get; }
     string Source { get; }
         
+    /// <summary>The language which the original document is in</summary>
+    /// <remarks>
+    /// Typically <code>"Manx"</code> or <code>"English"</code>, but other values are possible
+    /// </remarks>
+    /// <remarks>By convention, we display the original on the left (if known)</remarks>
     string Original { get; }
 
     IDictionary<string, object> GetAllExtensionData();

--- a/CorpusSearch/Views/Browse/Browse.cshtml
+++ b/CorpusSearch/Views/Browse/Browse.cshtml
@@ -60,10 +60,10 @@
             {
                 var index = x.IndexOf(". ", StringComparison.Ordinal);
                 // if there's only two strings and the second is small, don't split on .
-                // This stops (Cregeen) or (Kelly) ending u[ on the second line
+                // This stops (Cregeen) or (Kelly) ending up on the second line
                 if (index == -1 || (x.Length - index < 150)) 
                 {
-                    return new[] { x };
+                    return [x];
                 }
                 return new [] { x[..(index + 1)], x[(index + 1)..] }.Where(s => !string.IsNullOrEmpty(s));
             })

--- a/CorpusSearch/Views/Browse/Browse.cshtml
+++ b/CorpusSearch/Views/Browse/Browse.cshtml
@@ -1,4 +1,5 @@
-﻿@using CorpusSearch.Model
+﻿@* See BrowseController.cs *@
+@using CorpusSearch.Model
 
 <!doctype html>
 <html lang="en">
@@ -73,11 +74,15 @@
 
 @* TODO: Add all fields from the JSON here *@
 
+@{
+    var manxOnLeftSide = ViewData["OriginalLanguage"]?.ToString() != "English";
+}
+
 <table class='table table-striped text-center' style="table-layout: fixed; width: 100%">
 <thead>
 <tr>
-    <th class="text-center" style="width: 50%">Manx</th>
-    <th class="text-center" style="width: 50%">English</th>
+    <th class="text-center" style="width: 50%">@(manxOnLeftSide ? "Manx" : "English")</th>
+    <th class="text-center" style="width: 50%">@(manxOnLeftSide ? "English" : "Manx")</th>
 </tr>
 </thead>
     <tbody>
@@ -85,10 +90,10 @@
         {
             <tr>
                 <td>
-                    @line.Manx
+                    @(manxOnLeftSide ? line.Manx : line.English) 
                 </td>
                 <td>
-                    @line.English
+                    @(manxOnLeftSide ? line.English : line.Manx)
                 </td>
                     @* {line.page != null && response.pdfLink && *@
                     @* <a href={response.pdfLink + "#page=" + line.page} target="_blank" rel="noreferrer">p{line.page}</a> } *@


### PR DESCRIPTION
This is a convention on the main corpus
But was not implemented on the 'Browse' endpoints

* Fixes #235