### PR TITLE
fix(home): recent docs & footer

### DIFF
--- a/CorpusSearch/ClientApp/public/site-design.css
+++ b/CorpusSearch/ClientApp/public/site-design.css
@@ -134,11 +134,11 @@ input, button, select {
 .page-main {
     max-width: 1020px;
     margin: 0 auto;
-    padding: 34px 24px 80px 24px;
+    padding: 34px 24px 16px 24px;
 }
 
 .site-footer {
-    margin-top: 70px;
+    margin-top: 16px;
     border-top: 1px solid var(--c-border-header);
     padding-top: 18px;
     display: flex;

--- a/CorpusSearch/ClientApp/src/custom.css
+++ b/CorpusSearch/ClientApp/src/custom.css
@@ -152,7 +152,7 @@ input, button, select {
 
 /* ============ Footer (all pages) ============ */
 .site-footer {
-    margin-top: 70px;
+    margin-top: 16px;
     border-top: 1px solid var(--c-border-header);
     padding-top: 18px;
     display: flex;

--- a/CorpusSearch/ClientApp/src/routes/Home.css
+++ b/CorpusSearch/ClientApp/src/routes/Home.css
@@ -34,7 +34,7 @@
 }
 
 .recent-docs {
-    margin-top: 52px;
+    margin-top: 30px;
     max-width: 640px;
     margin-left: auto;
     margin-right: auto;

--- a/CorpusSearch/ClientApp/src/routes/Home.css
+++ b/CorpusSearch/ClientApp/src/routes/Home.css
@@ -50,14 +50,17 @@
 .recent-doc-row {
     display: flex;
     justify-content: space-between;
+    align-items: baseline;
     gap: 16px;
-    flex-wrap: wrap;
 }
 
 .recent-doc-row a {
     text-decoration: none;
     color: var(--c-ink);
     font-family: var(--font-display);
+    /* long titles wrap in their own column; the date stays pinned right */
+    flex: 1;
+    min-width: 0;
 }
 
 .recent-doc-row a:hover {
@@ -67,6 +70,7 @@
 .recent-doc-date {
     color: var(--c-muted-2);
     font-size: 13px;
+    white-space: nowrap;
 }
 
 .home-support {


### PR DESCRIPTION
Recent docs didn't appear in dev, but was too tall, so the footer got pushed off the end of the screen

There was also a wrapping bug on long titles where the date was pushed to the next line