### PR TITLE
feat(app): handle 'query too long' with error message

### DIFF
--- a/CorpusSearch.Test/SearchControllerTest.cs
+++ b/CorpusSearch.Test/SearchControllerTest.cs
@@ -1,0 +1,63 @@
+using System.Threading.Tasks;
+using CorpusSearch.Controllers;
+using CorpusSearch.Model;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+[TestFixture]
+public class SearchControllerTest
+{
+    private static readonly string MaxLengthQuery = new('a', CorpusSearchQuery.MAX_LENGTH);
+    private static readonly string TooLongQuery = new('a', CorpusSearchQuery.MAX_LENGTH + 1);
+
+    /// <remarks>Services are not used here.</remarks>
+    private static SearchController GetController() => new(null, null, [], null);
+
+    [Test]
+    public async Task SearchCorpusRejectsTooLongQuery()
+    {
+        var result = await GetController().SearchCorpus(TooLongQuery);
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(result.Value, Is.Null);
+    }
+
+    [Test]
+    public async Task SearchWorkRejectsTooLongQuery()
+    {
+        var result = await GetController().SearchWork("anyIdent", TooLongQuery);
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(result.Value, Is.Null);
+    }
+
+    [Test]
+    public void QueryAtMaxLengthIsValid()
+    {
+        var query = new CorpusSearchQuery(MaxLengthQuery) { Manx = true };
+        Assert.That(query.IsValid(), Is.True);
+    }
+
+    [Test]
+    public void QueryOverMaxLengthIsInvalid()
+    {
+        var query = new CorpusSearchQuery(TooLongQuery) { Manx = true };
+        Assert.That(query.IsValid(), Is.False);
+    }
+
+    [Test]
+    public void WorkQueryAtMaxLengthIsValid()
+    {
+        var query = new CorpusSearchWorkQuery(MaxLengthQuery) { Ident = "anyIdent", Manx = true };
+        Assert.That(query.IsValid(), Is.True);
+    }
+
+    [Test]
+    public void WorkQueryOverMaxLengthIsInvalid()
+    {
+        var query = new CorpusSearchWorkQuery(TooLongQuery) { Ident = "anyIdent", Manx = true };
+        Assert.That(query.IsValid(), Is.False);
+    }
+}

--- a/CorpusSearch/ClientApp/src/api/SearchApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchApi.ts
@@ -1,3 +1,6 @@
+// Keep in sync with CorpusSearchQuery.MAX_LENGTH
+export const MAX_QUERY_LENGTH = 100
+
 export type DictionaryDefinition = {
     entries: string[]
     allowLookup: boolean
@@ -44,6 +47,9 @@ export const search = async (
         `search/search/${query}?minDate=${params.minDate}&maxDate=${params.maxDate}&manx=${params.manx.toString()}&english=${params.english.toString()}`,
         { signal },
     )
+    if (!response.ok) {
+        throw new Error(`search failed: ${response.status}`)
+    }
     // TODO: Validation
     const ret = (await response.json()) as SearchResponse
 

--- a/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
@@ -42,6 +42,9 @@ type WorkSearch = {
     searchManx: boolean
 }
 
+/**
+ * @throws Error if the search fails (e.g. query is too long)
+ */
 export const searchWork = async (
     params: WorkSearch,
     signal?: AbortSignal,
@@ -51,5 +54,8 @@ export const searchWork = async (
         `search/searchWork/${params.docIdent}/${encodeURIComponent(searchValue)}?english=${params.searchEnglish.toString()}&manx=${params.searchManx.toString()}`,
         { signal },
     )
+    if (!response.ok) {
+        throw new Error(`work search failed: ${response.status}`)
+    }
     return (await response.json()) as SearchWorkResponse
 }

--- a/CorpusSearch/ClientApp/src/routes/Home.test.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { Home } from "./Home"
+import { MAX_QUERY_LENGTH } from "../api/SearchApi"
+
+// stub fetch so tests never hit the network; callers route to their error state
+const fetchMock = vi.fn<typeof fetch>(() =>
+    Promise.reject(new Error("fetch is disabled in tests")),
+)
+vi.stubGlobal("fetch", fetchMock)
+
+beforeEach(() => {
+    fetchMock.mockClear()
+})
+
+afterEach(cleanup)
+
+const renderWithQuery = (query: string) =>
+    render(
+        <MemoryRouter initialEntries={[`/?q=${encodeURIComponent(query)}`]}>
+            <Home />
+        </MemoryRouter>,
+    )
+
+const searchRequests = () =>
+    fetchMock.mock.calls.filter(
+        ([url]) => typeof url === "string" && url.includes("search/"),
+    )
+
+// #229
+describe("query too long", () => {
+    it("shows a message and does not call the server", () => {
+        renderWithQuery("a".repeat(MAX_QUERY_LENGTH + 1))
+
+        expect(screen.getByText(/too long/)).toBeTruthy()
+        expect(searchRequests()).toHaveLength(0)
+    })
+
+    it("searches when the query is at the limit", async () => {
+        renderWithQuery("a".repeat(MAX_QUERY_LENGTH))
+
+        // the stubbed fetch rejects, so a search attempt shows the error state
+        await screen.findByText(/Something went wrong/)
+        expect(screen.queryByText(/too long/)).toBeNull()
+        expect(searchRequests()).toHaveLength(1)
+    })
+})

--- a/CorpusSearch/ClientApp/src/routes/Home.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.tsx
@@ -22,7 +22,12 @@ import {
 import { hasTranslations, TranslationList } from "../components/TranslationList"
 import AdvancedOptions, { DateRange } from "../components/AdvancedOptions"
 import { useSearchParams } from "react-router-dom"
-import { search, SearchResponse, SearchParams } from "../api/SearchApi"
+import {
+    search,
+    SearchResponse,
+    SearchParams,
+    MAX_QUERY_LENGTH,
+} from "../api/SearchApi"
 import { CircularProgress } from "@mui/material"
 import { ManxEnglishSelector } from "../components/ManxEnglishSelector"
 import { getCorpusStatistics, Statistics } from "../api/CorpusStatistics"
@@ -118,10 +123,12 @@ export const Home = () => {
     )
 
     const hasNoSearch = query.trim() == ""
+    // the server rejects long queries; "match phrase" adds 2 characters
+    const queryTooLong = request.query.length > MAX_QUERY_LENGTH
 
     // load the data
     useEffect(() => {
-        if (hasNoSearch) {
+        if (hasNoSearch || queryTooLong) {
             return
         }
 
@@ -138,7 +145,7 @@ export const Home = () => {
             }
         })
         return () => controller.abort()
-    }, [request, hasNoSearch])
+    }, [request, hasNoSearch, queryTooLong])
 
     const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
         setQuery(event.target.value)
@@ -155,6 +162,14 @@ export const Home = () => {
                 <Suspense fallback={<ProgressBar />}>
                     <HomeIntro statsPromise={statsPromise} />
                 </Suspense>
+            )
+        }
+        if (queryTooLong) {
+            return (
+                <div className={"home-error"}>
+                    Search text is too long. The maximum is {MAX_QUERY_LENGTH}{" "}
+                    characters.
+                </div>
             )
         }
         if (result === null) {

--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -105,8 +105,12 @@ public partial class SearchController(
     }
 
     [HttpGet("SearchWork/{workIdent}/{query}")]
-    public async Task<SearchWorkResult> SearchWork(string workIdent, string query = null, bool manx = true, bool english = true)
+    public async Task<ActionResult<SearchWorkResult>> SearchWork(string workIdent, string query = null, bool manx = true, bool english = true)
     {
+        if (QueryTooLong(query))
+        {
+            return QueryTooLongResult();
+        }
         var sw = Stopwatch.StartNew();
         AnonymousAnalytics.Track("Search Work");
         var workQuery = new CorpusSearchWorkQuery(query)
@@ -138,7 +142,8 @@ public partial class SearchController(
     {
         // PREF: Much slower than necessary
         if (matchNumber < 1 || query == null || workIdent == null) return null;
-        var workResult = await SearchWork(workIdent, query: query, manx: true, english: false);
+        var workResult = (await SearchWork(workIdent, query: query, manx: true, english: false)).Value;
+        if (workResult == null) return null;
         var selectedIndex = QueryMatchIndex(workResult.Results, matchNumber);
         if (selectedIndex == null) return null;
         return new MatchReference(workIdent, matchNumber, workResult.Results[selectedIndex.Value.LineIndex].Manx, 
@@ -168,8 +173,12 @@ public partial class SearchController(
     }
 
     [HttpGet("Search/{query}")]
-    public async Task<QueryDocumentSearchResult> SearchCorpus(string query, bool manx = true, bool english = true, int minDate = 1600, int maxDate = 2100)
+    public async Task<ActionResult<QueryDocumentSearchResult>> SearchCorpus(string query, bool manx = true, bool english = true, int minDate = 1600, int maxDate = 2100)
     {
+        if (QueryTooLong(query))
+        {
+            return QueryTooLongResult();
+        }
         var sw = Stopwatch.StartNew();
         AnonymousAnalytics.Track("Search Corpus");
         QueryDocumentSearchResult ret = new QueryDocumentSearchResult()
@@ -209,6 +218,11 @@ public partial class SearchController(
         ret.NumberOfDocuments = ret.Results.Count;
         return ret;
     }
+
+    private static bool QueryTooLong(string query) => query is { Length: > CorpusSearchQuery.MAX_LENGTH };
+
+    private BadRequestObjectResult QueryTooLongResult() =>
+        BadRequest($"Query too long: the maximum is {CorpusSearchQuery.MAX_LENGTH} characters");
 
     private Dictionary<string, DictionaryData> DictionaryLookup(string query, QueryLanguages languages)
     {

--- a/CorpusSearch/Model/CorpusSearchQuery.cs
+++ b/CorpusSearch/Model/CorpusSearchQuery.cs
@@ -4,6 +4,9 @@ namespace CorpusSearch.Model;
 
 public class CorpusSearchQuery(string query)
 {
+    /// <summary>Keep this in sync with `MAX_QUERY_LENGTH`</summary>
+    public const int MAX_LENGTH = 100;
+
     public string Query { get; } = query;
 
     public bool Manx { get; internal set; }
@@ -14,7 +17,7 @@ public class CorpusSearchQuery(string query)
 
     internal bool IsValid()
     {
-        if (string.IsNullOrWhiteSpace(Query) || Query.Length > 100)
+        if (string.IsNullOrWhiteSpace(Query) || Query.Length > MAX_LENGTH)
         {
             return false;
         }

--- a/CorpusSearch/Model/CorpusSearchWorkQuery.cs
+++ b/CorpusSearch/Model/CorpusSearchWorkQuery.cs
@@ -10,7 +10,7 @@ public class CorpusSearchWorkQuery(string query)
 
     internal bool IsValid()
     {
-        if (string.IsNullOrWhiteSpace(Query) || string.IsNullOrEmpty(Ident) || Query.Length > 100)
+        if (string.IsNullOrWhiteSpace(Query) || string.IsNullOrEmpty(Ident) || Query.Length > CorpusSearchQuery.MAX_LENGTH)
         {
             return false;
         }


### PR DESCRIPTION
Previously it failed silently

- Fixes #229