### PR TITLE
build(deps): replace build break on vulns with CI and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      nuget-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/CorpusSearch/ClientApp"
+    schedule:
+      interval: "monthly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,34 @@
+name: Dependency Audit
+
+# Check vulnerability advisories on a schedule
+#
+# Note: GitHub disables scheduled workflows after 60 days without repository
+# activity; re-enable from the Actions tab if that happens.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  audit:
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      NUGET_XMLDOC_MODE: skip
+    name: NuGet Vulnerability Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+      - run: dotnet restore
+      - name: Check for vulnerable packages
+        run: |
+          output=$(dotnet list package --vulnerable --include-transitive)
+          echo "$output"
+          if grep -q "has the following vulnerable packages" <<< "$output"; then
+            echo "::error::Vulnerable packages found, see the log above. Reproduce locally with: dotnet list package --vulnerable --include-transitive"
+            exit 1
+          fi

--- a/CorpusSearch/CorpusSearch.csproj
+++ b/CorpusSearch/CorpusSearch.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
@@ -12,6 +12,9 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Keep NuGet audit findings as warnings (#227). They introduce temporal coupling.
+    The 'Dependency Audit' workflow and Dependabot are better for this use case. -->
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Breaking the build introduces temporal coupling and breaks `git bisect`.

Instead, have dependabot alerting handle this and add an action to confirm fixes are merged.

By default, .NET does not break the build, our 'warnings as errors' caused this.

- Fixes #227