### PR TITLE
feat(client-app) - link to multidict if there are no results.

### DIFF
--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -10,6 +10,7 @@ import {
     ReactNode,
 } from "react"
 import { manxDictionaryLookup } from "../api/DictionaryApi"
+import { getMultidictLookupWord, MultidictLink } from "./MultidictLink"
 import Highlighter from "react-highlight-words"
 import { Box, CircularProgress, Modal } from "@mui/material"
 import Typography from "@mui/material/Typography"
@@ -95,6 +96,7 @@ export const ComparisonTable = (props: {
     const [modalOpen, setModalOpen] = useState(false)
     const [modalText, setModalText] = useState("")
     const handleModalClose = () => setModalOpen(false)
+    const modalMultidictWord = getMultidictLookupWord(modalText)
 
     const [modalValue, setModalValue] = useState<string | null>(null)
 
@@ -532,7 +534,18 @@ export const ComparisonTable = (props: {
                             />
                         )}
                         {modalValue == "" && (
-                            <span>Could not find definition</span>
+                            <span>
+                                Could not find definition
+                                {modalMultidictWord != null && (
+                                    <>
+                                        {". Try searching "}
+                                        <MultidictLink
+                                            word={modalMultidictWord}
+                                            language="Manx"
+                                        />
+                                    </>
+                                )}
+                            </span>
                         )}
                     </Typography>
                 </Box>

--- a/CorpusSearch/ClientApp/src/components/MultidictLink.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/MultidictLink.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { getMultidictLookupWord, multidictUrl } from "./MultidictLink"
+
+describe("getMultidictLookupWord", () => {
+    it("accepts a single word", () => {
+        expect(getMultidictLookupWord("moghrey")).toBe("moghrey")
+    })
+
+    it("strips the wildcards added by 'match phrase'", () => {
+        expect(getMultidictLookupWord("*moghrey*")).toBe("moghrey")
+    })
+
+    it("accepts words with apostrophes and hyphens", () => {
+        expect(getMultidictLookupWord("'sy")).toBe("'sy")
+        expect(getMultidictLookupWord("lhiann-oo")).toBe("lhiann-oo")
+    })
+
+    it("rejects phrases", () => {
+        expect(getMultidictLookupWord("moghrey mie")).toBeNull()
+    })
+
+    it("rejects wildcard queries", () => {
+        expect(getMultidictLookupWord("mogh*ey")).toBeNull()
+        expect(getMultidictLookupWord("mogh?ey")).toBeNull()
+    })
+
+    it("rejects empty queries", () => {
+        expect(getMultidictLookupWord("")).toBeNull()
+        expect(getMultidictLookupWord("*")).toBeNull()
+        expect(getMultidictLookupWord("  ")).toBeNull()
+    })
+})
+
+describe("multidictUrl", () => {
+    it("looks up Manx to English", () => {
+        expect(multidictUrl("moghrey", "Manx")).toBe(
+            "https://multidict.net/multidict/?word=moghrey&sl=gv&tl=en",
+        )
+    })
+
+    it("looks up English to Manx", () => {
+        expect(multidictUrl("morning", "English")).toBe(
+            "https://multidict.net/multidict/?word=morning&sl=en&tl=gv",
+        )
+    })
+
+    it("escapes the word", () => {
+        expect(multidictUrl("çhengey", "Manx")).toBe(
+            "https://multidict.net/multidict/?word=%C3%A7hengey&sl=gv&tl=en",
+        )
+    })
+})

--- a/CorpusSearch/ClientApp/src/components/MultidictLink.tsx
+++ b/CorpusSearch/ClientApp/src/components/MultidictLink.tsx
@@ -1,0 +1,52 @@
+import { SearchLanguage } from "../routes/Home"
+
+/**
+ * Extracts a single word suitable for a Multidict lookup, or null.
+ *
+ * Multidict looks up single words, so phrases and wildcard queries are
+ * rejected. "Match phrase" searches wrap the query in asterisks; these are
+ * stripped.
+ *
+ * TODO: get this metadata (whether a raw word was provided) from the server.
+ */
+export const getMultidictLookupWord = (query: string): string | null => {
+    const word = query.replace(/^\*+|\*+$/g, "").trim()
+    if (word == "" || /[\s*?"()[\]]/.test(word)) {
+        return null
+    }
+    return word
+}
+
+export const multidictUrl = (word: string, language: SearchLanguage) => {
+    const sourceLanguage = language === "Manx" ? "gv" : "en"
+    const targetLanguage = language === "Manx" ? "en" : "gv"
+    return `https://multidict.net/multidict/?word=${encodeURIComponent(word)}&sl=${sourceLanguage}&tl=${targetLanguage}`
+}
+
+/** A link to https://multidict.net/, searching many dictionaries at once */
+export const MultidictLink = (props: {
+    word: string
+    language: SearchLanguage
+}) => (
+    <a
+        href={multidictUrl(props.word, props.language)}
+        target="_blank"
+        rel="noreferrer"
+    >
+        Multidict
+    </a>
+)
+
+/** Shown in the dictionary strip when none of our dictionaries know the word */
+export const MultidictNotFoundRow = (props: {
+    word: string
+    language: SearchLanguage
+}) => (
+    <div className="dict-strip-row">
+        <span className="dict-strip-label">Dictionaries:</span>
+        <span className="dict-strip-text">
+            No results found. Try searching{" "}
+            <MultidictLink word={props.word} language={props.language} />
+        </span>
+    </div>
+)

--- a/CorpusSearch/ClientApp/src/routes/Home.test.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { cleanup, render, screen } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import { Home } from "./Home"
-import { MAX_QUERY_LENGTH } from "../api/SearchApi"
+import { MAX_QUERY_LENGTH, SearchResponse } from "../api/SearchApi"
 
 // stub fetch so tests never hit the network; callers route to their error state
 const fetchMock = vi.fn<typeof fetch>(() =>
@@ -44,5 +44,56 @@ describe("query too long", () => {
         await screen.findByText(/Something went wrong/)
         expect(screen.queryByText(/too long/)).toBeNull()
         expect(searchRequests()).toHaveLength(1)
+    })
+})
+
+const emptySearchResponse = (query: string): SearchResponse => ({
+    results: [],
+    query,
+    numberOfResults: 0,
+    numberOfDocuments: 0,
+    timeTaken: "0ms",
+    definedInDictionaries: {},
+    translations: {},
+})
+
+// #134
+describe("multidict lookup", () => {
+    it("links to Multidict when no dictionary knows the word", async () => {
+        fetchMock.mockImplementation(() =>
+            Promise.resolve(Response.json(emptySearchResponse("cabbyldereen"))),
+        )
+        renderWithQuery("cabbyldereen")
+
+        const link = await screen.findByRole("link", { name: "Multidict" })
+        expect(link.getAttribute("href")).toBe(
+            "https://multidict.net/multidict/?word=cabbyldereen&sl=gv&tl=en",
+        )
+    })
+
+    it("does not link to Multidict for phrases", async () => {
+        fetchMock.mockImplementation(() =>
+            Promise.resolve(Response.json(emptySearchResponse("moghrey mie"))),
+        )
+        renderWithQuery("moghrey mie")
+
+        await screen.findByText(/No matches/)
+        expect(screen.queryByRole("link", { name: "Multidict" })).toBeNull()
+    })
+
+    it("does not link to Multidict when a dictionary knows the word", async () => {
+        const response: SearchResponse = {
+            ...emptySearchResponse("moghrey"),
+            definedInDictionaries: {
+                Cregeen: { entries: ["morning"], allowLookup: false },
+            },
+        }
+        fetchMock.mockImplementation(() =>
+            Promise.resolve(Response.json(response)),
+        )
+        renderWithQuery("moghrey")
+
+        await screen.findByText(/morning/)
+        expect(screen.queryByRole("link", { name: "Multidict" })).toBeNull()
     })
 })

--- a/CorpusSearch/ClientApp/src/routes/Home.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.tsx
@@ -19,6 +19,10 @@ import {
     DictionaryLink,
     hasDictionaryDefinitions,
 } from "../components/DictionaryLink"
+import {
+    getMultidictLookupWord,
+    MultidictNotFoundRow,
+} from "../components/MultidictLink"
 import { hasTranslations, TranslationList } from "../components/TranslationList"
 import AdvancedOptions, { DateRange } from "../components/AdvancedOptions"
 import { useSearchParams } from "react-router-dom"
@@ -192,6 +196,7 @@ export const Home = () => {
             >
                 <SearchResultHeader
                     response={result.data}
+                    searchLanguage={searchLanguage}
                     sortKey={sortKey}
                     onSortKeyChange={setSortKey}
                     density={density}
@@ -325,6 +330,7 @@ const ViewSelect = (props: {
 
 const SearchResultHeader = (props: {
     response: SearchResponse
+    searchLanguage: SearchLanguage
     sortKey: ResultsSortKey
     onSortKeyChange: (key: ResultsSortKey) => void
     density: ResultsDensity
@@ -335,6 +341,9 @@ const SearchResultHeader = (props: {
 
     const isDict = hasDictionaryDefinitions(response.definedInDictionaries)
     const isTranslation = hasTranslations(response.translations)
+    // if no dictionary knows the word, offer an external Multidict lookup
+    const multidictWord =
+        !isDict && !isTranslation ? getMultidictLookupWord(query) : null
 
     return (
         <div>
@@ -371,7 +380,7 @@ const SearchResultHeader = (props: {
                     </label>
                 </div>
             </div>
-            {(isDict || isTranslation) && (
+            {(isDict || isTranslation || multidictWord != null) && (
                 <div className="dict-strip">
                     {isDict && (
                         <DictionaryLink
@@ -381,6 +390,12 @@ const SearchResultHeader = (props: {
                     )}
                     {isTranslation && (
                         <TranslationList translations={response.translations} />
+                    )}
+                    {multidictWord != null && (
+                        <MultidictNotFoundRow
+                            word={multidictWord}
+                            language={props.searchLanguage}
+                        />
                     )}
                 </div>
             )}


### PR DESCRIPTION
...no results.

A link is added:
* on 'tap word' modal definition
* on 'no dictionary' entry
----

- Fixes #134