### PR TITLE
build(deps): only group minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       nuget-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/CorpusSearch/ClientApp"
@@ -17,6 +20,9 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Major updates often break the build, batching them adds complexity.

Caused by the following

- https://github.com/david-allison/manx-corpus-search/pull/264
- https://github.com/david-allison/manx-corpus-search/pull/263