### PR TITLE
feat(search): 'ignore hyphens' search option

### DIFF
--- a/CorpusSearch.Test/HighlightingTest.cs
+++ b/CorpusSearch.Test/HighlightingTest.cs
@@ -15,10 +15,10 @@ public class HighlightingTest : QueryBase
 {
     private const string DOC = "doc";
 
-    private SearchResult SearchWork(string query, SearchType type = SearchType.Manx)
+    private SearchResult SearchWork(string query, SearchType type = SearchType.Manx, bool ignoreHyphens = false)
     {
         return new Searcher(luceneIndex, parser)
-            .SearchWork(DOC, query, new SearchOptions { Type = type });
+            .SearchWork(DOC, query, new SearchOptions { Type = type, IgnoreHyphens = ignoreHyphens });
     }
 
     /// <summary>The substrings of the raw text selected by the returned highlight ranges</summary>
@@ -202,9 +202,55 @@ public class HighlightingTest : QueryBase
         Assert.That(result.Lines.Select(x => x.ManxHighlights), Is.All.Null);
     }
 
+    [Test]
+    public void IgnoreHyphensHighlightsTheSpacedForm()
+    {
+        // #18 - a hyphenated query matches (and must highlight) the spaced form
+        this.AddManxDoc(DOC, "s’beg lhiam lhiat");
+        var line = SearchWork("lhiam-lhiat", ignoreHyphens: true).Lines.Single();
+        Assert.That(Highlighted(line.Manx, line.ManxHighlights), Is.EqualTo(new[] { "lhiam lhiat" }));
+    }
+
+    [Test]
+    public void IgnoreHyphensHighlightsThePunctuatedSpacedForm()
+    {
+        // punctuation is a token separator, so 'lhiam, lhiat' matches as a phrase:
+        // the highlight covers the whole stretch, comma included
+        this.AddManxDoc(DOC, "S’beg lhiam, lhiat, lesh");
+        var line = SearchWork("lhiam-lhiat", ignoreHyphens: true).Lines.Single();
+        Assert.That(Highlighted(line.Manx, line.ManxHighlights), Is.EqualTo(new[] { "lhiam, lhiat" }));
+    }
+
+    [Test]
+    public void IgnoreHyphensHighlightsTheHyphenatedForm()
+    {
+        // #18 - the reverse direction: a spaced query highlights the single hyphenated token
+        this.AddManxDoc(DOC, "she lhiam-lhiat eh");
+        var line = SearchWork("lhiam lhiat", ignoreHyphens: true).Lines.Single();
+        Assert.That(Highlighted(line.Manx, line.ManxHighlights), Is.EqualTo(new[] { "lhiam-lhiat" }));
+    }
+
+    [Test]
+    public void IgnoreHyphensJoinedQueryHighlightsTheHyphenatedForm()
+    {
+        this.AddManxDoc(DOC, "she lhiam-lhiat eh");
+        var line = SearchWork("lhiamlhiat", ignoreHyphens: true).Lines.Single();
+        Assert.That(Highlighted(line.Manx, line.ManxHighlights), Is.EqualTo(new[] { "lhiam-lhiat" }));
+    }
+
     private ScanResult Scan(string query, ScanOptions options = null)
     {
         return new Searcher(luceneIndex, parser).Scan(query, options ?? ScanOptions.Default);
+    }
+
+    [Test]
+    public void ScanIgnoringHyphensHighlightsTheSample()
+    {
+        // the corpus-search sample line gets the same hyphen-insensitive highlights
+        this.AddManxDoc(DOC, "she lhiam-lhiat eh");
+        var result = Scan("lhiam lhiat", new ScanOptions { IgnoreHyphens = true })
+            .DocumentResults.Single();
+        Assert.That(Highlighted(result.Sample, result.SampleHighlights), Is.EqualTo(new[] { "lhiam-lhiat" }));
     }
 
     [Test]

--- a/CorpusSearch.Test/QueryParserTest.cs
+++ b/CorpusSearch.Test/QueryParserTest.cs
@@ -466,6 +466,116 @@ public class QueryParserTest : QueryBase
         Assert.That(resultCre.NumberOfSegments, Is.EqualTo(1), "could not find 'cre'");
         Assert.That(resultCreErbee.NumberOfSegments, Is.EqualTo(1), "could not find 'cre-erbee'");
     }
+
+    [Test]
+    public void TestIgnoreHyphensWithHyphenatedQuery()
+    {
+        // #18 - hyphens, spaces and joined words are interchangeable
+        this.AddManxDoc("1", "lhiam-lhiat", "lhiam lhiat", "lhiamlhiat");
+
+        var withOption = Query("lhiam-lhiat", new ScanOptions { IgnoreHyphens = true });
+        var withoutOption = Query("lhiam-lhiat");
+
+        Assert.That(withOption.NumberOfSegments, Is.EqualTo(3), "should match all three forms");
+        Assert.That(withoutOption.NumberOfSegments, Is.EqualTo(1), "by default, only the hyphenated form should match");
+    }
+
+    [Test]
+    public void TestIgnoreHyphensWithSpacedQuery()
+    {
+        // #18 - a space-separated query should also match the hyphenated/joined forms
+        this.AddManxDoc("1", "lhiam-lhiat", "lhiam lhiat", "lhiamlhiat");
+
+        var withOption = Query("lhiam lhiat", new ScanOptions { IgnoreHyphens = true });
+        var withoutOption = Query("lhiam lhiat");
+
+        Assert.That(withOption.NumberOfSegments, Is.EqualTo(3), "should match all three forms");
+        Assert.That(withoutOption.NumberOfSegments, Is.EqualTo(1), "by default, only the spaced form should match");
+    }
+
+    [Test]
+    public void TestIgnoreHyphensWithJoinedQuery()
+    {
+        // a joined query cannot know where a space would fall, so 'lhiam lhiat' is not matched
+        this.AddManxDoc("1", "lhiam-lhiat", "lhiam lhiat", "lhiamlhiat");
+
+        var withOption = Query("lhiamlhiat", new ScanOptions { IgnoreHyphens = true });
+        var withoutOption = Query("lhiamlhiat");
+
+        Assert.That(withOption.NumberOfSegments, Is.EqualTo(2), "should match the hyphenated and joined forms");
+        Assert.That(withoutOption.NumberOfSegments, Is.EqualTo(1), "by default, only the joined form should match");
+    }
+
+    [Test]
+    public void TestIgnoreHyphensWithinPhrase()
+    {
+        // the hyphenated word can sit inside a longer phrase
+        this.AddManxDoc("1", "yn lhiam-lhiat mooar", "yn lhiam lhiat mooar", "yn lhiamlhiat mooar");
+
+        var result = Query("yn lhiam lhiat mooar", new ScanOptions { IgnoreHyphens = true });
+
+        Assert.That(result.NumberOfSegments, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void TestIgnoreHyphensWithDiacritics()
+    {
+        // IgnoreHyphens composes with diacritic normalization
+        this.AddManxDoc("1", "çhione-jiarg");
+
+        var result = Query("chione jiarg", new ScanOptions { IgnoreHyphens = true });
+
+        Assert.That(result.NumberOfSegments, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TestIgnoreHyphensWithThreePartWord()
+    {
+        // all mixed groupings of a three-part word match
+        this.AddManxDoc("1", "cur-my-ner", "cur my ner", "curmyner", "cur-my ner", "cur my-ner");
+
+        var result = Query("cur my ner", new ScanOptions { IgnoreHyphens = true });
+
+        Assert.That(result.NumberOfSegments, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void TestIgnoreHyphensWithHyphenRuns()
+    {
+        // a run of hyphens (e.g. an ASCII em-dash: 'a---b') is still 'a hyphen'
+        this.AddManxDoc("1", "cur---my");
+
+        Assert.That(Query("cur---my", new ScanOptions { IgnoreHyphens = true }).NumberOfSegments,
+            Is.EqualTo(1), "could not find 'cur---my' with its own text");
+        Assert.That(Query("cur-my", new ScanOptions { IgnoreHyphens = true }).NumberOfSegments,
+            Is.EqualTo(1), "could not find 'cur---my' with 'cur-my'");
+        Assert.That(Query("cur my", new ScanOptions { IgnoreHyphens = true }).NumberOfSegments,
+            Is.EqualTo(1), "could not find 'cur---my' with 'cur my'");
+        Assert.That(Query("curmy", new ScanOptions { IgnoreHyphens = true }).NumberOfSegments,
+            Is.EqualTo(1), "could not find 'cur---my' with 'curmy'");
+    }
+
+    [Test]
+    public void TestIgnoreHyphensWithLeadingHyphen()
+    {
+        // dialogue dashes: '—Cre' is indexed as the single token '-cre'
+        this.AddManxDoc("1", "—Cre t’ou");
+
+        var result = Query("cre", new ScanOptions { IgnoreHyphens = true });
+
+        Assert.That(result.NumberOfSegments, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TestIgnoreHyphensWithEnDash()
+    {
+        // '–' is normalized to '-' on both the index and the query
+        this.AddManxDoc("1", "lhiam–lhiat");
+
+        var result = Query("lhiam lhiat", new ScanOptions { IgnoreHyphens = true });
+
+        Assert.That(result.NumberOfSegments, Is.EqualTo(1));
+    }
         
     [Test]
     public void OrPrefix()

--- a/CorpusSearch/ClientApp/src/api/Matches.ts
+++ b/CorpusSearch/ClientApp/src/api/Matches.ts
@@ -14,6 +14,7 @@ type MatchQuery = {
     docIdent: string
     query: string
     match: number
+    ignoreHyphens: boolean
 }
 
 /** Given (document, query, matchIndex):  return a the matched line + information on the match,
@@ -34,7 +35,7 @@ export const GetMatch = async (
     signal?: AbortSignal,
 ): Promise<MatchReference> => {
     const response = await fetch(
-        `search/Match/${params.docIdent}/?query=${params.query}&match=${params.match}`,
+        `search/Match/${params.docIdent}/?query=${params.query}&match=${params.match}&ignoreHyphens=${params.ignoreHyphens.toString()}`,
         { signal },
     )
     return (await response.json()) as MatchReference

--- a/CorpusSearch/ClientApp/src/api/SearchApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchApi.ts
@@ -48,6 +48,8 @@ export type SearchParams = {
     maxDate: number
     manx: boolean
     english: boolean
+    /** Hyphens, spaces and joined words are interchangeable: "lhiam-lhiat" matches "lhiam lhiat" and "lhiamlhiat" */
+    ignoreHyphens: boolean
 }
 
 export const search = async (
@@ -56,7 +58,7 @@ export const search = async (
 ): Promise<SearchResponse> => {
     const query = encodeURIComponent(params.query)
     const response = await fetch(
-        `search/search/${query}?minDate=${params.minDate}&maxDate=${params.maxDate}&manx=${params.manx.toString()}&english=${params.english.toString()}`,
+        `search/search/${query}?minDate=${params.minDate}&maxDate=${params.maxDate}&manx=${params.manx.toString()}&english=${params.english.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}`,
         { signal },
     )
     if (!response.ok) {

--- a/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
@@ -44,6 +44,8 @@ type WorkSearch = {
     value: string
     searchEnglish: boolean
     searchManx: boolean
+    /** Hyphens, spaces and joined words are interchangeable: "lhiam-lhiat" matches "lhiam lhiat" and "lhiamlhiat" */
+    ignoreHyphens: boolean
 }
 
 /**
@@ -55,7 +57,7 @@ export const searchWork = async (
 ): Promise<SearchWorkResponse> => {
     const searchValue = !params.value ? "*" : params.value
     const response = await fetch(
-        `search/searchWork/${params.docIdent}/${encodeURIComponent(searchValue)}?english=${params.searchEnglish.toString()}&manx=${params.searchManx.toString()}`,
+        `search/searchWork/${params.docIdent}/${encodeURIComponent(searchValue)}?english=${params.searchEnglish.toString()}&manx=${params.searchManx.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}`,
         { signal },
     )
     if (!response.ok) {

--- a/CorpusSearch/ClientApp/src/components/AdvancedOptions.tsx
+++ b/CorpusSearch/ClientApp/src/components/AdvancedOptions.tsx
@@ -10,6 +10,7 @@ export type DateRange = {
 const AdvancedOptions = (props: {
     onDateRangeChange: (range: DateRange) => void
     onMatchChange: (match: boolean) => void
+    onIgnoreHyphensChange: (ignoreHyphens: boolean) => void
     children?: ReactNode
 }) => {
     // keep the raw text so clearing a field while typing doesn't snap the value back
@@ -64,9 +65,38 @@ const AdvancedOptions = (props: {
                     />
                 </span>
                 <MatchWithinWords onMatchChange={props.onMatchChange} />
+                <IgnoreHyphens
+                    onIgnoreHyphensChange={props.onIgnoreHyphensChange}
+                />
                 {props.children}
             </div>
         </details>
+    )
+}
+
+const IgnoreHyphens = (props: {
+    onIgnoreHyphensChange: (ignoreHyphens: boolean) => void
+}) => {
+    const [ignoreHyphens, setIgnoreHyphens] = useState(false)
+
+    const onIgnoreHyphensChanged = (event: ChangeEvent<HTMLInputElement>) => {
+        setIgnoreHyphens(event.target.checked)
+        props.onIgnoreHyphensChange(event.target.checked)
+    }
+
+    return (
+        <label
+            className="advanced-options-match"
+            title="“lhiam-lhiat” also matches “lhiam lhiat” and “lhiamlhiat” (and vice-versa)"
+        >
+            <input
+                id="ignoreHyphens"
+                type="checkbox"
+                checked={ignoreHyphens}
+                onChange={onIgnoreHyphensChanged}
+            />
+            Ignore hyphens
+        </label>
     )
 }
 

--- a/CorpusSearch/ClientApp/src/components/MainSearchResults.tsx
+++ b/CorpusSearch/ClientApp/src/components/MainSearchResults.tsx
@@ -118,6 +118,7 @@ export default function MainSearchResults(props: {
     results: SearchResultEntry[]
     english: boolean
     manx: boolean
+    ignoreHyphens: boolean
     sortKey: ResultsSortKey
     density: ResultsDensity
 }) {
@@ -141,6 +142,7 @@ export default function MainSearchResults(props: {
                         result={result}
                         query={query}
                         manx={props.manx}
+                        ignoreHyphens={props.ignoreHyphens}
                         striped={i % 2 === 1}
                     />
                 ))}
@@ -156,6 +158,7 @@ export default function MainSearchResults(props: {
                     result={result}
                     query={query}
                     manx={props.manx}
+                    ignoreHyphens={props.ignoreHyphens}
                 />
             ))}
         </div>
@@ -163,7 +166,11 @@ export default function MainSearchResults(props: {
 }
 
 /** Stepping through the matches of a document via the GetMatch API (KWIC) */
-const useMatchStepper = (result: SearchResultEntry, query: string) => {
+const useMatchStepper = (
+    result: SearchResultEntry,
+    query: string,
+    ignoreHyphens: boolean,
+) => {
     const [matchNumber, setMatchNumber] = useState(1) // 1-based
     const [sample, setSample] = useState(result.sample)
     const [highlights, setHighlights] = useState(result.sampleHighlights ?? [])
@@ -174,6 +181,7 @@ const useMatchStepper = (result: SearchResultEntry, query: string) => {
             query: query,
             match: line,
             docIdent: result.ident,
+            ignoreHyphens,
         })
         setSample(lineResult.manx)
         setHighlights(lineResult.highlights ?? [])
@@ -261,10 +269,11 @@ const documentLink = (
     result: SearchResultEntry,
     query: string,
     manx: boolean,
+    ignoreHyphens: boolean,
 ) => ({
     to: {
         pathname: `/docs/${result.ident}`,
-        search: `?q=${query}`,
+        search: `?q=${query}` + (ignoreHyphens ? "&ignoreHyphens=true" : ""),
     },
     state: { searchLanguage: manx ? "Manx" : "English", previousPage: "/" },
 })
@@ -274,10 +283,11 @@ const ResultCard = (props: {
     result: SearchResultEntry
     query: string
     manx: boolean
+    ignoreHyphens: boolean
 }) => {
-    const { result, query, manx } = props
-    const stepper = useMatchStepper(result, query)
-    const link = documentLink(result, query, manx)
+    const { result, query, manx, ignoreHyphens } = props
+    const stepper = useMatchStepper(result, query, ignoreHyphens)
+    const link = documentLink(result, query, manx, ignoreHyphens)
 
     return (
         <div className="result-card">
@@ -310,11 +320,12 @@ const ResultRow = (props: {
     result: SearchResultEntry
     query: string
     manx: boolean
+    ignoreHyphens: boolean
     striped: boolean
 }) => {
-    const { result, query, manx, striped } = props
-    const stepper = useMatchStepper(result, query)
-    const link = documentLink(result, query, manx)
+    const { result, query, manx, ignoreHyphens, striped } = props
+    const stepper = useMatchStepper(result, query, ignoreHyphens)
+    const link = documentLink(result, query, manx, ignoreHyphens)
 
     return (
         <div className={"results-compact-row" + (striped ? " striped" : "")}>

--- a/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
+++ b/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
@@ -169,6 +169,9 @@ export const DocumentView = () => {
 
     // the 'q' parameter from the querystring
     const q = new URLSearchParams(location.search).get("q")
+    // set when following a result of a hyphen-insensitive corpus search, so the counts match
+    const ignoreHyphens =
+        new URLSearchParams(location.search).get("ignoreHyphens") === "true"
 
     const [value, setValue] = useState(q ?? "*")
 
@@ -208,6 +211,7 @@ export const DocumentView = () => {
                     value,
                     searchEnglish,
                     searchManx,
+                    ignoreHyphens,
                 })
                 setSearchWorkResponse(data)
                 setTitle(data.title)
@@ -215,7 +219,7 @@ export const DocumentView = () => {
                 console.error(e)
             }
         })
-    }, [value, searchEnglish, searchManx, docIdent])
+    }, [value, searchEnglish, searchManx, docIdent, ignoreHyphens])
 
     const [metadata, setMetadata] = useState<Metadata | null>(null)
     const [showAllMeta, setShowAllMeta] = useState(false)

--- a/CorpusSearch/ClientApp/src/routes/Home.test.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { cleanup, render, screen } from "@testing-library/react"
+import {
+    cleanup,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import { Home } from "./Home"
 import { MAX_QUERY_LENGTH, SearchResponse } from "../api/SearchApi"
@@ -44,6 +50,20 @@ describe("query too long", () => {
         await screen.findByText(/Something went wrong/)
         expect(screen.queryByText(/too long/)).toBeNull()
         expect(searchRequests()).toHaveLength(1)
+    })
+})
+
+describe("ignore hyphens option", () => {
+    it("is sent to the server when toggled", async () => {
+        renderWithQuery("lhiam-lhiat")
+
+        await screen.findByText(/Something went wrong/)
+        expect(searchRequests().at(-1)?.[0]).toContain("ignoreHyphens=false")
+
+        fireEvent.click(screen.getByLabelText("Ignore hyphens"))
+
+        await waitFor(() => expect(searchRequests()).toHaveLength(2))
+        expect(searchRequests().at(-1)?.[0]).toContain("ignoreHyphens=true")
     })
 })
 

--- a/CorpusSearch/ClientApp/src/routes/Home.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.tsx
@@ -103,6 +103,7 @@ export const Home = () => {
         end: HomeData.currentYear,
     })
     const [matchPhrase, setMatchPhrase] = useState(false)
+    const [ignoreHyphens, setIgnoreHyphens] = useState(false)
 
     const [sortKey, setSortKey] = useState<ResultsSortKey>("year")
     const [density, setDensityState] = useState<ResultsDensity>(loadDensity)
@@ -122,8 +123,9 @@ export const Home = () => {
             maxDate: dateRange.end,
             manx: searchLanguage === "Manx",
             english: searchLanguage === "English",
+            ignoreHyphens,
         }),
-        [query, searchLanguage, dateRange, matchPhrase],
+        [query, searchLanguage, dateRange, matchPhrase, ignoreHyphens],
     )
 
     const hasNoSearch = query.trim() == ""
@@ -213,6 +215,7 @@ export const Home = () => {
                         results={result.data.results}
                         manx={searchLanguage == "Manx"}
                         english={searchLanguage == "English"}
+                        ignoreHyphens={ignoreHyphens}
                         sortKey={sortKey}
                         density={density}
                     />
@@ -241,6 +244,7 @@ export const Home = () => {
             <AdvancedOptions
                 onDateRangeChange={setDateRange}
                 onMatchChange={setMatchPhrase}
+                onIgnoreHyphensChange={setIgnoreHyphens}
             >
                 {/*on mobile the View control lives here rather than in the results header*/}
                 {!hasNoSearch && (

--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -105,7 +105,7 @@ public partial class SearchController(
     }
 
     [HttpGet("SearchWork/{workIdent}/{query}")]
-    public async Task<ActionResult<SearchWorkResult>> SearchWork(string workIdent, string query = null, bool manx = true, bool english = true)
+    public async Task<ActionResult<SearchWorkResult>> SearchWork(string workIdent, string query = null, bool manx = true, bool english = true, bool ignoreHyphens = false)
     {
         if (QueryTooLong(query))
         {
@@ -118,6 +118,7 @@ public partial class SearchController(
             Ident = workIdent,
             Manx = manx,
             English = english,
+            IgnoreHyphens = ignoreHyphens,
         };
         SearchWorkResult ret = await documentSearchService.SearchWork(workQuery);
 
@@ -138,11 +139,11 @@ public partial class SearchController(
     }
 
     [HttpGet("Match/{workIdent}")]
-    public async Task<MatchReference> GetMatch(string workIdent, [FromQuery] string query, [FromQuery(Name = "match")] int matchNumber)
+    public async Task<MatchReference> GetMatch(string workIdent, [FromQuery] string query, [FromQuery(Name = "match")] int matchNumber, bool ignoreHyphens = false)
     {
         // PREF: Much slower than necessary
         if (matchNumber < 1 || query == null || workIdent == null) return null;
-        var workResult = (await SearchWork(workIdent, query: query, manx: true, english: false)).Value;
+        var workResult = (await SearchWork(workIdent, query: query, manx: true, english: false, ignoreHyphens: ignoreHyphens)).Value;
         if (workResult == null) return null;
         var selectedIndex = QueryMatchIndex(workResult.Results, matchNumber);
         if (selectedIndex == null) return null;
@@ -175,7 +176,7 @@ public partial class SearchController(
     }
 
     [HttpGet("Search/{query}")]
-    public async Task<ActionResult<QueryDocumentSearchResult>> SearchCorpus(string query, bool manx = true, bool english = true, int minDate = 1600, int maxDate = 2100)
+    public async Task<ActionResult<QueryDocumentSearchResult>> SearchCorpus(string query, bool manx = true, bool english = true, int minDate = 1600, int maxDate = 2100, bool ignoreHyphens = false)
     {
         if (QueryTooLong(query))
         {
@@ -193,7 +194,8 @@ public partial class SearchController(
             Manx = manx,
             English = english,
             MinDate = DateTimeUtil.FromYear(Math.Max(1, minDate)),
-            MaxDate = DateTimeUtil.FromYearMax(maxDate)
+            MaxDate = DateTimeUtil.FromYearMax(maxDate),
+            IgnoreHyphens = ignoreHyphens,
         };
         if (!searchQuery.IsValid())
         {

--- a/CorpusSearch/Dependencies/Lucene/ManxQuery.cs
+++ b/CorpusSearch/Dependencies/Lucene/ManxQuery.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace CorpusSearch.Dependencies.Lucene;
 
-public class ManxQuery(Term term) : AutomatonQuery(GetTerm(term), ToAutomaton(term))
+public class ManxQuery(Term term, bool ignoreHyphens = false) : AutomatonQuery(GetTerm(term), ToAutomaton(term, ignoreHyphens))
 {
     private static Term GetTerm(Term term)
     {
@@ -20,7 +20,7 @@ public class ManxQuery(Term term) : AutomatonQuery(GetTerm(term), ToAutomaton(te
     /// </summary>
     public virtual Term Term => base.m_term;
 
-    private static Automaton ToAutomaton(Term term)
+    private static Automaton ToAutomaton(Term term, bool ignoreHyphens)
     {
         IList<Automaton> automata = new List<Automaton>();
 
@@ -29,6 +29,19 @@ public class ManxQuery(Term term) : AutomatonQuery(GetTerm(term), ToAutomaton(te
         for (int i = 0; i < wildcardText.Length; i++)
         {
             char c = wildcardText[i];
+
+            // hyphens in the token are ignorable: drop them from the query and allow any run
+            // of hyphens before each character instead, so 'lhiamlhiat' matches 'lhiam-lhiat',
+            // 'cur-my' matches 'cur---my' (an ASCII em-dash) and 'cre' matches '-cre'
+            // (a dialogue dash)
+            if (ignoreHyphens)
+            {
+                if (c == '-')
+                {
+                    continue;
+                }
+                automata.Add(BasicOperations.Repeat(BasicAutomata.MakeChar('-')));
+            }
 
             // any string
             if (c ==  '*')

--- a/CorpusSearch/Dependencies/Searcher.cs
+++ b/CorpusSearch/Dependencies/Searcher.cs
@@ -18,7 +18,7 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
     internal SearchResult SearchWork(string ident, string query, SearchOptions options)
     {
         // HACK: use the ScanOptions as they're the same for now
-        var scanOptionsHack = new ScanOptions { SearchType = options.Type };
+        var scanOptionsHack = new ScanOptions { SearchType = options.Type, IgnoreHyphens = options.IgnoreHyphens };
 
         // Detect '*' on the normalized*query to handle '.*'.
         // Intended for good faith use, not security hardening.
@@ -105,6 +105,14 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
                 return new SpanNearQuery([left, right], int.MaxValue, false);
             }
             case AdjacentWordExpression e:
+                if (searchOptions.IgnoreHyphens)
+                {
+                    var atoms = e.Words.SelectMany(w => SplitAtoms(GetTerm(w, searchOptions))).ToList();
+                    if (atoms.Count > 0)
+                    {
+                        return HyphenAgnosticQuery(atoms, searchOptions);
+                    }
+                }
                 var queries = e.Words.Select(ToManx);
                 return new SpanNearQuery(queries.ToArray(), 0, true);
             case NotExpression e:
@@ -122,15 +130,86 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
 
     private static SpanQuery ManxTermQuery(string value, ScanOptions searchOptions)
     {
-        Term term = new Term(GetTermKey(searchOptions), GetTerm(value, searchOptions));
+        var normalizedTerm = GetTerm(value, searchOptions);
+        if (searchOptions.IgnoreHyphens)
+        {
+            var atoms = SplitAtoms(normalizedTerm);
+            if (atoms.Length > 0)
+            {
+                return HyphenAgnosticQuery(atoms, searchOptions);
+            }
+        }
+        return SingleTokenQuery(normalizedTerm, searchOptions, ignoreHyphens: false);
+    }
+
+    /// <summary>
+    /// A query where hyphens, spaces and joined words are interchangeable: the atoms of
+    /// 'lhiam-lhiat' (or of 'lhiam lhiat') match 'lhiam-lhiat', 'lhiam lhiat' and 'lhiamlhiat'.
+    /// </summary>
+    /// <param name="atoms">the hyphen/space-separated parts of the query, in order</param>
+    private static SpanQuery HyphenAgnosticQuery(IReadOnlyList<string> atoms, ScanOptions searchOptions)
+    {
+        // one alternative per way of regrouping adjacent atoms into tokens:
+        // [lhiam, lhiat] => the token 'lhiamlhiat' (which also matches 'lhiam-lhiat', see
+        // ManxQuery) or the phrase 'lhiam lhiat'
+        var alternatives = Segmentations(atoms)
+            .Select(tokens => tokens.Count == 1
+                ? TokenQuery(tokens[0])
+                : new SpanNearQuery(tokens.Select(TokenQuery).ToArray(), 0, true))
+            .ToArray();
+        return alternatives.Length == 1 ? alternatives[0] : new SpanOrQuery(alternatives);
+
+        SpanQuery TokenQuery(string token) => SingleTokenQuery(token, searchOptions, ignoreHyphens: true);
+    }
+
+    /// <summary>Every way of regrouping adjacent atoms into tokens (2^(n-1) for n atoms)</summary>
+    private static List<List<string>> Segmentations(IReadOnlyList<string> atoms)
+    {
+        // guard against pathological queries: only the fully-split and fully-joined forms
+        const int maxAtomsForFullExpansion = 5;
+        if (atoms.Count > maxAtomsForFullExpansion)
+        {
+            return [atoms.ToList(), [string.Concat(atoms)]];
+        }
+
+        var result = new List<List<string>>();
+        for (int joinMask = 0; joinMask < 1 << (atoms.Count - 1); joinMask++)
+        {
+            var tokens = new List<string>();
+            var current = atoms[0];
+            for (int i = 1; i < atoms.Count; i++)
+            {
+                if ((joinMask & (1 << (i - 1))) != 0)
+                {
+                    current += atoms[i];
+                }
+                else
+                {
+                    tokens.Add(current);
+                    current = atoms[i];
+                }
+            }
+            tokens.Add(current);
+            result.Add(tokens);
+        }
+        return result;
+    }
+
+    /// <summary>Splits a normalized term on hyphens (and any spaces normalization introduced)</summary>
+    private static string[] SplitAtoms(string normalizedTerm) =>
+        normalizedTerm.Split(['-', ' '], StringSplitOptions.RemoveEmptyEntries);
+
+    private static SpanQuery SingleTokenQuery(string normalizedTerm, ScanOptions searchOptions, bool ignoreHyphens)
+    {
+        Term term = new Term(GetTermKey(searchOptions), normalizedTerm);
         if (searchOptions.NormalizeDiacritics)
         {
-            var manx = new ManxQuery(term);
+            var manx = new ManxQuery(term, ignoreHyphens);
             return new SpanMultiTermQueryWrapper<ManxQuery>(manx);
         }
-        else if (ExtendedWildcardQuery.AppliesTo(value))
+        else if (ExtendedWildcardQuery.AppliesTo(normalizedTerm))
         {
-            return new SpanMultiTermQueryWrapper<ExtendedWildcardQuery>(new ExtendedWildcardQuery(term)); 
+            return new SpanMultiTermQueryWrapper<ExtendedWildcardQuery>(new ExtendedWildcardQuery(term));
         }
         else
         {

--- a/CorpusSearch/Docs/searching.md
+++ b/CorpusSearch/Docs/searching.md
@@ -35,3 +35,15 @@ The system allows three wildcards. These can appear at either end, or the middle
 * `*` - matches zero or more characters. `as*` will match `as` and `ashoonyn`
 * `+` - matches one or more character. `as+` will match `ashoonyn`, but not `as`
 * `_` - matches one character. `agh_` will match `aght` but not `agh` or `aghin`
+
+## Ignore hyphens
+
+By default, hyphens are significant: `lhiam-lhiat`, `lhiam lhiat` and `lhiamlhiat` are three different searches.
+
+Ticking `Ignore hyphens` under `Advanced options` makes hyphens, spaces and joined words interchangeable, so any of the three searches above matches all of:
+
+* `lhiam-lhiat`
+* `lhiam lhiat`
+* `lhiamlhiat`
+
+The exception: a search with no hyphen or space (`lhiamlhiat`) will not match the spaced form (`lhiam lhiat`), as the system cannot know where the word would be split.

--- a/CorpusSearch/Model/CorpusSearchQuery.cs
+++ b/CorpusSearch/Model/CorpusSearchQuery.cs
@@ -14,6 +14,8 @@ public class CorpusSearchQuery(string query)
     public DateTime MinDate { get; internal set; }
     public DateTime MaxDate { get; internal set; }
     public bool CaseSensitive { get; internal set; }
+    /// <inheritdoc cref="ScanOptions.IgnoreHyphens"/>
+    public bool IgnoreHyphens { get; internal set; }
 
     internal bool IsValid()
     {

--- a/CorpusSearch/Model/CorpusSearchWorkQuery.cs
+++ b/CorpusSearch/Model/CorpusSearchWorkQuery.cs
@@ -7,6 +7,8 @@ public class CorpusSearchWorkQuery(string query)
     public string Ident { get; set; }
     public bool Manx { get; set; }
     public bool English { get; set; }
+    /// <inheritdoc cref="ScanOptions.IgnoreHyphens"/>
+    public bool IgnoreHyphens { get; set; }
 
     internal bool IsValid()
     {

--- a/CorpusSearch/Model/ScanOptions.cs
+++ b/CorpusSearch/Model/ScanOptions.cs
@@ -10,6 +10,12 @@ public class ScanOptions
     /// Whether we want 'ç' to match 'c' (and other diacritics)
     /// </summary>
     public bool NormalizeDiacritics { get; set; } = true;
+
+    /// <summary>
+    /// Whether hyphens, spaces and joined words are interchangeable:
+    /// 'lhiam-lhiat' matches 'lhiam lhiat' and 'lhiamlhiat' (and vice-versa)
+    /// </summary>
+    public bool IgnoreHyphens { get; set; }
     public DateTime MaxDate { get; internal set; }
     public DateTime MinDate { get; internal set; }
     public SearchType SearchType { get; internal set; }

--- a/CorpusSearch/Model/SearchOptions.cs
+++ b/CorpusSearch/Model/SearchOptions.cs
@@ -4,4 +4,6 @@ public class SearchOptions
 {
     public SearchType Type { get; set; }
     public bool ReturnTranscriptData { get; set; }
+    /// <inheritdoc cref="ScanOptions.IgnoreHyphens"/>
+    public bool IgnoreHyphens { get; set; }
 }

--- a/CorpusSearch/Service/DocumentSearchService.cs
+++ b/CorpusSearch/Service/DocumentSearchService.cs
@@ -60,6 +60,7 @@ public class DocumentSearchService(
         return new SearchOptions
         {
             Type = workQuery.Manx ? SearchType.Manx : SearchType.English,
+            IgnoreHyphens = workQuery.IgnoreHyphens,
         };
     }
 }

--- a/CorpusSearch/Service/OverviewSearchService2.cs
+++ b/CorpusSearch/Service/OverviewSearchService2.cs
@@ -36,6 +36,7 @@ public class OverviewSearchService2(WorkService workService, Searcher searcher)
         options.MaxDate = searchQuery.MaxDate;
         options.MinDate = searchQuery.MinDate;
         options.SearchType = searchQuery.Manx ? SearchType.Manx : SearchType.English;
+        options.IgnoreHyphens = searchQuery.IgnoreHyphens;
 
         return options;
     }


### PR DESCRIPTION
'lhiam-lhiat' may be written as 'lhiam lhiat'.

This was requested as an option to return both.

 - Fixes #18