### PR TITLE
fix(YouTube): handle 'SubStart: 0'

### DIFF
--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
@@ -1,7 +1,23 @@
-import { describe, expect, it } from "vitest"
-import { render } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, fireEvent, render } from "@testing-library/react"
 import { ComparisonTable, segmentChunks } from "./ComparisonTable"
 import { SearchWorkResponse, SearchWorkResult } from "../api/SearchWorkApi"
+import { Ref } from "react"
+import { Player } from "./YouTuber"
+
+const mockPlayer = vi.hoisted(() => ({
+    seek: vi.fn(),
+    getCurrentTime: vi.fn((): number | null => null),
+}))
+
+vi.mock("./YouTuber", async () => {
+    const { useImperativeHandle } = await import("react")
+    const MockYouTuber = ({ ref }: { videoId: string; ref?: Ref<Player> }) => {
+        useImperativeHandle(ref, () => mockPlayer)
+        return null
+    }
+    return { default: MockYouTuber }
+})
 
 const line = (overrides: Partial<SearchWorkResult>): SearchWorkResult => ({
     english: "",
@@ -103,6 +119,58 @@ describe("ComparisonTable highlighting", () => {
         ])
         const marks = container.querySelectorAll("mark")
         expect(Array.from(marks).map((x) => x.textContent)).toEqual(["çhengey"])
+    })
+})
+
+describe("ComparisonTable video (#200)", () => {
+    // a 'subStart' of 0 is valid: the first subtitle of a video starts at 0s
+    const videoLine = line({ manx: "moghrey mie", subStart: 0, subEnd: 5 })
+    const renderVideoTable = () =>
+        renderTable([videoLine], {
+            response: {
+                ...response([videoLine]),
+                source: "https://www.youtube.com/watch?v=abc123",
+            },
+        })
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        mockPlayer.seek.mockClear()
+        mockPlayer.getCurrentTime.mockReturnValue(null)
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it("seeks to 0 when playing a line with a subStart of 0", () => {
+        const { container } = renderVideoTable()
+        fireEvent.click(container.querySelector(".doc-play-btn")!)
+        expect(mockPlayer.seek).toHaveBeenCalledWith(0)
+    })
+
+    it("shows the play tooltip for a subStart of 0", () => {
+        const { container } = renderVideoTable()
+        const button = container.querySelector(".doc-play-btn")
+        expect(button?.getAttribute("title")).toBe("Play from 0:00")
+    })
+
+    it("does not highlight a line starting at 0 while the video never loaded", async () => {
+        const { container } = renderVideoTable()
+        // let the playback-position polling fire while getCurrentTime() is null
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(50)
+        })
+        expect(container.querySelector(".doc-row-playing")).toBeNull()
+    })
+
+    it("highlights a line starting at 0 once the video plays at 0s", async () => {
+        mockPlayer.getCurrentTime.mockReturnValue(0)
+        const { container } = renderVideoTable()
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(50)
+        })
+        expect(container.querySelector(".doc-row-playing")).not.toBeNull()
     })
 })
 

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -239,9 +239,13 @@ export const ComparisonTable = (props: {
         return translations[key] ?? []
     }
 
-    const [videoTime, setVideoTime] = useState(0)
+    // null until the video loads: lines with subStart 0 must not highlight before then
+    const [videoTime, setVideoTime] = useState<number | null>(null)
 
-    useInterval(() => setVideoTime(player.current?.getCurrentTime() ?? 0), 10)
+    useInterval(
+        () => setVideoTime(player.current?.getCurrentTime() ?? null),
+        10,
+    )
 
     const getVideoId = (source: string) => {
         try {
@@ -262,7 +266,8 @@ export const ComparisonTable = (props: {
     const player = useRef<Player>(null)
 
     const isPlaying = (line: SearchWorkResult): boolean => {
-        if (!isVideo || !line.subStart || !line.subEnd) return false
+        if (!isVideo || videoTime == null) return false
+        if (line.subStart == null || line.subEnd == null) return false
         return videoTime >= line.subStart && videoTime <= line.subEnd
     }
 
@@ -387,13 +392,15 @@ export const ComparisonTable = (props: {
                                                         type="button"
                                                         className="doc-play-btn"
                                                         title={
-                                                            line.subStart
+                                                            line.subStart !=
+                                                            null
                                                                 ? `Play from ${formatTime(line.subStart)}`
                                                                 : undefined
                                                         }
                                                         onClick={() => {
                                                             if (
-                                                                line.subStart &&
+                                                                line.subStart !=
+                                                                    null &&
                                                                 player.current
                                                             ) {
                                                                 player.current.seek(

--- a/CorpusSearch/ClientApp/src/components/YouTuber.tsx
+++ b/CorpusSearch/ClientApp/src/components/YouTuber.tsx
@@ -4,7 +4,8 @@ import "./ComparisonTable.css"
 
 export type Player = {
     seek: (time: number) => void
-    getCurrentTime: () => number
+    /** The current playback time, or null if the video never loaded */
+    getCurrentTime: () => number | null
 }
 
 // event.target needs work, as does 'opts'
@@ -22,7 +23,7 @@ const YouTuber = ({ videoId, ref }: { videoId: string; ref?: Ref<Player> }) => {
 
     useImperativeHandle(ref, () => ({
         seek,
-        getCurrentTime: () => player.current?.getCurrentTime() ?? 0,
+        getCurrentTime: () => player.current?.getCurrentTime() ?? null,
     }))
 
     const onPlayerReady: YouTubeProps["onReady"] = (event) => {


### PR DESCRIPTION
Using `null` as a sentinel instead of 0

- Fixes #200