### PR TITLE
fix(dictionaries): Trim input to 'Translation' function

### DIFF
--- a/CorpusSearch.Test/SearchControllerTest.cs
+++ b/CorpusSearch.Test/SearchControllerTest.cs
@@ -95,11 +95,40 @@ public class SearchControllerTest
         Assert.That(result.Keys, Is.EquivalentTo(new[] { "manxDictionary", "englishDictionary" }));
     }
 
-    private static Dictionary<string, SearchController.DictionaryData> DictionaryLookup(QueryLanguages languages)
+    // #159: 'aall ' returned no translations, as the dictionaries perform exact-match lookups
+    [Test]
+    public void TranslationsFromManxTrimsQuery()
+    {
+        Startup.ManxToEnglishDictionary = new Dictionary<string, IList<string>> { ["aall"] = new List<string> { "fork" } };
+
+        var result = SearchController.Translations.FromManx("aall ");
+
+        Assert.That(result["Phil Kelly (en)"], Is.EqualTo(new[] { "fork" }));
+    }
+
+    [Test]
+    public void TranslationsFromEnglishTrimsQuery()
+    {
+        Startup.EnglishToManxDictionary = new Dictionary<string, IList<string>> { ["fork"] = new List<string> { "aall" } };
+
+        var result = SearchController.Translations.FromEnglish(" fork");
+
+        Assert.That(result["Phil Kelly (gv)"], Is.EqualTo(new[] { "aall" }));
+    }
+
+    [Test]
+    public void DictionaryLookupTrimsQuery()
+    {
+        var result = DictionaryLookup(new QueryLanguages(Manx: true, English: false), "moddey ");
+
+        Assert.That(result["manxDictionary"].Entries, Is.EqualTo(new[] { "definition of moddey" }));
+    }
+
+    private static Dictionary<string, SearchController.DictionaryData> DictionaryLookup(QueryLanguages languages, string query = "moddey")
     {
         ISearchDictionary[] dictionaries = [new FakeDictionary("manxDictionary", "gv"), new FakeDictionary("englishDictionary", "en")];
         var controller = new SearchController(null, null, dictionaries, null);
-        return controller.DictionaryLookup("moddey", languages);
+        return controller.DictionaryLookup(query, languages);
     }
 
     private class FakeDictionary(string identifier, params string[] queryLanguages) : ISearchDictionary

--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -37,7 +37,7 @@ public partial class SearchController(
     {
         public static Translations FromManx(string query)
         {
-            var results = Startup.ManxToEnglishDictionary.GetValueOrDefault(query, new List<string>());
+            var results = Startup.ManxToEnglishDictionary.GetValueOrDefault(query.Trim(), new List<string>());
             var ret = new Translations
             {
                 { "Phil Kelly (en)", results }
@@ -47,7 +47,7 @@ public partial class SearchController(
 
         public static Translations FromEnglish(string query)
         {
-            var results = Startup.EnglishToManxDictionary.GetValueOrDefault(query, new List<string>());
+            var results = Startup.EnglishToManxDictionary.GetValueOrDefault(query.Trim(), new List<string>());
             var ret = new Translations
             {
                 { "Phil Kelly (gv)", results }
@@ -230,7 +230,9 @@ public partial class SearchController(
 
     internal Dictionary<string, DictionaryData> DictionaryLookup(string query, QueryLanguages languages)
     {
-        var requestedLanguages = languages.AsList(); 
+        // #159: the dictionaries perform exact-match lookups, so surrounding whitespace returns no results
+        query = query.Trim();
+        var requestedLanguages = languages.AsList();
         var lookup = dictionaryServices.Where(x => x.QueryLanguages.Any(supportedLanguages => requestedLanguages.Contains(supportedLanguages))).ToDictionary(x => x.Identifier,
             x => new { summaries = x.GetSummaries(query), AllowLookup = x.LinkToDictionary });
         return lookup


### PR DESCRIPTION
Improves the dictionary lookups: `aall ` now matches.

- Fixes #159