### PR TITLE
feat(search): add 'did you mean'  if no results are returned, but the query matches a hyphenated version of the input

### DIFF
--- a/CorpusSearch.Test/HyphenSuggestionTest.cs
+++ b/CorpusSearch.Test/HyphenSuggestionTest.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CorpusSearch.Dependencies;
+using CorpusSearch.Model;
+using CorpusSearch.Service;
+using CorpusSearch.Test.TestUtils;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+/// <summary>#158: 'did you mean' candidates for a query which found nothing</summary>
+[TestFixture]
+public class HyphenSuggestionTest : QueryBase
+{
+    [Test]
+    public void FusedQuerySuggestsHyphenatedTerm()
+    {
+        this.AddManxDoc("1", "yn lum-lane mooar");
+
+        var alternates = Alternates("lumlane");
+
+        Assert.That(alternates, Does.Contain("lum-lane"));
+    }
+
+    [Test]
+    public void HyphenatedQuerySuggestsJoinedAndSpacedForms()
+    {
+        this.AddManxDoc("1", "lhiamlhiat");
+
+        var alternates = Alternates("lhiam-lhiat");
+
+        Assert.That(alternates, Does.Contain("lhiamlhiat"));
+        Assert.That(alternates, Does.Contain("lhiam lhiat"));
+    }
+
+    [Test]
+    public void SpacedQuerySuggestsHyphenatedForm()
+    {
+        this.AddManxDoc("1", "yn lum-lane mooar");
+
+        var alternates = Alternates("lum lane");
+
+        Assert.That(alternates, Does.Contain("lum-lane"));
+        Assert.That(alternates, Does.Not.Contain("lum lane"), "the query itself is not an alternative");
+    }
+
+    [Test]
+    public void TheQueryItselfIsNotSuggested()
+    {
+        this.AddManxDoc("1", "yn lum-lane mooar");
+
+        Assert.That(Alternates("lum-lane"), Does.Not.Contain("lum-lane"));
+    }
+
+    [Test]
+    public void WildcardQueriesHaveNoSuggestions()
+    {
+        this.AddManxDoc("1", "yn lum-lane mooar");
+
+        Assert.That(Alternates("lum*lane"), Is.Empty);
+        Assert.That(Alternates("lumlane*"), Is.Empty);
+    }
+
+    [Test]
+    public void SuggestionsRespectDiacritics()
+    {
+        this.AddManxDoc("1", "çhione-jiarg");
+
+        Assert.That(Alternates("chionejiarg"), Does.Contain("çhione-jiarg"));
+    }
+
+    [Test]
+    public async Task SuggestionsAreCountedViaTheRealSearch()
+    {
+        this.AddManxDoc("1", "yn lum-lane mooar", "as lum-lane elley");
+
+        var suggestions = await GetSuggestions("lumlane");
+
+        Assert.That(suggestions, Is.EqualTo(new List<SearchSuggestion> { new("lum-lane", 2) }));
+    }
+
+    [Test]
+    public async Task SuggestionCountsRespectTheDateRange()
+    {
+        this.AddManxDoc("1", "yn lum-lane mooar");
+
+        var suggestions = await GetSuggestions("lumlane", maxDate: DOC_DATE.AddYears(-1));
+
+        Assert.That(suggestions, Is.Empty, "matches outside the date range should not be suggested");
+    }
+
+    private async Task<List<SearchSuggestion>> GetSuggestions(string query, DateTime? maxDate = null)
+    {
+        var workService = new WorkService();
+        workService.AddWork(new TestDocument("1", DOC_DATE));
+        var service = new OverviewSearchService2(workService, new Searcher(luceneIndex, parser));
+
+        return await service.GetSuggestions(new CorpusSearchQuery(query)
+        {
+            Manx = true,
+            MinDate = DateTime.MinValue,
+            MaxDate = maxDate ?? DateTime.MaxValue,
+        });
+    }
+
+    private List<string> Alternates(string query)
+    {
+        return new Searcher(luceneIndex, parser).GetHyphenAlternates(query, ScanOptions.Default);
+    }
+}

--- a/CorpusSearch/ClientApp/src/api/SearchApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchApi.ts
@@ -19,6 +19,14 @@ export type HighlightRange = {
     end: number
 }
 
+/** A 'did you mean' alternative for a query which found nothing (#158) */
+export type SearchSuggestion = {
+    /** the suggested query, e.g. "lum-lane" when "lumlane" was searched */
+    query: string
+    /** the number of matches the suggestion returns */
+    count: number
+}
+
 export type SearchResponse = {
     results: SearchResultEntry[]
     query: string
@@ -27,6 +35,8 @@ export type SearchResponse = {
     timeTaken: string
     definedInDictionaries: DefinedInDictionaries
     translations: Translations
+    /** populated when the search found nothing (#158) */
+    suggestions?: SearchSuggestion[]
 }
 
 type date = string

--- a/CorpusSearch/ClientApp/src/components/AdvancedOptions.tsx
+++ b/CorpusSearch/ClientApp/src/components/AdvancedOptions.tsx
@@ -10,6 +10,7 @@ export type DateRange = {
 const AdvancedOptions = (props: {
     onDateRangeChange: (range: DateRange) => void
     onMatchChange: (match: boolean) => void
+    ignoreHyphens: boolean
     onIgnoreHyphensChange: (ignoreHyphens: boolean) => void
     children?: ReactNode
 }) => {
@@ -66,6 +67,7 @@ const AdvancedOptions = (props: {
                 </span>
                 <MatchWithinWords onMatchChange={props.onMatchChange} />
                 <IgnoreHyphens
+                    ignoreHyphens={props.ignoreHyphens}
                     onIgnoreHyphensChange={props.onIgnoreHyphensChange}
                 />
                 {props.children}
@@ -74,16 +76,11 @@ const AdvancedOptions = (props: {
     )
 }
 
+// controlled from Home: the 'no results' suggestion can also enable the option (#158)
 const IgnoreHyphens = (props: {
+    ignoreHyphens: boolean
     onIgnoreHyphensChange: (ignoreHyphens: boolean) => void
 }) => {
-    const [ignoreHyphens, setIgnoreHyphens] = useState(false)
-
-    const onIgnoreHyphensChanged = (event: ChangeEvent<HTMLInputElement>) => {
-        setIgnoreHyphens(event.target.checked)
-        props.onIgnoreHyphensChange(event.target.checked)
-    }
-
     return (
         <label
             className="advanced-options-match"
@@ -92,8 +89,8 @@ const IgnoreHyphens = (props: {
             <input
                 id="ignoreHyphens"
                 type="checkbox"
-                checked={ignoreHyphens}
-                onChange={onIgnoreHyphensChanged}
+                checked={props.ignoreHyphens}
+                onChange={(e) => props.onIgnoreHyphensChange(e.target.checked)}
             />
             Ignore hyphens
         </label>

--- a/CorpusSearch/ClientApp/src/routes/Home.css
+++ b/CorpusSearch/ClientApp/src/routes/Home.css
@@ -191,3 +191,23 @@ a.dict-strip-label:hover {
     font-family: var(--font-display);
     font-size: 18px;
 }
+
+/* 'Did you mean lum-lane (2 matches)?' (#158) */
+.no-results-suggestions {
+    margin-top: 12px;
+}
+
+/* link-styled button: it re-runs the search rather than navigating */
+.no-results-suggestion {
+    padding: 0;
+    border: none;
+    background: none;
+    font: inherit;
+    color: var(--c-link);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.no-results-suggestion:hover {
+    color: var(--c-link-hover);
+}

--- a/CorpusSearch/ClientApp/src/routes/Home.test.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.test.tsx
@@ -77,6 +77,62 @@ const emptySearchResponse = (query: string): SearchResponse => ({
     translations: {},
 })
 
+// #158
+describe("did-you-mean suggestion", () => {
+    const hyphenatedResults: SearchResponse = {
+        ...emptySearchResponse("lum-lane"),
+        numberOfResults: 2,
+        numberOfDocuments: 1,
+        results: [
+            {
+                startDate: "1900-01-01",
+                endDate: "1900-01-01",
+                documentName: "Test Doc",
+                count: 2,
+                ident: "doc1",
+                sample: "yn lum-lane mooar",
+            },
+        ],
+    }
+
+    it("suggests the alternate forms the server returned", async () => {
+        fetchMock.mockImplementation((url) =>
+            Promise.resolve(
+                Response.json(
+                    typeof url === "string" && url.includes("lum-lane")
+                        ? hyphenatedResults
+                        : {
+                              ...emptySearchResponse("lumlane"),
+                              suggestions: [{ query: "lum-lane", count: 2 }],
+                          },
+                ),
+            ),
+        )
+        renderWithQuery("lumlane")
+
+        const suggestion = await screen.findByRole("button", {
+            name: "lum-lane",
+        })
+        screen.getByText(/2 matches/)
+
+        fireEvent.click(suggestion)
+
+        // the suggestion becomes the query
+        await screen.findByText("Test Doc")
+        expect(searchRequests().at(-1)?.[0]).toContain("lum-lane")
+    })
+
+    it("shows no suggestion when the server offers none", async () => {
+        fetchMock.mockImplementation(() =>
+            Promise.resolve(Response.json(emptySearchResponse("xyzzy"))),
+        )
+        renderWithQuery("xyzzy")
+
+        await screen.findByText(/No matches/)
+        expect(screen.queryByText(/Did you mean/)).toBeNull()
+    })
+})
+
 // #134
 describe("multidict lookup", () => {
     it("links to Multidict when no dictionary knows the word", async () => {

--- a/CorpusSearch/ClientApp/src/routes/Home.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.tsx
@@ -3,6 +3,7 @@
 import "./Home.css"
 
 import {
+    Fragment,
     Suspense,
     use,
     useEffect,
@@ -208,6 +209,32 @@ export const Home = () => {
                     <div className="no-results">
                         No matches for “{result.data.query || query}”. Try
                         another spelling, or a synonym.
+                        {(result.data.suggestions?.length ?? 0) > 0 && (
+                            <div className="no-results-suggestions">
+                                Did you mean{" "}
+                                {result.data.suggestions?.map(
+                                    (suggestion, i) => (
+                                        <Fragment key={suggestion.query}>
+                                            {i > 0 && " or "}
+                                            <button
+                                                className="no-results-suggestion"
+                                                onClick={() =>
+                                                    setQuery(suggestion.query)
+                                                }
+                                            >
+                                                {suggestion.query}
+                                            </button>{" "}
+                                            ({suggestion.count.toLocaleString()}{" "}
+                                            {suggestion.count === 1
+                                                ? "match"
+                                                : "matches"}
+                                            )
+                                        </Fragment>
+                                    ),
+                                )}
+                                ?
+                            </div>
+                        )}
                     </div>
                 ) : (
                     <MainSearchResults
@@ -244,6 +271,7 @@ export const Home = () => {
             <AdvancedOptions
                 onDateRangeChange={setDateRange}
                 onMatchChange={setMatchPhrase}
+                ignoreHyphens={ignoreHyphens}
                 onIgnoreHyphensChange={setIgnoreHyphens}
             >
                 {/*on mobile the View control lives here rather than in the results header*/}

--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -218,6 +218,11 @@ public partial class SearchController(
 
         ret.DefinedInDictionaries = DictionaryLookup(query, new QueryLanguages(Manx: manx, English: english));
         ret.SetResults(results);
+        if (ret.Results.Count == 0 && !ignoreHyphens)
+        {
+            // #158: 'lumlane' found nothing, but 'lum-lane' exists
+            ret.Suggestions = await overviewSearchService.GetSuggestions(searchQuery);
+        }
         ret.EnrichWithTime(sw);
         ret.NumberOfDocuments = ret.Results.Count;
         return ret;
@@ -252,6 +257,8 @@ public partial class SearchController(
         public string TimeTaken { get; set; }
         public Dictionary<string, DictionaryData> DefinedInDictionaries { get; internal set; } = new();
         public Translations Translations { get; set; } = new();
+        /// <summary>'Did you mean' alternatives, populated when the search found nothing (#158)</summary>
+        public List<SearchSuggestion> Suggestions { get; set; } = [];
     }
 }
 

--- a/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
+++ b/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
@@ -9,6 +9,7 @@ using Lucene.Net.Search;
 using Lucene.Net.Search.Spans;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
+using Lucene.Net.Util.Automaton;
 using Document = Lucene.Net.Documents.Document;
 
 namespace CorpusSearch.Dependencies.Lucene;
@@ -420,6 +421,30 @@ public class LuceneIndex(IndexWriter indexWriter)
         return totalMatches;
     }
         
+    /// <summary>
+    /// Index terms accepted by <paramref name="automaton"/>: e.g. 'lum-lane' for the
+    /// hyphen-tolerant automaton of 'lumlane'. Used for 'did you mean' suggestions (#158).
+    /// </summary>
+    public List<string> GetMatchingTerms(string field, Automaton automaton, int limit)
+    {
+        var ret = new List<string>();
+
+        using var reader = UseReader();
+        var terms = MultiFields.GetTerms(reader, field);
+        if (terms == null)
+        {
+            return ret;
+        }
+
+        var termsEnum = new CompiledAutomaton(automaton).GetTermsEnum(terms);
+        while (ret.Count < limit && termsEnum.MoveNext())
+        {
+            ret.Add(termsEnum.Term.Utf8ToString());
+        }
+
+        return ret;
+    }
+
     public List<(string, long)> GetTermFrequencyList()
     {
         var termList = new List<(string, long)>();

--- a/CorpusSearch/Dependencies/Lucene/ManxQuery.cs
+++ b/CorpusSearch/Dependencies/Lucene/ManxQuery.cs
@@ -20,6 +20,11 @@ public class ManxQuery(Term term, bool ignoreHyphens = false) : AutomatonQuery(G
     /// </summary>
     public virtual Term Term => base.m_term;
 
+    /// <summary>The automaton this query matches index terms with; exposed so 'did you mean'
+    /// suggestions can enumerate the vocabulary it accepts (#158)</summary>
+    internal static Automaton BuildAutomaton(Term term, bool ignoreHyphens) =>
+        ToAutomaton(term, ignoreHyphens);
+
     private static Automaton ToAutomaton(Term term, bool ignoreHyphens)
     {
         IList<Automaton> automata = new List<Automaton>();

--- a/CorpusSearch/Dependencies/Searcher.cs
+++ b/CorpusSearch/Dependencies/Searcher.cs
@@ -199,6 +199,52 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
     private static string[] SplitAtoms(string normalizedTerm) =>
         normalizedTerm.Split(['-', ' '], StringSplitOptions.RemoveEmptyEntries);
 
+    /// <summary>
+    /// 'Did you mean' candidates for a query which found nothing (#158): index terms which
+    /// differ only in hyphenation ('lumlane' => 'lum-lane'), plus the space-separated form
+    /// of a hyphenated query. Callers should drop candidates without matches.
+    /// </summary>
+    public List<string> GetHyphenAlternates(string query, ScanOptions searchOptions)
+    {
+        var parsed = parser.Parse(query);
+        if (!parsed.IsOk || parsed.Result == null)
+        {
+            return [];
+        }
+
+        var words = PlainWords(parsed.Result);
+        if (words == null)
+        {
+            return [];
+        }
+
+        var atoms = words.SelectMany(w => SplitAtoms(GetTerm(w, searchOptions))).ToList();
+        // a wildcard matches far more of the vocabulary than hyphen variants
+        if (atoms.Count == 0 || atoms.Any(a => a.Any(c => c is '*' or '_' or '+' or '?')))
+        {
+            return [];
+        }
+
+        var termKey = GetTermKey(searchOptions);
+        var automaton = ManxQuery.BuildAutomaton(new Term(termKey, string.Concat(atoms)), ignoreHyphens: true);
+        var alternates = luceneIndex.GetMatchingTerms(termKey, automaton, limit: 5);
+        if (atoms.Count > 1)
+        {
+            alternates.Add(string.Join(" ", atoms));
+        }
+
+        var normalizedQuery = GetTerm(query, searchOptions);
+        return alternates.Where(x => x != normalizedQuery).Distinct().ToList();
+    }
+
+    /// <summary>The words of a plain word/phrase query; null for operators etc.</summary>
+    private static List<string> PlainWords(Expression expression) => expression switch
+    {
+        StringExpression s => [s.Term],
+        AdjacentWordExpression e => e.Words.ToList(),
+        _ => null,
+    };
+
     private static SpanQuery SingleTokenQuery(string normalizedTerm, ScanOptions searchOptions, bool ignoreHyphens)
     {
         Term term = new Term(GetTermKey(searchOptions), normalizedTerm);

--- a/CorpusSearch/Model/SearchSuggestion.cs
+++ b/CorpusSearch/Model/SearchSuggestion.cs
@@ -1,0 +1,6 @@
+namespace CorpusSearch.Model;
+
+/// <summary>A 'did you mean' alternative for a query which found nothing (#158)</summary>
+/// <param name="Query">the suggested query, e.g. 'lum-lane' when 'lumlane' was searched</param>
+/// <param name="Count">the number of matches the suggestion returns</param>
+public record SearchSuggestion(string Query, int Count);

--- a/CorpusSearch/Service/OverviewSearchService2.cs
+++ b/CorpusSearch/Service/OverviewSearchService2.cs
@@ -1,5 +1,6 @@
 ﻿using CorpusSearch.Dependencies;
 using CorpusSearch.Model;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -20,6 +21,44 @@ public class OverviewSearchService2(WorkService workService, Searcher searcher)
         var validResults = docResults.Where(x => validIdents.Contains(x.Ident)).ToList();
 
         return validResults;
+    }
+
+    /// <summary>
+    /// 'Did you mean' suggestions for a query which found nothing (#158): alternate
+    /// hyphenations which do have matches, e.g. 'lum-lane (2 matches)' for 'lumlane'.
+    /// </summary>
+    public async Task<List<SearchSuggestion>> GetSuggestions(CorpusSearchQuery searchQuery)
+    {
+        var alternates = searcher.GetHyphenAlternates(searchQuery.Query, ToScanOptions(searchQuery));
+
+        var suggestions = new List<SearchSuggestion>();
+        foreach (var alternate in alternates)
+        {
+            int count;
+            try
+            {
+                // the real pipeline, so the counts respect the date range
+                var results = await CorpusSearch(new CorpusSearchQuery(alternate)
+                {
+                    Manx = searchQuery.Manx,
+                    English = searchQuery.English,
+                    MinDate = searchQuery.MinDate,
+                    MaxDate = searchQuery.MaxDate,
+                });
+                count = results.Sum(x => x.Count);
+            }
+            catch (ArgumentException)
+            {
+                // an index term need not round-trip through the query parser
+                continue;
+            }
+            if (count > 0)
+            {
+                suggestions.Add(new SearchSuggestion(alternate, count));
+            }
+        }
+
+        return suggestions.OrderByDescending(x => x.Count).Take(3).ToList();
     }
 
     /// <summary>Returns all the identifiers which are valid for the date range</summary>


### PR DESCRIPTION
If 'lumlane' returns no results, but would match 'lum-lane', then show a 'did you mean' UI element.

- Fixes #158
- Related to #18