### PR TITLE
fix(dictionary): better ordering of results

### DIFF
--- a/CorpusSearch.Test/DictionaryLookupServiceTest.cs
+++ b/CorpusSearch.Test/DictionaryLookupServiceTest.cs
@@ -114,6 +114,26 @@ public class DictionaryLookupServiceTest
         Assert.That(Lookup(service, "dy hroggal"), Is.EqualTo(new[] { "dy", "hroggal" }));
     }
 
+    /// <summary>
+    /// Kelly heads some entries with variant forms ('EEN, YN'), so looking up 'yn' also matches
+    /// them. Entries headed by the query itself must come first.
+    /// </summary>
+    [Test]
+    public void EntriesHeadedByTheQueryAreReturnedFirst()
+    {
+        var service = new DictionaryLookupService([new FakeDictionary(["EEN", "YN"], ["YN"])]);
+        Assert.That(Lookup(service, "yn"), Is.EqualTo(new[] { "YN", "EEN" }));
+    }
+
+    [Test]
+    public void PhrasesFromTheContextStillOutrankTheHeadedEntry()
+    {
+        // specificity wins over the headword: the phrase match is more useful than the exact entry
+        var service = new DictionaryLookupService([new FakeDictionary(["goll mygeayrt"], ["goll", "gholl"])]);
+        var result = Lookup(service, "goll", context: "v'eh goll mygeayrt y valley");
+        Assert.That(result, Is.EqualTo(new[] { "goll mygeayrt", "goll" }));
+    }
+
     [Test]
     public void DuplicateMatchesAreRemoved()
     {
@@ -142,13 +162,19 @@ public class DictionaryLookupServiceTest
 
     private class FakeDictionary : ISearchDictionary
     {
-        private readonly Dictionary<string, string> wordToPrimaryWord;
+        private readonly List<(List<string> Words, string PrimaryWord)> entries;
 
-        public FakeDictionary(params string[] words) : this(words.ToDictionary(x => x, x => x)) { }
+        public FakeDictionary(params string[] words) : this(words.Select(x => new[] { x }).ToArray()) { }
+
+        /// <summary>Each entry is its word list, headed by the primary word: ["EEN", "YN"] is the entry 'EEN, YN'</summary>
+        public FakeDictionary(params string[][] entryWords)
+        {
+            entries = entryWords.Select(words => (words.ToList(), words[0])).ToList();
+        }
 
         public FakeDictionary(Dictionary<string, string> wordToPrimaryWord)
         {
-            this.wordToPrimaryWord = new Dictionary<string, string>(wordToPrimaryWord, StringComparer.InvariantCultureIgnoreCase);
+            entries = wordToPrimaryWord.Select(x => (new List<string> { x.Key }, x.Value)).ToList();
         }
 
         public string Identifier => "Fake";
@@ -157,11 +183,10 @@ public class DictionaryLookupServiceTest
 
         public IEnumerable<DictionarySummary> GetSummaries(string query, bool basic = false)
         {
-            if (!wordToPrimaryWord.TryGetValue(query, out var primaryWord))
+            foreach (var (_, primaryWord) in entries.Where(e => e.Words.Contains(query, StringComparer.InvariantCultureIgnoreCase)))
             {
-                yield break;
+                yield return new DictionarySummary { PrimaryWord = primaryWord, Summary = $"definition of {primaryWord}" };
             }
-            yield return new DictionarySummary { PrimaryWord = primaryWord, Summary = $"definition of {primaryWord}" };
         }
     }
 }

--- a/CorpusSearch.Test/KellyManxToEnglishDictionaryServiceTest.cs
+++ b/CorpusSearch.Test/KellyManxToEnglishDictionaryServiceTest.cs
@@ -1,0 +1,30 @@
+using CorpusSearch.Model.Dictionary;
+using CorpusSearch.Service.Dictionaries;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+public class KellyManxToEnglishDictionaryServiceTest
+{
+    /// <summary>'SPAINEY, YN' (Spain) records the article, not a variant form: a lookup of the
+    /// article 'yn' should not return Spain</summary>
+    [Test]
+    public void TheArticleIsRemovedFromSpain()
+    {
+        var spain = new KellyManxToEnglishEntry { Words = ["SPAINEY", "YN"], Definition = "S. Spain. (Ir. An Spain.)" };
+
+        KellyManxToEnglishDictionaryService.RemoveArticleFromSpain(spain);
+
+        Assert.That(spain.Words, Is.EqualTo(new[] { "SPAINEY" }));
+    }
+
+    [Test]
+    public void OtherEntriesKeepTheirVariantForms()
+    {
+        var een = new KellyManxToEnglishEntry { Words = ["EEN", "YN"], Definition = "when added to a word forms a diminution" };
+
+        KellyManxToEnglishDictionaryService.RemoveArticleFromSpain(een);
+
+        Assert.That(een.Words, Is.EqualTo(new[] { "EEN", "YN" }));
+    }
+}

--- a/CorpusSearch/Service/Dictionaries/KellyManxToEnglishDictionaryService.cs
+++ b/CorpusSearch/Service/Dictionaries/KellyManxToEnglishDictionaryService.cs
@@ -49,8 +49,21 @@ public class KellyManxToEnglishDictionaryService(ISet<string> allWords, IList<Ke
 
         var entries = JsonConvert.DeserializeObject<List<KellyManxToEnglishEntry>>(text) ?? [];
 
+        entries.ForEach(RemoveArticleFromSpain);
         entries.ForEach(EnrichCedillaEntries);
         return entries;
+    }
+
+    /// <summary>The heading for Spain is 'SPAINEY, YN': the 'yn' records that the noun takes the
+    /// article ('yn Spainey', as Irish 'An Spáin'). It is not a form of the word, so looking up
+    /// the article 'yn' should not return Spain.</summary>
+    internal static void RemoveArticleFromSpain(KellyManxToEnglishEntry entry)
+    {
+        if (entry.Words is ["SPAINEY", "YN"])
+        {
+            entry.Words = ["SPAINEY"];
+        }
+        entry.SafeChildren.ForEach(RemoveArticleFromSpain);
     }
 
     /// <summary>If an entry has 'ç', allow 'c'</summary>

--- a/CorpusSearch/Service/DictionaryLookupService.cs
+++ b/CorpusSearch/Service/DictionaryLookupService.cs
@@ -28,7 +28,11 @@ public class DictionaryLookupService(IEnumerable<ISearchDictionary> dictionarySe
         var dictionaries = dictionaryServices.Where(x => x.QueryLanguages.Contains(lang)).ToList();
 
         List<DictionarySummary> GetSummaries(IEnumerable<string> queries) =>
-            queries.SelectMany(query => dictionaries.SelectMany(d => d.GetSummaries(query, basic: true))).ToList();
+            queries.SelectMany(query =>
+                dictionaries.SelectMany(d => d.GetSummaries(query, basic: true))
+                    // an entry can list the query as a mere variant ('EEN, YN'): those headed by it come first
+                    .OrderBy(x => string.Equals(x.PrimaryWord, query, StringComparison.InvariantCultureIgnoreCase) ? 0 : 1))
+                .ToList();
 
         var results = GetSummaries(GetCandidates(selection, context));
 


### PR DESCRIPTION
'yn' wasn't appearing as the first entry for 'yn'

Kelly provided some unusual data, handle it here rather than updating the JSON