### PR TITLE
feat(corpus): expandable line ranges

### DIFF
--- a/CorpusSearch.Test/LineRangeTest.cs
+++ b/CorpusSearch.Test/LineRangeTest.cs
@@ -1,0 +1,106 @@
+using System.Linq;
+using CorpusSearch.Model;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+/// <summary>'Expand context' when searching inside a document (#286)</summary>
+[TestFixture]
+public class LineRangeTest : QueryBase
+{
+    private const string DOC = "doc";
+
+    private void AddNumberedDocument(string name, params (int LineNumber, string Manx)[] lines)
+    {
+        luceneIndex.Add(new TestDocument(name, DOC_DATE), lines.Select(x => new DocumentLine
+        {
+            Manx = x.Manx,
+            English = "",
+            CsvLineNumber = x.LineNumber,
+        }));
+    }
+
+    [Test]
+    public void ReturnsTheLinesInTheRange()
+    {
+        AddNumberedDocument(DOC, (2, "a"), (3, "b"), (4, "c"), (5, "d"), (6, "e"));
+
+        var (lines, total) = luceneIndex.GetLines(DOC, start: 3, end: 5, limit: 100, fromEnd: false, getTranscript: false);
+
+        Assert.That(lines.Select(x => x.CsvLineNumber), Is.EqualTo(new[] { 3, 4, 5 }));
+        Assert.That(lines.Select(x => x.Manx), Is.EqualTo(new[] { "b", "c", "d" }));
+        Assert.That(total, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void LimitTakesTheFirstLines()
+    {
+        AddNumberedDocument(DOC, (2, "a"), (3, "b"), (4, "c"), (5, "d"), (6, "e"));
+
+        var (lines, total) = luceneIndex.GetLines(DOC, start: 2, end: 6, limit: 2, fromEnd: false, getTranscript: false);
+
+        Assert.That(lines.Select(x => x.CsvLineNumber), Is.EqualTo(new[] { 2, 3 }));
+        Assert.That(total, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void FromEndTakesTheLastLines()
+    {
+        AddNumberedDocument(DOC, (2, "a"), (3, "b"), (4, "c"), (5, "d"), (6, "e"));
+
+        var (lines, total) = luceneIndex.GetLines(DOC, start: 2, end: 6, limit: 2, fromEnd: true, getTranscript: false);
+
+        Assert.That(lines.Select(x => x.CsvLineNumber), Is.EqualTo(new[] { 5, 6 }));
+        Assert.That(total, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void BlankLinesAreSkipped()
+    {
+        AddNumberedDocument(DOC, (2, "a"), (3, ""), (4, "c"));
+
+        var (lines, total) = luceneIndex.GetLines(DOC, start: 2, end: 4, limit: 100, fromEnd: false, getTranscript: false);
+
+        Assert.That(lines.Select(x => x.CsvLineNumber), Is.EqualTo(new[] { 2, 4 }));
+        Assert.That(total, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void OtherDocumentsAreExcluded()
+    {
+        AddNumberedDocument(DOC, (2, "a"));
+        AddNumberedDocument("other", (2, "x"), (3, "y"));
+
+        var (lines, total) = luceneIndex.GetLines(DOC, start: 2, end: 3, limit: 100, fromEnd: false, getTranscript: false);
+
+        Assert.That(lines.Select(x => x.Manx), Is.EqualTo(new[] { "a" }));
+        Assert.That(total, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void EmptyRangeReturnsNothing()
+    {
+        AddNumberedDocument(DOC, (2, "a"), (10, "b"));
+
+        var (lines, total) = luceneIndex.GetLines(DOC, start: 3, end: 9, limit: 100, fromEnd: false, getTranscript: false);
+
+        Assert.That(lines, Is.Empty);
+        Assert.That(total, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void LineNumberRangeReturnsTheDocumentBounds()
+    {
+        AddNumberedDocument(DOC, (2, "a"), (10, "b"), (5, "c"));
+
+        Assert.That(luceneIndex.GetLineNumberRange(DOC), Is.EqualTo((2, 10)));
+    }
+
+    [Test]
+    public void LineNumberRangeIsNullForAnUnknownDocument()
+    {
+        AddNumberedDocument(DOC, (2, "a"));
+
+        Assert.That(luceneIndex.GetLineNumberRange("unknown"), Is.Null);
+    }
+}

--- a/CorpusSearch/ClientApp/e2e/context-expansion.spec.ts
+++ b/CorpusSearch/ClientApp/e2e/context-expansion.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test"
+
+// End-to-end coverage of #286: a search inside a document only returns the matching
+// lines; expanders between them reveal the hidden neighbours (like GitHub's
+// 'expand hunk' button).
+
+const DOC = "/docs/e2e-highlight-fixture"
+const expander = "tr.doc-expand-row"
+
+test.describe("context expansion", () => {
+    test("expands the hidden lines around the match", async ({ page }) => {
+        // 'moghrey' matches only line 6 of 8: the rest of the document is hidden
+        await page.goto(`${DOC}?q=moghrey`)
+        await expect(page.locator("mark.textHighlight")).toHaveText("moghrey")
+        await expect(page.locator(expander)).toHaveCount(2)
+        await expect(page.getByText("Va’n dooinney")).toHaveCount(0)
+
+        // above the match
+        await page.getByRole("button", { name: /Show previous/ }).click()
+        await expect(page.getByText("Va’n dooinney")).toBeVisible()
+
+        // below the match; the whole document is then visible
+        await page.getByRole("button", { name: /Show next/ }).click()
+        await expect(page.getByText("jee.")).toBeVisible()
+        await expect(page.locator(expander)).toHaveCount(0)
+    })
+
+    test("a '*' search shows every line with nothing to expand", async ({
+        page,
+    }) => {
+        await page.goto(DOC)
+        await expect(page.getByText("Va’n dooinney")).toBeVisible()
+        await expect(page.locator(expander)).toHaveCount(0)
+    })
+})

--- a/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
@@ -37,6 +37,19 @@ export type SearchWorkResponse = {
     googleBooksId: string | undefined
     gitHubLink: string
     original?: string
+    /** The document's first CSV line number: lets us offer 'expand context' above the first
+     * result (#286). Absent when searching for '*' or when there are no results */
+    firstLineNumber?: number
+    /** The document's last CSV line number (see `firstLineNumber`) */
+    lastLineNumber?: number
+}
+
+export type WorkLinesResponse = {
+    /** The requested lines, in document order */
+    lines: SearchWorkResult[]
+    /** Lines in [start, end] before the limit was applied: if this is no more than the
+     * limit, the range is exhausted */
+    totalInRange: number
 }
 
 type WorkSearch = {
@@ -64,4 +77,26 @@ export const searchWork = async (
         throw new Error(`work search failed: ${response.status}`)
     }
     return (await response.json()) as SearchWorkResponse
+}
+
+/**
+ * Lines of the document with a csvLineNumber in [start, end]: the first `limit` of them, or
+ * the last if `fromEnd`. Expands the context around a search result (#286).
+ *
+ * @throws Error if the fetch fails
+ */
+export const fetchLines = async (params: {
+    docIdent: string
+    start: number
+    end: number
+    limit: number
+    fromEnd: boolean
+}): Promise<WorkLinesResponse> => {
+    const response = await fetch(
+        `search/lines/${params.docIdent}?start=${params.start.toString()}&end=${params.end.toString()}&limit=${params.limit.toString()}&fromEnd=${params.fromEnd.toString()}`,
+    )
+    if (!response.ok) {
+        throw new Error(`line fetch failed: ${response.status}`)
+    }
+    return (await response.json()) as WorkLinesResponse
 }

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, fireEvent, render } from "@testing-library/react"
+import {
+    act,
+    cleanup,
+    fireEvent,
+    render,
+    waitFor,
+} from "@testing-library/react"
 import { ComparisonTable, segmentChunks } from "./ComparisonTable"
 import { SearchWorkResponse, SearchWorkResult } from "../api/SearchWorkApi"
 import { Ref } from "react"
@@ -18,6 +24,17 @@ vi.mock("./YouTuber", async () => {
     }
     return { default: MockYouTuber }
 })
+
+const mockFetchLines = vi.hoisted(() => vi.fn())
+
+vi.mock("../api/SearchWorkApi", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../api/SearchWorkApi")>()),
+    fetchLines: mockFetchLines,
+}))
+
+// vitest globals are off, so testing-library does not clean up by itself; without this,
+// document-wide queries (getByText) see the tables of earlier tests
+afterEach(cleanup)
 
 const line = (overrides: Partial<SearchWorkResult>): SearchWorkResult => ({
     english: "",
@@ -171,6 +188,186 @@ describe("ComparisonTable video (#200)", () => {
             await vi.advanceTimersByTimeAsync(50)
         })
         expect(container.querySelector(".doc-row-playing")).not.toBeNull()
+    })
+})
+
+describe("context expansion (#286)", () => {
+    const gapResults = () => [
+        line({ manx: "top match", csvLineNumber: 10 }),
+        line({ manx: "bottom match", csvLineNumber: 50 }),
+    ]
+    const renderWithGap = () =>
+        renderTable(gapResults(), {
+            docIdent: "doc",
+            response: {
+                ...response(gapResults()),
+                firstLineNumber: 10,
+                lastLineNumber: 50,
+            },
+        })
+
+    beforeEach(() => {
+        mockFetchLines.mockReset()
+    })
+
+    it("shows an expander between results with hidden lines", () => {
+        const { container, getByText } = renderWithGap()
+        expect(container.querySelectorAll(".doc-expand-row")).toHaveLength(1)
+        expect(getByText("Show next 5 lines")).toBeTruthy()
+        expect(getByText("Show previous 5 lines")).toBeTruthy()
+    })
+
+    it("shows no expander without a docIdent", () => {
+        const { container } = renderTable(gapResults())
+        expect(container.querySelector(".doc-expand-row")).toBeNull()
+    })
+
+    it("shows no expander for a '*' search", () => {
+        const { container } = renderTable(gapResults(), {
+            docIdent: "doc",
+            response: { ...response(gapResults()), totalMatches: null },
+        })
+        expect(container.querySelector(".doc-expand-row")).toBeNull()
+    })
+
+    it("shows no expander between adjacent lines", () => {
+        const results = [
+            line({ manx: "a", csvLineNumber: 2 }),
+            line({ manx: "b", csvLineNumber: 3 }),
+        ]
+        const { container } = renderTable(results, {
+            docIdent: "doc",
+            response: {
+                ...response(results),
+                firstLineNumber: 2,
+                lastLineNumber: 3,
+            },
+        })
+        expect(container.querySelector(".doc-expand-row")).toBeNull()
+    })
+
+    it("expands downwards into the gap", async () => {
+        mockFetchLines.mockResolvedValue({
+            lines: [11, 12, 13, 14, 15].map((n) =>
+                line({ manx: `context ${n}`, csvLineNumber: n }),
+            ),
+            totalInRange: 39,
+        })
+        const { container, getByText } = renderWithGap()
+
+        fireEvent.click(getByText("Show next 5 lines"))
+
+        expect(mockFetchLines).toHaveBeenCalledWith({
+            docIdent: "doc",
+            start: 11,
+            end: 49,
+            limit: 5,
+            fromEnd: false,
+        })
+        await waitFor(() => expect(getByText("context 15")).toBeTruthy())
+        // the revealed lines are marked as context, and more lines remain hidden
+        expect(container.querySelectorAll(".doc-row-context")).toHaveLength(5)
+        expect(container.querySelectorAll(".doc-expand-row")).toHaveLength(1)
+    })
+
+    it("expands upwards into the gap", async () => {
+        mockFetchLines.mockResolvedValue({
+            lines: [45, 46, 47, 48, 49].map((n) =>
+                line({ manx: `context ${n}`, csvLineNumber: n }),
+            ),
+            totalInRange: 39,
+        })
+        const { getByText } = renderWithGap()
+
+        fireEvent.click(getByText("Show previous 5 lines"))
+
+        expect(mockFetchLines).toHaveBeenCalledWith({
+            docIdent: "doc",
+            start: 11,
+            end: 49,
+            limit: 5,
+            fromEnd: true,
+        })
+        await waitFor(() => expect(getByText("context 45")).toBeTruthy())
+    })
+
+    it("removes the expander when the gap is exhausted", async () => {
+        mockFetchLines.mockResolvedValue({
+            lines: [11, 12].map((n) =>
+                line({ manx: `context ${n}`, csvLineNumber: n }),
+            ),
+            totalInRange: 2,
+        })
+        const { container, getByText } = renderWithGap()
+
+        fireEvent.click(getByText("Show next 5 lines"))
+
+        await waitFor(() =>
+            expect(container.querySelector(".doc-expand-row")).toBeNull(),
+        )
+        expect(getByText("context 12")).toBeTruthy()
+    })
+
+    it("expands a small gap with a single click", async () => {
+        // between lines 10 and 18 only 7 lines can hide: one button reveals them all
+        const results = [
+            line({ manx: "top match", csvLineNumber: 10 }),
+            line({ manx: "bottom match", csvLineNumber: 18 }),
+        ]
+        mockFetchLines.mockResolvedValue({
+            lines: [line({ manx: "context 11", csvLineNumber: 11 })],
+            totalInRange: 1,
+        })
+        const { container, getByText } = renderTable(results, {
+            docIdent: "doc",
+            response: response(results),
+        })
+
+        fireEvent.click(getByText("Show context"))
+
+        expect(mockFetchLines).toHaveBeenCalledWith({
+            docIdent: "doc",
+            start: 11,
+            end: 17,
+            limit: 7,
+            fromEnd: false,
+        })
+        await waitFor(() =>
+            expect(container.querySelector(".doc-expand-row")).toBeNull(),
+        )
+        expect(getByText("context 11")).toBeTruthy()
+    })
+
+    it("omits the count when a single line can hide", () => {
+        const results = [line({ manx: "match", csvLineNumber: 3 })]
+        const { getByText } = renderTable(results, {
+            docIdent: "doc",
+            response: {
+                ...response(results),
+                firstLineNumber: 2,
+                lastLineNumber: 3,
+            },
+        })
+
+        expect(getByText("Show previous line")).toBeTruthy()
+    })
+
+    it("only expands towards the results at the document bounds", () => {
+        const results = [line({ manx: "only match", csvLineNumber: 20 })]
+        const { container, queryByText, getByText } = renderTable(results, {
+            docIdent: "doc",
+            response: {
+                ...response(results),
+                firstLineNumber: 2,
+                lastLineNumber: 40,
+            },
+        })
+
+        // above the match: only 'previous'; below it: only 'next'
+        expect(container.querySelectorAll(".doc-expand-row")).toHaveLength(2)
+        expect(getByText("Show previous 5 lines")).toBeTruthy()
+        expect(getByText("Show next 5 lines")).toBeTruthy()
+        expect(queryByText("Show context")).toBeNull()
     })
 })
 

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -17,6 +17,13 @@ import Typography from "@mui/material/Typography"
 import { diffChars } from "diff"
 import YouTuber, { Player } from "./YouTuber"
 import useInterval from "../vendor/use-interval/UseInterval"
+import {
+    CONTEXT_CHUNK,
+    ContextGap,
+    ExpandDirection,
+    SMALL_GAP,
+    useContextExpansion,
+} from "../hooks/useContextExpansion"
 import "./ComparisonTable.css"
 
 function escapeRegex(s: string) {
@@ -55,6 +62,92 @@ const formatTime = (seconds: number): string => {
     return `${m}:${String(s).padStart(2, "0")}`
 }
 
+/** "line" / "5 lines": the count is omitted for a single line */
+const countedLines = (n: number) => (n == 1 ? "line" : `${n} lines`)
+
+const Chevron = ({ direction }: { direction: "up" | "down" }) => (
+    <svg
+        className="doc-expand-chevron"
+        width="12"
+        height="12"
+        viewBox="0 0 16 16"
+        aria-hidden="true"
+    >
+        <path
+            d={direction == "down" ? "M3 6l5 5 5-5" : "M3 10l5-5 5 5"}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+    </svg>
+)
+
+/** A GitHub-style 'expand hunk' divider for the hidden lines between search results (#286) */
+const ExpanderRow = (props: {
+    gap: ContextGap
+    /** empty cells before the band (the video/speaker columns) */
+    leadingCells: number
+    /** how many language columns the band covers */
+    languageColSpan: number
+    /** the Link column is present: keep the band off it */
+    hasLinkCell: boolean
+    onExpand: (gap: ContextGap, direction: ExpandDirection) => void
+}) => {
+    const { gap, leadingCells, languageColSpan, hasLinkCell, onExpand } = props
+    const span = gap.end - gap.start + 1
+    const chunk = Math.min(CONTEXT_CHUNK, span)
+    // the edges of the document only reveal towards the nearest result
+    const showDown = gap.position != "leading"
+    const showUp = gap.position != "trailing"
+    const showAll = gap.position == "middle" && span <= SMALL_GAP
+
+    // an extremity fills the whole band: balance it with a chevron on each side
+    const isEdge = gap.position != "middle"
+    const button = (direction: ExpandDirection, label: string) => (
+        <button
+            type="button"
+            className={`doc-expand-btn doc-expand-btn-${direction}`}
+            disabled={gap.loading}
+            onClick={() => onExpand(gap, direction)}
+        >
+            {direction != "all" && <Chevron direction={direction} />}
+            {label}
+            {direction != "all" && isEdge && <Chevron direction={direction} />}
+        </button>
+    )
+
+    return (
+        <tr className="doc-expand-row">
+            {Array.from({ length: leadingCells }, (_, i) => (
+                <td key={i} />
+            ))}
+            <td colSpan={languageColSpan}>
+                <div className="doc-expand-buttons">
+                    {showAll ? (
+                        button("all", "Show context")
+                    ) : (
+                        <>
+                            {showDown &&
+                                button(
+                                    "down",
+                                    `Show next ${countedLines(chunk)}`,
+                                )}
+                            {showUp &&
+                                button(
+                                    "up",
+                                    `Show previous ${countedLines(chunk)}`,
+                                )}
+                        </>
+                    )}
+                </div>
+            </td>
+            {hasLinkCell && <td />}
+        </tr>
+    )
+}
+
 export const ComparisonTable = (props: {
     response: SearchWorkResponse
     value: string
@@ -63,6 +156,8 @@ export const ComparisonTable = (props: {
     manxVisible: boolean
     englishVisible: boolean
     translations?: Translations
+    /** enables 'expand context' between the results (#286) */
+    docIdent?: string
 }) => {
     const {
         response,
@@ -72,6 +167,7 @@ export const ComparisonTable = (props: {
         manxVisible,
         englishVisible,
         translations,
+        docIdent,
     } = props
 
     const onClickWordForDictionaryLookup = (context: string) => {
@@ -277,14 +373,28 @@ export const ComparisonTable = (props: {
     const getRowClassName = (
         line: SearchWorkResult,
         index: number,
+        isContext: boolean,
     ): string | undefined => {
-        if (isPlaying(line)) return "doc-row-playing"
-        return index % 2 === 1 ? "doc-row-striped" : undefined
+        const classes: string[] = []
+        if (isPlaying(line)) {
+            classes.push("doc-row-playing")
+        } else if (index % 2 === 1) {
+            classes.push("doc-row-striped")
+        }
+        if (isContext) {
+            classes.push("doc-row-context")
+        }
+        return classes.length > 0 ? classes.join(" ") : undefined
     }
+
+    const { entries, expand } = useContextExpansion(response, docIdent)
+    const displayedLines = entries.flatMap((x) =>
+        x.type == "line" ? [x.line] : [],
+    )
 
     const hasSpeakerColumn =
         isVideo &&
-        response.results.filter((x) => x.speaker != null && x.speaker != "")
+        displayedLines.filter((x) => x.speaker != null && x.speaker != "")
             .length > 0
 
     const tableStyle = (): CSSProperties => {
@@ -303,7 +413,7 @@ export const ComparisonTable = (props: {
     // TODO: optimise this - no need to iterate each render
     const linkVisible =
         response.gitHubLink ||
-        response.results.filter(
+        displayedLines.filter(
             (x) =>
                 x.page != null && (response.pdfLink || response.googleBooksId),
         ).length > 0
@@ -338,10 +448,14 @@ export const ComparisonTable = (props: {
                                     <th style={{ width: 120 }}>Speaker</th>
                                 )}
                                 {leftVisible && (
-                                    <th>{originalManx ? "Manx" : "English"}</th>
+                                    <th className="doc-lang-head">
+                                        {originalManx ? "Manx" : "English"}
+                                    </th>
                                 )}
                                 {rightVisible && (
-                                    <th>{originalManx ? "English" : "Manx"}</th>
+                                    <th className="doc-lang-head">
+                                        {originalManx ? "English" : "Manx"}
+                                    </th>
                                 )}
                                 {linkVisible && (
                                     <th style={{ width: 70 }}>Link</th>
@@ -349,7 +463,27 @@ export const ComparisonTable = (props: {
                             </tr>
                         </thead>
                         <tbody>
-                            {response.results.map((line, index) => {
+                            {entries.map((entry) => {
+                                if (entry.type == "gap") {
+                                    return (
+                                        <ExpanderRow
+                                            key={`gap-${entry.gap.start}`}
+                                            gap={entry.gap}
+                                            leadingCells={
+                                                (isVideo ? 1 : 0) +
+                                                (hasSpeakerColumn ? 1 : 0)
+                                            }
+                                            languageColSpan={Math.max(
+                                                1,
+                                                (leftVisible ? 1 : 0) +
+                                                    (rightVisible ? 1 : 0),
+                                            )}
+                                            hasLinkCell={Boolean(linkVisible)}
+                                            onExpand={expand}
+                                        />
+                                    )
+                                }
+                                const { line, index, isContext } = entry
                                 // TODO: Only due to technical reasons, we can't mix highlights and diffs.
                                 // This should be fixed via vendoring react-highlight-words's `Highlighter` class
                                 const manxText =
@@ -387,6 +521,7 @@ export const ComparisonTable = (props: {
                                             className={getRowClassName(
                                                 line,
                                                 index,
+                                                isContext,
                                             )}
                                         >
                                             {isVideo && (

--- a/CorpusSearch/ClientApp/src/custom.css
+++ b/CorpusSearch/ClientApp/src/custom.css
@@ -26,6 +26,8 @@
     --c-border-row: #F0E6CE;
     --c-row-stripe: #F8F0DD;
     --c-note-row: #F3EDDD;
+    --c-expand-row: #EDE3C8;
+    --c-expand-row-alt: #F4ECD6;
     --c-dict-strip: #F6ECD9;
     --c-dict-strip-border: #E4D5B4;
     --c-audio-active-row: #EAF0F2;

--- a/CorpusSearch/ClientApp/src/hooks/useContextExpansion.test.ts
+++ b/CorpusSearch/ClientApp/src/hooks/useContextExpansion.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { deriveGaps } from "./useContextExpansion"
+import { SearchWorkResponse, SearchWorkResult } from "../api/SearchWorkApi"
+
+const line = (csvLineNumber: number): SearchWorkResult => ({
+    english: "",
+    manx: "",
+    page: "",
+    csvLineNumber,
+    date: "",
+    notes: "",
+})
+
+const response = (
+    lineNumbers: number[],
+    overrides?: Partial<SearchWorkResponse>,
+): SearchWorkResponse => ({
+    results: lineNumbers.map(line),
+    title: "Test Document",
+    translations: {},
+    totalMatches: lineNumbers.length,
+    timeTaken: "0s",
+    numberOfResults: lineNumbers.length,
+    notes: "",
+    source: "",
+    sourceLinks: null,
+    pdfLink: undefined,
+    googleBooksId: undefined,
+    gitHubLink: "",
+    ...overrides,
+})
+
+describe("deriveGaps (#286)", () => {
+    it("finds the gap between results more than one line apart", () => {
+        expect(deriveGaps(response([2, 10]))).toEqual([
+            { start: 3, end: 9, position: "middle", loading: false },
+        ])
+    })
+
+    it("finds no gap between adjacent results", () => {
+        expect(deriveGaps(response([2, 3, 4]))).toEqual([])
+    })
+
+    it("finds the gaps between the results and the document bounds", () => {
+        const gaps = deriveGaps(
+            response([10, 11], { firstLineNumber: 2, lastLineNumber: 20 }),
+        )
+        expect(gaps).toEqual([
+            { start: 2, end: 9, position: "leading", loading: false },
+            { start: 12, end: 20, position: "trailing", loading: false },
+        ])
+    })
+
+    it("finds no boundary gaps when the results reach the document bounds", () => {
+        const gaps = deriveGaps(
+            response([2, 3], { firstLineNumber: 2, lastLineNumber: 3 }),
+        )
+        expect(gaps).toEqual([])
+    })
+
+    it("finds no boundary gaps without the document bounds", () => {
+        // a '*' search or an empty result has no firstLineNumber/lastLineNumber
+        expect(deriveGaps(response([10, 11]))).toEqual([])
+    })
+
+    it("finds no gaps for a '*' search", () => {
+        // '*' returns every line: line-number jumps are multi-line records, not hidden lines
+        expect(deriveGaps(response([2, 10], { totalMatches: null }))).toEqual(
+            [],
+        )
+    })
+
+    it("finds no gaps without results", () => {
+        expect(
+            deriveGaps(
+                response([], { firstLineNumber: 2, lastLineNumber: 20 }),
+            ),
+        ).toEqual([])
+    })
+})

--- a/CorpusSearch/ClientApp/src/hooks/useContextExpansion.ts
+++ b/CorpusSearch/ClientApp/src/hooks/useContextExpansion.ts
@@ -1,0 +1,240 @@
+import { useEffect, useMemo, useState } from "react"
+import {
+    fetchLines,
+    SearchWorkResponse,
+    SearchWorkResult,
+} from "../api/SearchWorkApi"
+
+/** Lines revealed per click of an expander (#286) */
+export const CONTEXT_CHUNK = 5
+/** A middle gap spanning at most this many CSV lines is expanded with a single click */
+export const SMALL_GAP = CONTEXT_CHUNK * 2
+
+export type ContextGap = {
+    /** the first hidden CSV line number */
+    start: number
+    /** the last hidden CSV line number */
+    end: number
+    /** where the gap sits relative to the results: the edges only expand in one direction */
+    position: "leading" | "middle" | "trailing"
+    /** a fetch for this gap is in flight: ignore further clicks */
+    loading: boolean
+}
+
+/**
+ * "down" continues from the line above the gap; "up" reveals the lines just above the line
+ * below it; "all" reveals the whole gap (small gaps only)
+ */
+export type ExpandDirection = "up" | "down" | "all"
+
+export type TableEntry =
+    | {
+          type: "line"
+          line: SearchWorkResult
+          /** a context line revealed by an expander, rather than a search result */
+          isContext: boolean
+          /** ordinal among the displayed lines (used for row striping) */
+          index: number
+      }
+    | { type: "gap"; gap: ContextGap }
+
+/**
+ * The hidden regions of an in-document search: between results more than one CSV line apart,
+ * and between the results and the bounds of the document.
+ *
+ * A jump in csvLineNumber does not always hide anything (a record may span several raw CSV
+ * lines): such a gap resolves itself on the first click, when the server reports the range
+ * as empty.
+ */
+export const deriveGaps = (response: SearchWorkResponse): ContextGap[] => {
+    // a '*' search already returns every line
+    if (response.totalMatches == null) {
+        return []
+    }
+    const results = response.results
+    if (results.length == 0) {
+        return []
+    }
+
+    const gaps: ContextGap[] = []
+    const first = response.firstLineNumber
+    if (first != null && results[0].csvLineNumber > first) {
+        gaps.push({
+            start: first,
+            end: results[0].csvLineNumber - 1,
+            position: "leading",
+            loading: false,
+        })
+    }
+    for (let i = 1; i < results.length; i++) {
+        const previous = results[i - 1].csvLineNumber
+        const next = results[i].csvLineNumber
+        if (next - previous > 1) {
+            gaps.push({
+                start: previous + 1,
+                end: next - 1,
+                position: "middle",
+                loading: false,
+            })
+        }
+    }
+    const last = response.lastLineNumber
+    const lastResult = results[results.length - 1].csvLineNumber
+    if (last != null && lastResult < last) {
+        gaps.push({
+            start: lastResult + 1,
+            end: last,
+            position: "trailing",
+            loading: false,
+        })
+    }
+    return gaps
+}
+
+type ExpansionState = {
+    contextLines: SearchWorkResult[]
+    gaps: ContextGap[]
+}
+
+/**
+ * 'Expand context' within a document search (#286): tracks the gaps between the returned
+ * lines, fetches hidden lines on demand and merges them into the displayed rows.
+ *
+ * Returns the rows to display (lines interleaved with gap markers, in document order) and
+ * the expand action. Expansion is disabled without a `docIdent`.
+ */
+export const useContextExpansion = (
+    response: SearchWorkResponse,
+    docIdent?: string,
+) => {
+    const initialState = (): ExpansionState => ({
+        contextLines: [],
+        gaps: docIdent ? deriveGaps(response) : [],
+    })
+    const [state, setState] = useState<ExpansionState>(initialState)
+
+    // a new search discards the expansion
+    useEffect(() => {
+        setState({
+            contextLines: [],
+            gaps: docIdent ? deriveGaps(response) : [],
+        })
+    }, [response, docIdent])
+
+    const expand = (gap: ContextGap, direction: ExpandDirection) => {
+        if (gap.loading || docIdent == null) {
+            return
+        }
+        const isSame = (g: ContextGap) =>
+            g.start == gap.start && g.end == gap.end
+        setState((s) => ({
+            ...s,
+            gaps: s.gaps.map((g) => (isSame(g) ? { ...g, loading: true } : g)),
+        }))
+
+        const span = gap.end - gap.start + 1
+        const limit = direction == "all" ? span : Math.min(CONTEXT_CHUNK, span)
+        fetchLines({
+            docIdent,
+            start: gap.start,
+            end: gap.end,
+            limit,
+            fromEnd: direction == "up",
+        })
+            .then((data) => {
+                setState((s) => {
+                    const revealed = data.lines.map((x) => x.csvLineNumber)
+                    const gaps = s.gaps.flatMap((g): ContextGap[] => {
+                        if (!isSame(g)) {
+                            return [g]
+                        }
+                        if (
+                            data.totalInRange <= limit ||
+                            revealed.length == 0
+                        ) {
+                            return [] // nothing left hidden
+                        }
+                        return direction == "up"
+                            ? [
+                                  {
+                                      ...g,
+                                      end: Math.min(...revealed) - 1,
+                                      loading: false,
+                                  },
+                              ]
+                            : [
+                                  {
+                                      ...g,
+                                      start: Math.max(...revealed) + 1,
+                                      loading: false,
+                                  },
+                              ]
+                    })
+                    // belt-and-braces: gap arithmetic should already prevent duplicates
+                    const known = new Set([
+                        ...response.results.map((x) => x.csvLineNumber),
+                        ...s.contextLines.map((x) => x.csvLineNumber),
+                    ])
+                    return {
+                        contextLines: [
+                            ...s.contextLines,
+                            ...data.lines.filter(
+                                (x) => !known.has(x.csvLineNumber),
+                            ),
+                        ],
+                        gaps,
+                    }
+                })
+            })
+            .catch((e: unknown) => {
+                console.warn(e)
+                setState((s) => ({
+                    ...s,
+                    gaps: s.gaps.map((g) =>
+                        isSame(g) ? { ...g, loading: false } : g,
+                    ),
+                }))
+            })
+    }
+
+    const entries = useMemo((): TableEntry[] => {
+        const results = response.results
+        if (state.contextLines.length == 0 && state.gaps.length == 0) {
+            // nothing to expand: preserve the server's ordering exactly
+            return results.map((line, index) => ({
+                type: "line",
+                line,
+                isContext: false,
+                index,
+            }))
+        }
+
+        const rows = [
+            ...results.map((line) => ({ line, isContext: false })),
+            ...state.contextLines.map((line) => ({ line, isContext: true })),
+        ].sort((a, b) => a.line.csvLineNumber - b.line.csvLineNumber)
+        const gaps = [...state.gaps].sort((a, b) => a.start - b.start)
+
+        // interleave: a gap's lines are all hidden, so it sorts before any later row
+        const merged: TableEntry[] = []
+        let gapIndex = 0
+        let lineIndex = 0
+        for (const row of rows) {
+            while (
+                gapIndex < gaps.length &&
+                gaps[gapIndex].start < row.line.csvLineNumber
+            ) {
+                merged.push({ type: "gap", gap: gaps[gapIndex] })
+                gapIndex++
+            }
+            merged.push({ type: "line", ...row, index: lineIndex })
+            lineIndex++
+        }
+        for (; gapIndex < gaps.length; gapIndex++) {
+            merged.push({ type: "gap", gap: gaps[gapIndex] })
+        }
+        return merged
+    }, [response, state])
+
+    return { entries, expand }
+}

--- a/CorpusSearch/ClientApp/src/routes/DocumentView.css
+++ b/CorpusSearch/ClientApp/src/routes/DocumentView.css
@@ -144,6 +144,10 @@
     border-bottom: 1px solid var(--c-border-table-head);
 }
 
+.doc-table th.doc-lang-head {
+    text-align: center;
+}
+
 .doc-table td {
     padding: 8px 10px;
     font-size: 15px;
@@ -153,8 +157,13 @@
     overflow-wrap: break-word;
 }
 
-.doc-row-striped {
+/* stripe the content cells, but keep the Link column uncoloured (like the expanders) */
+.doc-row-striped td {
     background: var(--c-row-stripe);
+}
+
+.doc-row-striped td.doc-link-cell {
+    background: none;
 }
 
 .doc-row-playing {
@@ -167,6 +176,57 @@
     font-size: 13px;
     color: var(--c-secondary);
     text-align: center;
+}
+
+/* context lines revealed by an expander (#286): visibly not matches */
+.doc-row-context {
+    opacity: 0.75;
+}
+
+.doc-table .doc-expand-row td {
+    padding: 0;
+}
+
+.doc-expand-buttons {
+    display: flex;
+    /* too narrow for both halves: stack them instead of spilling over the Link column */
+    flex-wrap: wrap;
+}
+
+/* each direction is a half-width (full-width when alone) coloured band */
+.doc-expand-btn {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border: none;
+    cursor: pointer;
+    padding: 8px 10px;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--c-link);
+    white-space: nowrap;
+}
+
+.doc-expand-btn-down,
+.doc-expand-btn-all {
+    background: var(--c-expand-row);
+}
+
+.doc-expand-btn-up {
+    background: var(--c-expand-row-alt);
+}
+
+.doc-expand-btn:hover {
+    color: var(--c-link-hover);
+    text-decoration: underline;
+}
+
+.doc-expand-btn:disabled {
+    color: var(--c-muted);
+    cursor: default;
+    text-decoration: none;
 }
 
 .doc-play-btn {

--- a/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
+++ b/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
@@ -447,6 +447,7 @@ export const DocumentView = () => {
 
                     <ComparisonTable
                         response={searchWorkResponse}
+                        docIdent={docIdent}
                         value={value}
                         highlightManx={searchManx}
                         highlightEnglish={searchEnglish}

--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -90,7 +90,15 @@ public partial class SearchController(
         public object Notes { get; internal set; }
         public string Source { get; set; }
         public List<SourceLink> SourceLinks { get; internal set; } = [];
-            
+
+        /// <summary>
+        /// The document's first CsvLineNumber: lets the client offer 'expand context' above the
+        /// first result. Null when searching for '*' or when there are no results.
+        /// </summary>
+        public int? FirstLineNumber { get; set; }
+
+        /// <summary>The document's last CsvLineNumber (see <see cref="FirstLineNumber"/>)</summary>
+        public int? LastLineNumber { get; set; }
 
         internal static SearchWorkResult Empty(string title)
         {
@@ -136,6 +144,43 @@ public partial class SearchController(
 
         ret.EnrichWithTime(sw);
         return ret;
+    }
+
+    /// <summary>The most lines an 'expand context' request may return</summary>
+    public const int MAX_CONTEXT_LINES = 100;
+
+    public class WorkLinesResult
+    {
+        /// <summary>The requested lines, in document order</summary>
+        public List<DocumentLine> Lines { get; set; } = [];
+
+        /// <summary>
+        /// The number of lines in [start, end] before the limit was applied: if this is no more
+        /// than the limit, the range is exhausted
+        /// </summary>
+        public int TotalInRange { get; set; }
+    }
+
+    /// <summary>
+    /// Lines of a document by CsvLineNumber range: 'expand context' around a search result (#286).
+    /// Returns the first <paramref name="limit"/> lines of the range, or the last if
+    /// <paramref name="fromEnd"/>.
+    /// </summary>
+    [HttpGet("Lines/{workIdent}")]
+    public async Task<ActionResult<WorkLinesResult>> GetLines(string workIdent, [FromQuery] int start,
+        [FromQuery] int end, [FromQuery] int limit = 5, [FromQuery] bool fromEnd = false)
+    {
+        if (start < 1 || end < start)
+        {
+            return BadRequest("invalid line range");
+        }
+        if (limit is < 1 or > MAX_CONTEXT_LINES)
+        {
+            return BadRequest($"limit must be between 1 and {MAX_CONTEXT_LINES}");
+        }
+        AnonymousAnalytics.Track("Expand Context");
+        var (lines, totalInRange) = await documentSearchService.GetLines(workIdent, start, end, limit, fromEnd);
+        return new WorkLinesResult { Lines = lines, TotalInRange = totalInRange };
     }
 
     [HttpGet("Match/{workIdent}")]

--- a/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
+++ b/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
@@ -370,9 +370,72 @@ public class LuceneIndex(IndexWriter indexWriter)
     {
         using var reader = UseReader();
         var searcher = new IndexSearcher(reader);
-            
+
         TopDocs docs = searcher.Search(new TermQuery(new Term(DOCUMENT_IDENT, ident)), Int32.MaxValue);
 
+        var fieldsToLoad = LineFields(getTranscript);
+
+        return docs.ScoreDocs
+            .Select(x => searcher.Doc(x.Doc, fieldsToLoad))
+            .Select(x => ToDocumentLine(x, getTranscript)).ToList();
+    }
+
+    /// <summary>
+    /// The non-blank lines of a document with a CsvLineNumber in [start, end], in document order:
+    /// the first <paramref name="limit"/> of them, or the last if <paramref name="fromEnd"/>.
+    /// Expands the context around a search result (#286).
+    /// </summary>
+    /// <returns>the lines, and the count in the range before the limit was applied: if it is no
+    /// more than the limit, the range is exhausted</returns>
+    public (List<DocumentLine> Lines, int TotalInRange) GetLines(string ident, int start, int end, int limit,
+        bool fromEnd, bool getTranscript)
+    {
+        using var reader = UseReader();
+        var searcher = new IndexSearcher(reader);
+
+        var query = new BooleanQuery
+        {
+            { new TermQuery(new Term(DOCUMENT_IDENT, ident)), Occur.MUST },
+            { NumericRangeQuery.NewInt32Range(DOCUMENT_LINE_NUMBER, start, end, minInclusive: true, maxInclusive: true), Occur.MUST },
+        };
+
+        var probeFields = new HashSet<string> { DOCUMENT_LINE_NUMBER, DOCUMENT_REAL_MANX, DOCUMENT_REAL_ENGLISH };
+        var candidates = searcher.Search(query, int.MaxValue).ScoreDocs
+            .Select(x => (x.Doc, Probe: searcher.Doc(x.Doc, probeFields)))
+            .Where(x => !string.IsNullOrEmpty(x.Probe.GetField(DOCUMENT_REAL_MANX)?.GetStringValue())
+                        || !string.IsNullOrEmpty(x.Probe.GetField(DOCUMENT_REAL_ENGLISH)?.GetStringValue()))
+            .OrderBy(x => x.Probe.GetField(DOCUMENT_LINE_NUMBER)?.GetInt32Value() ?? -1)
+            .ToList();
+
+        var window = fromEnd ? candidates.Skip(Math.Max(0, candidates.Count - limit)) : candidates.Take(limit);
+        var fieldsToLoad = LineFields(getTranscript);
+        var lines = window
+            .Select(x => ToDocumentLine(searcher.Doc(x.Doc, fieldsToLoad), getTranscript))
+            .ToList();
+        return (lines, candidates.Count);
+    }
+
+    /// <summary>The first and last CsvLineNumber of a document; null if the document has no lines</summary>
+    public (int First, int Last)? GetLineNumberRange(string ident)
+    {
+        using var reader = UseReader();
+        var searcher = new IndexSearcher(reader);
+        var fieldsToLoad = new HashSet<string> { DOCUMENT_LINE_NUMBER };
+
+        int? first = null, last = null;
+        foreach (var scoreDoc in searcher.Search(new TermQuery(new Term(DOCUMENT_IDENT, ident)), int.MaxValue).ScoreDocs)
+        {
+            var line = searcher.Doc(scoreDoc.Doc, fieldsToLoad).GetField(DOCUMENT_LINE_NUMBER)?.GetInt32Value();
+            if (line == null) continue;
+            if (first == null || line < first) first = line;
+            if (last == null || line > last) last = line;
+        }
+
+        return first == null ? null : (first.Value, last.Value);
+    }
+
+    private static HashSet<string> LineFields(bool getTranscript)
+    {
         var fieldsToLoad = new HashSet<string> { DOCUMENT_REAL_MANX, DOCUMENT_REAL_ENGLISH, DOCUMENT_NOTES,
             DOCUMENT_PAGE,
             DOCUMENT_LINE_NUMBER, DOCUMENT_ORIGINAL_MANX, DOCUMENT_ORIGINAL_ENGLISH };
@@ -382,23 +445,23 @@ public class LuceneIndex(IndexWriter indexWriter)
             fieldsToLoad.Add(SUBTITLE_START);
             fieldsToLoad.Add(DOCUMENT_SPEAKER);
         }
-            
-        return docs.ScoreDocs
-            .Select(x => searcher.Doc(x.Doc, fieldsToLoad))
-            .Select(x => new DocumentLine
-            {
-                Manx = x.GetField(DOCUMENT_REAL_MANX)?.GetStringValue(),
-                English = x.GetField(DOCUMENT_REAL_ENGLISH)?.GetStringValue(),
-                Page = x.GetPageAsInt(),
-                Notes = x.GetField(DOCUMENT_NOTES)?.GetStringValue(),
-                CsvLineNumber = x.GetField(DOCUMENT_LINE_NUMBER)?.GetInt32Value() ?? -1,
-                ManxOriginal = x.GetField(DOCUMENT_ORIGINAL_MANX)?.GetStringValue(),
-                EnglishOriginal = x.GetField(DOCUMENT_ORIGINAL_ENGLISH)?.GetStringValue(),
-                SubStart = getTranscript ? x.GetField(SUBTITLE_START)?.GetDoubleValue() : null,
-                SubEnd = getTranscript ? x.GetField(SUBTITLE_END)?.GetDoubleValue() : null,
-                Speaker = getTranscript ? x.GetField(DOCUMENT_SPEAKER)?.GetStringValue() : null
-            }).ToList();
+
+        return fieldsToLoad;
     }
+
+    private static DocumentLine ToDocumentLine(Document document, bool getTranscript) => new()
+    {
+        Manx = document.GetField(DOCUMENT_REAL_MANX)?.GetStringValue(),
+        English = document.GetField(DOCUMENT_REAL_ENGLISH)?.GetStringValue(),
+        Page = document.GetPageAsInt(),
+        Notes = document.GetField(DOCUMENT_NOTES)?.GetStringValue(),
+        CsvLineNumber = document.GetField(DOCUMENT_LINE_NUMBER)?.GetInt32Value() ?? -1,
+        ManxOriginal = document.GetField(DOCUMENT_ORIGINAL_MANX)?.GetStringValue(),
+        EnglishOriginal = document.GetField(DOCUMENT_ORIGINAL_ENGLISH)?.GetStringValue(),
+        SubStart = getTranscript ? document.GetField(SUBTITLE_START)?.GetDoubleValue() : null,
+        SubEnd = getTranscript ? document.GetField(SUBTITLE_END)?.GetDoubleValue() : null,
+        Speaker = getTranscript ? document.GetField(DOCUMENT_SPEAKER)?.GetStringValue() : null
+    };
 
     public long CountManxTerms()
     {

--- a/CorpusSearch/Dependencies/Searcher.cs
+++ b/CorpusSearch/Dependencies/Searcher.cs
@@ -52,6 +52,23 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
         return luceneIndex.GetAllLines(ident, getTranscript: false);
     }
 
+    /// <summary>
+    /// The lines of a document with a CsvLineNumber in [start, end]: the first
+    /// <paramref name="limit"/> of them, or the last if <paramref name="fromEnd"/>.
+    /// Expands the context around a search result (#286).
+    /// </summary>
+    internal (List<DocumentLine> Lines, int TotalInRange) GetLines(string ident, int start, int end, int limit,
+        bool fromEnd, bool getTranscript)
+    {
+        return luceneIndex.GetLines(ident, start, end, limit, fromEnd, getTranscript);
+    }
+
+    /// <summary>The first and last CsvLineNumber of a document; null if the document has no lines</summary>
+    internal (int First, int Last)? GetLineNumberRange(string ident)
+    {
+        return luceneIndex.GetLineNumberRange(ident);
+    }
+
     public ScanResult Scan(string query)
     {
         return Scan(query, ScanOptions.Default);

--- a/CorpusSearch/Service/DocumentSearchService.cs
+++ b/CorpusSearch/Service/DocumentSearchService.cs
@@ -31,10 +31,8 @@ public class DocumentSearchService(
         ret.Source = document.Source;
 
         var searchOptions = ToSearchOptions(workQuery);
-        searchOptions.ReturnTranscriptData = document.Source != null &&
-                                             (document.Source.Trim().StartsWith("https://youtube.com") || 
-                                              document.Source.Trim().StartsWith("https://www.youtube.com")); 
-            
+        searchOptions.ReturnTranscriptData = HasTranscript(document);
+
         var results = searcher.SearchWork(workQuery.Ident, workQuery.Query, searchOptions);
 
         newspaperSourceEnricher.Enrich(ret, document);
@@ -43,9 +41,18 @@ public class DocumentSearchService(
         // Handles more than one result per document line
         ret.TotalMatches = results.TotalMatches;
 
+        // Bounds for 'expand context' (#286): a '*' search (TotalMatches == null) already
+        // returns every line, so has nothing to expand
+        if (results.TotalMatches != null && results.Lines.Count > 0)
+        {
+            var lineNumberRange = searcher.GetLineNumberRange(workQuery.Ident);
+            ret.FirstLineNumber = lineNumberRange?.First;
+            ret.LastLineNumber = lineNumberRange?.Last;
+        }
+
         return ret;
     }
-        
+
     /// <summary>
     /// Returns all lines for a provided document
     /// </summary>
@@ -53,6 +60,26 @@ public class DocumentSearchService(
     internal List<DocumentLine> GetAllLines(string ident)
     {
         return searcher.GetAllLines(ident);
+    }
+
+    /// <summary>
+    /// The lines of a document with a CsvLineNumber in [start, end]: the first
+    /// <paramref name="limit"/> of them, or the last if <paramref name="fromEnd"/>.
+    /// Expands the context around a search result (#286).
+    /// </summary>
+    public async Task<(List<DocumentLine> Lines, int TotalInRange)> GetLines(string ident, int start, int end,
+        int limit, bool fromEnd)
+    {
+        IDocument document = await workService.ByIdent(ident);
+        return searcher.GetLines(ident, start, end, limit, fromEnd, HasTranscript(document));
+    }
+
+    /// <summary>Whether lines carry subtitle timings/speakers: the document is a YouTube transcription</summary>
+    private static bool HasTranscript(IDocument document)
+    {
+        return document.Source != null &&
+               (document.Source.Trim().StartsWith("https://youtube.com") ||
+                document.Source.Trim().StartsWith("https://www.youtube.com"));
     }
 
     private static SearchOptions ToSearchOptions(CorpusSearchWorkQuery workQuery)


### PR DESCRIPTION
If a user has filtered a document to a given search term, there are 'missing' lines, which mean a reader may not have the context they require.

This adds a GitHub style 'expand hunk' button, feeding the line data through
 from Lucene

If there are many lines between the results, a split 'next 5 lines | previous 5' control is added.

Also remove the background color from the 'link' row - it looked bad with the new design

Also center the Manx and English headers on the table

- Fixes #286