### PR TITLE
feat(search): add case-sensitive search option

### DIFF
--- a/CorpusSearch.Test/HighlightingTest.cs
+++ b/CorpusSearch.Test/HighlightingTest.cs
@@ -15,10 +15,11 @@ public class HighlightingTest : QueryBase
 {
     private const string DOC = "doc";
 
-    private SearchResult SearchWork(string query, SearchType type = SearchType.Manx, bool ignoreHyphens = false)
+    private SearchResult SearchWork(string query, SearchType type = SearchType.Manx, bool ignoreHyphens = false,
+        bool caseSensitive = false)
     {
         return new Searcher(luceneIndex, parser)
-            .SearchWork(DOC, query, new SearchOptions { Type = type, IgnoreHyphens = ignoreHyphens });
+            .SearchWork(DOC, query, new SearchOptions { Type = type, IgnoreHyphens = ignoreHyphens, CaseSensitive = caseSensitive });
     }
 
     /// <summary>The substrings of the raw text selected by the returned highlight ranges</summary>
@@ -47,6 +48,33 @@ public class HighlightingTest : QueryBase
     {
         this.AddManxDoc(DOC, "Çhengey ny mayrey");
         AssertSingleLineHighlights("chengey", "Çhengey");
+    }
+
+    [Test]
+    public void CaseSensitiveQueryHighlightsOnlyTheMatchingCase()
+    {
+        // #19 - the cased field has its own term vectors: offsets still map back to the raw text
+        this.AddManxDoc(DOC, "Ta çhengey aym as Çhengey elley");
+        var line = SearchWork("Chengey", caseSensitive: true).Lines.Single();
+        Assert.That(Highlighted(line.Manx, line.ManxHighlights), Is.EqualTo(new[] { "Çhengey" }));
+        Assert.That(line.MatchesInLine, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void CaseSensitiveQueryFindsNothingWhenTheCaseDiffers()
+    {
+        this.AddManxDoc(DOC, "Çhengey ny mayrey");
+        var result = SearchWork("çhengey", caseSensitive: true);
+        Assert.That(result.Lines, Is.Empty);
+    }
+
+    [Test]
+    public void CaseSensitiveEnglishSearchHighlightsTheEnglishText()
+    {
+        AddDocument(DOC, new Line { Manx = "yn çhengey", English = "The Tongue and the tongue" });
+        var line = SearchWork("Tongue", SearchType.English, caseSensitive: true).Lines.Single();
+        Assert.That(Highlighted(line.English, line.EnglishHighlights), Is.EqualTo(new[] { "Tongue" }));
+        Assert.That(line.ManxHighlights, Is.Null);
     }
 
     [Test]
@@ -259,6 +287,14 @@ public class HighlightingTest : QueryBase
         this.AddManxDoc(DOC, "Ta çhengey aym");
         var result = Scan("chengey").DocumentResults.Single();
         Assert.That(Highlighted(result.Sample, result.SampleHighlights), Is.EqualTo(new[] { "çhengey" }));
+    }
+
+    [Test]
+    public void CaseSensitiveScanHighlightsTheSample()
+    {
+        this.AddManxDoc(DOC, "Çhengey ny mayrey as çhengey");
+        var result = Scan("Chengey", new ScanOptions { CaseSensitive = true }).DocumentResults.Single();
+        Assert.That(Highlighted(result.Sample, result.SampleHighlights), Is.EqualTo(new[] { "Çhengey" }));
     }
 
     [Test]

--- a/CorpusSearch.Test/QueryParserTest.cs
+++ b/CorpusSearch.Test/QueryParserTest.cs
@@ -33,7 +33,7 @@ public class QueryParserTest : QueryBase
     [Test]
     public void SearchIsNotCaseSensitive()
     {
-        // TODO: We will fix this later once I write an optional case sensitive span query, but for now, this works.
+        // the default; see TestCaseSensitiveSearch for the opt-in (#19)
         this.AddManxDoc("1", "Hello");
 
         var result = Query("hello");
@@ -45,7 +45,7 @@ public class QueryParserTest : QueryBase
     [Test]
     public void TestSearchForCaps()
     {
-        // TODO: We will fix this later once I write an optional case sensitive span query, but for now, this works.
+        // the default; see TestCaseSensitiveSearch for the opt-in (#19)
         this.AddManxDoc("1", "	dy ve beaghey ayns aggle Yee, as jeaghyn son");
 
         var result = Query("Aggle");
@@ -181,6 +181,87 @@ public class QueryParserTest : QueryBase
 
         Assert.That(withoutDiacritics1.NumberOfMatches, Is.EqualTo(1), "façade should be only match");
         Assert.That(withoutDiacritics2.NumberOfMatches, Is.EqualTo(1), "facade should be only match");
+    }
+
+    [Test]
+    public void TestCaseSensitiveSearch()
+    {
+        // #19 - opt-in case-sensitive matching
+        this.AddManxDoc("1", "hello", "Hello");
+
+        var lower = Query("hello", new ScanOptions { CaseSensitive = true });
+        var caps = Query("Hello", new ScanOptions { CaseSensitive = true });
+
+        Assert.That(lower.NumberOfMatches, Is.EqualTo(1), "'hello' should be the only match");
+        Assert.That(caps.NumberOfMatches, Is.EqualTo(1), "'Hello' should be the only match");
+    }
+
+    [Test]
+    public void TestCaseSensitiveWithDiacritics()
+    {
+        // case and diacritics are independent axes: 'Chengey' still matches 'Çhengey'
+        this.AddManxDoc("1", "Çhengey", "çhengey");
+
+        var caps = Query("Chengey", new ScanOptions { CaseSensitive = true });
+        var lower = Query("chengey", new ScanOptions { CaseSensitive = true });
+
+        Assert.That(caps.NumberOfMatches, Is.EqualTo(1), "'Çhengey' should be the only match");
+        Assert.That(lower.NumberOfMatches, Is.EqualTo(1), "'çhengey' should be the only match");
+    }
+
+    [Test]
+    public void TestCaseSensitiveWithExactDiacritics()
+    {
+        // both options at once: only the identical form matches
+        this.AddManxDoc("1", "Çhengey", "Chengey", "çhengey");
+
+        var result = Query("Çhengey", new ScanOptions { CaseSensitive = true, NormalizeDiacritics = false });
+
+        Assert.That(result.NumberOfMatches, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TestCaseSensitiveWildcard()
+    {
+        this.AddManxDoc("1", "Hello", "hello");
+
+        var caps = Query("H*", new ScanOptions { CaseSensitive = true });
+        var lower = Query("h*", new ScanOptions { CaseSensitive = true });
+
+        Assert.That(caps.NumberOfMatches, Is.EqualTo(1), "'Hello' should be the only match");
+        Assert.That(lower.NumberOfMatches, Is.EqualTo(1), "'hello' should be the only match");
+    }
+
+    [Test]
+    public void TestCaseSensitivePhrase()
+    {
+        this.AddManxDoc("1", "Yn Baase Mooar", "yn baase mooar");
+
+        var result = Query("Baase Mooar", new ScanOptions { CaseSensitive = true });
+
+        Assert.That(result.NumberOfMatches, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TestCaseSensitiveWithIgnoreHyphens()
+    {
+        this.AddManxDoc("1", "Lhiam-Lhiat", "lhiam-lhiat");
+
+        var result = Query("Lhiam Lhiat", new ScanOptions { CaseSensitive = true, IgnoreHyphens = true });
+
+        Assert.That(result.NumberOfMatches, Is.EqualTo(1), "'Lhiam-Lhiat' should be the only match");
+    }
+
+    [Test]
+    public void TestCaseSensitiveEnglish()
+    {
+        AddDocument("1",
+            new Line { Manx = "", English = "The Tongue" },
+            new Line { Manx = "", English = "the tongue" });
+
+        var result = Query("Tongue", new ScanOptions { CaseSensitive = true, SearchType = SearchType.English });
+
+        Assert.That(result.NumberOfMatches, Is.EqualTo(1), "'The Tongue' should be the only match");
     }
 
     [Test]

--- a/CorpusSearch/ClientApp/e2e/highlighting.spec.ts
+++ b/CorpusSearch/ClientApp/e2e/highlighting.spec.ts
@@ -55,6 +55,42 @@ test.describe("document view", () => {
     })
 })
 
+// #19
+test.describe("case-sensitive search", () => {
+    test("a case-matching query still matches with 'Match case' on", async ({
+        page,
+    }) => {
+        await page.goto(`${DOC}?q=Va'n&caseSensitive=true`)
+        await expect(page.locator(mark)).toHaveText("Va’n")
+    })
+
+    test("toggling 'Match case' on the document page filters by case", async ({
+        page,
+    }) => {
+        await page.goto(`${DOC}?q=va'n`)
+        await expect(page.locator(mark)).toHaveText("Va’n")
+
+        await page.locator("summary", { hasText: "Advanced options" }).click()
+        await page.getByLabel("Match case").check()
+
+        // the raw text is "Va’n": the lowercase query no longer matches
+        await expect(page.locator(mark)).toHaveCount(0)
+        await expect(page.getByText(/0 matches/)).toBeVisible()
+    })
+
+    test("toggling 'Match case' on the home page filters results", async ({
+        page,
+    }) => {
+        await page.goto("/?q=va'n")
+        await expect(page.locator("strong.kwic-match")).toHaveText("Va’n")
+
+        await page.locator("summary", { hasText: "Advanced options" }).click()
+        await page.getByLabel("Match case").check()
+
+        await expect(page.getByText(/No matches/)).toBeVisible()
+    })
+})
+
 test.describe("home page", () => {
     test("diacritic-folded query highlights the KWIC sample", async ({
         page,

--- a/CorpusSearch/ClientApp/src/api/Matches.ts
+++ b/CorpusSearch/ClientApp/src/api/Matches.ts
@@ -15,6 +15,7 @@ type MatchQuery = {
     query: string
     match: number
     ignoreHyphens: boolean
+    caseSensitive: boolean
 }
 
 /** Given (document, query, matchIndex):  return a the matched line + information on the match,
@@ -35,7 +36,7 @@ export const GetMatch = async (
     signal?: AbortSignal,
 ): Promise<MatchReference> => {
     const response = await fetch(
-        `search/Match/${params.docIdent}/?query=${params.query}&match=${params.match}&ignoreHyphens=${params.ignoreHyphens.toString()}`,
+        `search/Match/${params.docIdent}/?query=${params.query}&match=${params.match}&ignoreHyphens=${params.ignoreHyphens.toString()}&caseSensitive=${params.caseSensitive.toString()}`,
         { signal },
     )
     return (await response.json()) as MatchReference

--- a/CorpusSearch/ClientApp/src/api/SearchApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchApi.ts
@@ -60,6 +60,8 @@ export type SearchParams = {
     english: boolean
     /** Hyphens, spaces and joined words are interchangeable: "lhiam-lhiat" matches "lhiam lhiat" and "lhiamlhiat" */
     ignoreHyphens: boolean
+    /** Case must match: "Moir" does not match "moir" */
+    caseSensitive: boolean
 }
 
 export const search = async (
@@ -68,7 +70,7 @@ export const search = async (
 ): Promise<SearchResponse> => {
     const query = encodeURIComponent(params.query)
     const response = await fetch(
-        `search/search/${query}?minDate=${params.minDate}&maxDate=${params.maxDate}&manx=${params.manx.toString()}&english=${params.english.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}`,
+        `search/search/${query}?minDate=${params.minDate}&maxDate=${params.maxDate}&manx=${params.manx.toString()}&english=${params.english.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}&caseSensitive=${params.caseSensitive.toString()}`,
         { signal },
     )
     if (!response.ok) {

--- a/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
@@ -59,6 +59,8 @@ type WorkSearch = {
     searchManx: boolean
     /** Hyphens, spaces and joined words are interchangeable: "lhiam-lhiat" matches "lhiam lhiat" and "lhiamlhiat" */
     ignoreHyphens: boolean
+    /** Case must match: "Moir" does not match "moir" */
+    caseSensitive: boolean
 }
 
 /**
@@ -70,7 +72,7 @@ export const searchWork = async (
 ): Promise<SearchWorkResponse> => {
     const searchValue = !params.value ? "*" : params.value
     const response = await fetch(
-        `search/searchWork/${params.docIdent}/${encodeURIComponent(searchValue)}?english=${params.searchEnglish.toString()}&manx=${params.searchManx.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}`,
+        `search/searchWork/${params.docIdent}/${encodeURIComponent(searchValue)}?english=${params.searchEnglish.toString()}&manx=${params.searchManx.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}&caseSensitive=${params.caseSensitive.toString()}`,
         { signal },
     )
     if (!response.ok) {

--- a/CorpusSearch/ClientApp/src/components/AdvancedOptions.tsx
+++ b/CorpusSearch/ClientApp/src/components/AdvancedOptions.tsx
@@ -12,6 +12,8 @@ const AdvancedOptions = (props: {
     onMatchChange: (match: boolean) => void
     ignoreHyphens: boolean
     onIgnoreHyphensChange: (ignoreHyphens: boolean) => void
+    caseSensitive: boolean
+    onCaseSensitiveChange: (caseSensitive: boolean) => void
     children?: ReactNode
 }) => {
     // keep the raw text so clearing a field while typing doesn't snap the value back
@@ -70,6 +72,10 @@ const AdvancedOptions = (props: {
                     ignoreHyphens={props.ignoreHyphens}
                     onIgnoreHyphensChange={props.onIgnoreHyphensChange}
                 />
+                <CaseSensitive
+                    caseSensitive={props.caseSensitive}
+                    onCaseSensitiveChange={props.onCaseSensitiveChange}
+                />
                 {props.children}
             </div>
         </details>
@@ -93,6 +99,27 @@ const IgnoreHyphens = (props: {
                 onChange={(e) => props.onIgnoreHyphensChange(e.target.checked)}
             />
             Ignore hyphens
+        </label>
+    )
+}
+
+// controlled from the page so the option can follow a result onto the document page (#19)
+export const CaseSensitive = (props: {
+    caseSensitive: boolean
+    onCaseSensitiveChange: (caseSensitive: boolean) => void
+}) => {
+    return (
+        <label
+            className="advanced-options-match"
+            title="“Moir” does not match “moir”"
+        >
+            <input
+                id="caseSensitive"
+                type="checkbox"
+                checked={props.caseSensitive}
+                onChange={(e) => props.onCaseSensitiveChange(e.target.checked)}
+            />
+            Match case
         </label>
     )
 }

--- a/CorpusSearch/ClientApp/src/components/MainSearchResults.tsx
+++ b/CorpusSearch/ClientApp/src/components/MainSearchResults.tsx
@@ -119,6 +119,7 @@ export default function MainSearchResults(props: {
     english: boolean
     manx: boolean
     ignoreHyphens: boolean
+    caseSensitive: boolean
     sortKey: ResultsSortKey
     density: ResultsDensity
 }) {
@@ -143,6 +144,7 @@ export default function MainSearchResults(props: {
                         query={query}
                         manx={props.manx}
                         ignoreHyphens={props.ignoreHyphens}
+                        caseSensitive={props.caseSensitive}
                         striped={i % 2 === 1}
                     />
                 ))}
@@ -159,6 +161,7 @@ export default function MainSearchResults(props: {
                     query={query}
                     manx={props.manx}
                     ignoreHyphens={props.ignoreHyphens}
+                    caseSensitive={props.caseSensitive}
                 />
             ))}
         </div>
@@ -170,6 +173,7 @@ const useMatchStepper = (
     result: SearchResultEntry,
     query: string,
     ignoreHyphens: boolean,
+    caseSensitive: boolean,
 ) => {
     const [matchNumber, setMatchNumber] = useState(1) // 1-based
     const [sample, setSample] = useState(result.sample)
@@ -182,6 +186,7 @@ const useMatchStepper = (
             match: line,
             docIdent: result.ident,
             ignoreHyphens,
+            caseSensitive,
         })
         setSample(lineResult.manx)
         setHighlights(lineResult.highlights ?? [])
@@ -270,10 +275,14 @@ const documentLink = (
     query: string,
     manx: boolean,
     ignoreHyphens: boolean,
+    caseSensitive: boolean,
 ) => ({
     to: {
         pathname: `/docs/${result.ident}`,
-        search: `?q=${query}` + (ignoreHyphens ? "&ignoreHyphens=true" : ""),
+        search:
+            `?q=${query}` +
+            (ignoreHyphens ? "&ignoreHyphens=true" : "") +
+            (caseSensitive ? "&caseSensitive=true" : ""),
     },
     state: { searchLanguage: manx ? "Manx" : "English", previousPage: "/" },
 })
@@ -284,10 +293,11 @@ const ResultCard = (props: {
     query: string
     manx: boolean
     ignoreHyphens: boolean
+    caseSensitive: boolean
 }) => {
-    const { result, query, manx, ignoreHyphens } = props
-    const stepper = useMatchStepper(result, query, ignoreHyphens)
-    const link = documentLink(result, query, manx, ignoreHyphens)
+    const { result, query, manx, ignoreHyphens, caseSensitive } = props
+    const stepper = useMatchStepper(result, query, ignoreHyphens, caseSensitive)
+    const link = documentLink(result, query, manx, ignoreHyphens, caseSensitive)
 
     return (
         <div className="result-card">
@@ -321,11 +331,12 @@ const ResultRow = (props: {
     query: string
     manx: boolean
     ignoreHyphens: boolean
+    caseSensitive: boolean
     striped: boolean
 }) => {
-    const { result, query, manx, ignoreHyphens, striped } = props
-    const stepper = useMatchStepper(result, query, ignoreHyphens)
-    const link = documentLink(result, query, manx, ignoreHyphens)
+    const { result, query, manx, ignoreHyphens, caseSensitive, striped } = props
+    const stepper = useMatchStepper(result, query, ignoreHyphens, caseSensitive)
+    const link = documentLink(result, query, manx, ignoreHyphens, caseSensitive)
 
     return (
         <div className={"results-compact-row" + (striped ? " striped" : "")}>

--- a/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
+++ b/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
@@ -16,6 +16,7 @@ import { metadataLookup } from "../api/MetadataApi"
 import { ComparisonTable } from "../components/ComparisonTable"
 import { SearchBar } from "../components/SearchBar"
 import { BackChevron } from "../components/BackChevron"
+import { CaseSensitive } from "../components/AdvancedOptions"
 import { useLanguageVisibility } from "../hooks/useLanguageVisibility"
 import { iMuseumUrl } from "../utils/IMuseum"
 import { isUrl } from "../utils/Url"
@@ -174,6 +175,10 @@ export const DocumentView = () => {
         new URLSearchParams(location.search).get("ignoreHyphens") === "true"
 
     const [value, setValue] = useState(q ?? "*")
+    // initially set when following a result of a case-sensitive corpus search (#19)
+    const [caseSensitive, setCaseSensitive] = useState(
+        new URLSearchParams(location.search).get("caseSensitive") === "true",
+    )
 
     const getInitialSearchLanguage = (): SearchLanguage => {
         // eslint-disable-next-line
@@ -212,6 +217,7 @@ export const DocumentView = () => {
                     searchEnglish,
                     searchManx,
                     ignoreHyphens,
+                    caseSensitive,
                 })
                 setSearchWorkResponse(data)
                 setTitle(data.title)
@@ -219,7 +225,14 @@ export const DocumentView = () => {
                 console.error(e)
             }
         })
-    }, [value, searchEnglish, searchManx, docIdent, ignoreHyphens])
+    }, [
+        value,
+        searchEnglish,
+        searchManx,
+        docIdent,
+        ignoreHyphens,
+        caseSensitive,
+    ])
 
     const [metadata, setMetadata] = useState<Metadata | null>(null)
     const [showAllMeta, setShowAllMeta] = useState(false)
@@ -329,6 +342,10 @@ export const DocumentView = () => {
                             Gaelg &amp; Baarle
                         </button>
                     </div>
+                    <CaseSensitive
+                        caseSensitive={caseSensitive}
+                        onCaseSensitiveChange={setCaseSensitive}
+                    />
                 </div>
             </details>
 

--- a/CorpusSearch/ClientApp/src/routes/Home.test.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.test.tsx
@@ -67,6 +67,21 @@ describe("ignore hyphens option", () => {
     })
 })
 
+// #19
+describe("match case option", () => {
+    it("is sent to the server when toggled", async () => {
+        renderWithQuery("Moir")
+
+        await screen.findByText(/Something went wrong/)
+        expect(searchRequests().at(-1)?.[0]).toContain("caseSensitive=false")
+
+        fireEvent.click(screen.getByLabelText("Match case"))
+
+        await waitFor(() => expect(searchRequests()).toHaveLength(2))
+        expect(searchRequests().at(-1)?.[0]).toContain("caseSensitive=true")
+    })
+})
+
 const emptySearchResponse = (query: string): SearchResponse => ({
     results: [],
     query,

--- a/CorpusSearch/ClientApp/src/routes/Home.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.tsx
@@ -105,6 +105,7 @@ export const Home = () => {
     })
     const [matchPhrase, setMatchPhrase] = useState(false)
     const [ignoreHyphens, setIgnoreHyphens] = useState(false)
+    const [caseSensitive, setCaseSensitive] = useState(false)
 
     const [sortKey, setSortKey] = useState<ResultsSortKey>("year")
     const [density, setDensityState] = useState<ResultsDensity>(loadDensity)
@@ -125,8 +126,16 @@ export const Home = () => {
             manx: searchLanguage === "Manx",
             english: searchLanguage === "English",
             ignoreHyphens,
+            caseSensitive,
         }),
-        [query, searchLanguage, dateRange, matchPhrase, ignoreHyphens],
+        [
+            query,
+            searchLanguage,
+            dateRange,
+            matchPhrase,
+            ignoreHyphens,
+            caseSensitive,
+        ],
     )
 
     const hasNoSearch = query.trim() == ""
@@ -243,6 +252,7 @@ export const Home = () => {
                         manx={searchLanguage == "Manx"}
                         english={searchLanguage == "English"}
                         ignoreHyphens={ignoreHyphens}
+                        caseSensitive={caseSensitive}
                         sortKey={sortKey}
                         density={density}
                     />
@@ -273,6 +283,8 @@ export const Home = () => {
                 onMatchChange={setMatchPhrase}
                 ignoreHyphens={ignoreHyphens}
                 onIgnoreHyphensChange={setIgnoreHyphens}
+                caseSensitive={caseSensitive}
+                onCaseSensitiveChange={setCaseSensitive}
             >
                 {/*on mobile the View control lives here rather than in the results header*/}
                 {!hasNoSearch && (

--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -113,7 +113,7 @@ public partial class SearchController(
     }
 
     [HttpGet("SearchWork/{workIdent}/{query}")]
-    public async Task<ActionResult<SearchWorkResult>> SearchWork(string workIdent, string query = null, bool manx = true, bool english = true, bool ignoreHyphens = false)
+    public async Task<ActionResult<SearchWorkResult>> SearchWork(string workIdent, string query = null, bool manx = true, bool english = true, bool ignoreHyphens = false, bool caseSensitive = false)
     {
         if (QueryTooLong(query))
         {
@@ -127,6 +127,7 @@ public partial class SearchController(
             Manx = manx,
             English = english,
             IgnoreHyphens = ignoreHyphens,
+            CaseSensitive = caseSensitive,
         };
         SearchWorkResult ret = await documentSearchService.SearchWork(workQuery);
 
@@ -184,11 +185,11 @@ public partial class SearchController(
     }
 
     [HttpGet("Match/{workIdent}")]
-    public async Task<MatchReference> GetMatch(string workIdent, [FromQuery] string query, [FromQuery(Name = "match")] int matchNumber, bool ignoreHyphens = false)
+    public async Task<MatchReference> GetMatch(string workIdent, [FromQuery] string query, [FromQuery(Name = "match")] int matchNumber, bool ignoreHyphens = false, bool caseSensitive = false)
     {
         // PREF: Much slower than necessary
         if (matchNumber < 1 || query == null || workIdent == null) return null;
-        var workResult = (await SearchWork(workIdent, query: query, manx: true, english: false, ignoreHyphens: ignoreHyphens)).Value;
+        var workResult = (await SearchWork(workIdent, query: query, manx: true, english: false, ignoreHyphens: ignoreHyphens, caseSensitive: caseSensitive)).Value;
         if (workResult == null) return null;
         var selectedIndex = QueryMatchIndex(workResult.Results, matchNumber);
         if (selectedIndex == null) return null;
@@ -221,7 +222,7 @@ public partial class SearchController(
     }
 
     [HttpGet("Search/{query}")]
-    public async Task<ActionResult<QueryDocumentSearchResult>> SearchCorpus(string query, bool manx = true, bool english = true, int minDate = 1600, int maxDate = 2100, bool ignoreHyphens = false)
+    public async Task<ActionResult<QueryDocumentSearchResult>> SearchCorpus(string query, bool manx = true, bool english = true, int minDate = 1600, int maxDate = 2100, bool ignoreHyphens = false, bool caseSensitive = false)
     {
         if (QueryTooLong(query))
         {
@@ -241,6 +242,7 @@ public partial class SearchController(
             MinDate = DateTimeUtil.FromYear(Math.Max(1, minDate)),
             MaxDate = DateTimeUtil.FromYearMax(maxDate),
             IgnoreHyphens = ignoreHyphens,
+            CaseSensitive = caseSensitive,
         };
         if (!searchQuery.IsValid())
         {

--- a/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
+++ b/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
@@ -27,12 +27,23 @@ public class LuceneIndex(IndexWriter indexWriter)
     public const string DOCUMENT_NORMALIZED_ENGLISH = "english";
     public const string DOCUMENT_REAL_ENGLISH = "real_english";
     public const string DOCUMENT_ORIGINAL_ENGLISH = "original_english";
+    /// <summary>Case-preserving <see cref="DOCUMENT_NORMALIZED_MANX"/>: targeted by case-sensitive queries (#19)</summary>
+    public const string DOCUMENT_CASED_MANX = "manx_cased";
+    /// <summary>Case-preserving <see cref="DOCUMENT_NORMALIZED_ENGLISH"/>: targeted by case-sensitive queries (#19)</summary>
+    public const string DOCUMENT_CASED_ENGLISH = "english_cased";
     public const string DOCUMENT_CREATED_START = "created_start";
     public const string DOCUMENT_CREATED_END = "created_end";
     public const string DOCUMENT_SPEAKER = "speaker";
 
     public const string SUBTITLE_START = "subtitle_start";
     public const string SUBTITLE_END = "subtitle_end";
+
+    /// <summary>Whether the field preserves case (so its analyzer must not case-fold)</summary>
+    internal static bool IsCasedField(string field) => field is DOCUMENT_CASED_MANX or DOCUMENT_CASED_ENGLISH;
+
+    private static bool IsManxField(string field) => field is DOCUMENT_NORMALIZED_MANX or DOCUMENT_CASED_MANX;
+
+    private static bool IsEnglishField(string field) => field is DOCUMENT_NORMALIZED_ENGLISH or DOCUMENT_CASED_ENGLISH;
 
     private IndexReader UseReader() => indexWriter.GetReader(applyAllDeletes: true);
 
@@ -62,6 +73,14 @@ public class LuceneIndex(IndexWriter indexWriter)
             StoreTermVectorOffsets = true
         };
 
+        // the cased fields are only queried, never read back: no need to store the text
+        var casedFieldType = new FieldType(TextField.TYPE_NOT_STORED)
+        {
+            StoreTermVectorPositions = true,
+            StoreTermVectors = true,
+            StoreTermVectorOffsets = true
+        };
+
         foreach (var line in data)
         {
             var doc = new Document
@@ -75,6 +94,8 @@ public class LuceneIndex(IndexWriter indexWriter)
                 new Field(DOCUMENT_NORMALIZED_MANX, line.NormalizedManx , fieldType),
                 // TODO: Confirm that the analyzer that we use is also appropriate for English
                 new Field(DOCUMENT_NORMALIZED_ENGLISH, line.NormalizedEnglish, fieldType),
+                new Field(DOCUMENT_CASED_MANX, line.NormalizedManxCased, casedFieldType),
+                new Field(DOCUMENT_CASED_ENGLISH, line.NormalizedEnglishCased, casedFieldType),
 
             };
 
@@ -140,7 +161,7 @@ public class LuceneIndex(IndexWriter indexWriter)
             int lineNumber = document.GetField(DOCUMENT_LINE_NUMBER)?.GetInt32Value() ?? -1;
 
             var highlights = ComputeHighlights(reader, docId, searchedField,
-                searchedField == DOCUMENT_NORMALIZED_ENGLISH ? english : manx,
+                IsEnglishField(searchedField) ? english : manx,
                 highlightTokenSpans.GetValueOrDefault(docId));
 
             return new DocumentLine
@@ -150,8 +171,8 @@ public class LuceneIndex(IndexWriter indexWriter)
                 Page = document.GetPageAsInt(),
                 Notes = notes,
                 CsvLineNumber = lineNumber,
-                ManxHighlights = searchedField == DOCUMENT_NORMALIZED_MANX ? highlights : null,
-                EnglishHighlights = searchedField == DOCUMENT_NORMALIZED_ENGLISH ? highlights : null,
+                ManxHighlights = IsManxField(searchedField) ? highlights : null,
+                EnglishHighlights = IsEnglishField(searchedField) ? highlights : null,
                 ManxOriginal = document.GetField(DOCUMENT_ORIGINAL_MANX)?.GetStringValue(),
                 EnglishOriginal = document.GetField(DOCUMENT_ORIGINAL_ENGLISH)?.GetStringValue(),
                 SubStart = getTranscriptData ? document.GetField(SUBTITLE_START)?.GetDoubleValue() : null,
@@ -257,9 +278,9 @@ public class LuceneIndex(IndexWriter indexWriter)
             return null;
         }
 
-        MappedText normalized = field == DOCUMENT_NORMALIZED_ENGLISH
-            ? NormalizationMapper.PaddedEnglish(rawText)
-            : NormalizationMapper.PaddedManx(rawText);
+        MappedText normalized = IsEnglishField(field)
+            ? NormalizationMapper.PaddedEnglish(rawText, preserveCase: IsCasedField(field))
+            : NormalizationMapper.PaddedManx(rawText, preserveCase: IsCasedField(field));
 
         var ranges = new List<HighlightRange>();
         foreach (var (start, end) in tokenSpans)
@@ -327,7 +348,7 @@ public class LuceneIndex(IndexWriter indexWriter)
 
         // The sample displayed on the Home page is always the Manx text: only highlight it when Manx was searched
         var sampleDocIds = new HashSet<int>(corpusDocuments.Select(x => x.Key));
-        var highlightTokenSpans = spanQuery.Field == DOCUMENT_NORMALIZED_MANX
+        var highlightTokenSpans = IsManxField(spanQuery.Field)
             ? CollectHighlightTokenSpans(spanQuery, reader, sampleDocIds)
             : [];
 
@@ -349,7 +370,7 @@ public class LuceneIndex(IndexWriter indexWriter)
                 Ident = ident,
                 DocumentName = doc.GetField(DOCUMENT_NAME).GetStringValue(),
                 Sample = sample,
-                SampleHighlights = ComputeHighlights(reader, kvp.Key, DOCUMENT_NORMALIZED_MANX, sample,
+                SampleHighlights = ComputeHighlights(reader, kvp.Key, spanQuery.Field, sample,
                     highlightTokenSpans.GetValueOrDefault(kvp.Key)),
                 EndDate = endDate,
                 StartDate = startDate,

--- a/CorpusSearch/Dependencies/Lucene/ManxAnalyzer.cs
+++ b/CorpusSearch/Dependencies/Lucene/ManxAnalyzer.cs
@@ -6,10 +6,17 @@ namespace CorpusSearch.Dependencies.Lucene;
 
 public class ManxAnalyzer : Analyzer
 {
+    // the cased fields need their own components: the default (global) strategy would reuse
+    // one tokenizer - with one preserveCase setting - for every field
+    public ManxAnalyzer() : base(PER_FIELD_REUSE_STRATEGY)
+    {
+    }
+
     protected override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
     {
-        Tokenizer tokenizer = new ManxTokenizer(LuceneVersion.LUCENE_48, reader);
+        bool preserveCase = LuceneIndex.IsCasedField(fieldName);
+        Tokenizer tokenizer = new ManxTokenizer(LuceneVersion.LUCENE_48, reader, preserveCase);
 
-        return new TokenStreamComponents(tokenizer, new ManxTokenFilter(tokenizer));
+        return new TokenStreamComponents(tokenizer, new ManxTokenFilter(tokenizer, preserveCase));
     }
 }

--- a/CorpusSearch/Dependencies/Lucene/ManxTokenFilter.cs
+++ b/CorpusSearch/Dependencies/Lucene/ManxTokenFilter.cs
@@ -8,10 +8,12 @@ namespace CorpusSearch.Dependencies.Lucene;
 public sealed class ManxTokenFilter : TokenFilter
 {
     private readonly ICharTermAttribute termAtt;
+    private readonly bool preserveCase;
 
-    public ManxTokenFilter(TokenStream input) : base(input)
+    public ManxTokenFilter(TokenStream input, bool preserveCase = false) : base(input)
     {
         this.termAtt = AddAttribute<ICharTermAttribute>();
+        this.preserveCase = preserveCase;
     }
 
     public override bool IncrementToken()
@@ -24,11 +26,11 @@ public sealed class ManxTokenFilter : TokenFilter
             // trailing ? as a question mark
             if (term.EndsWith("?") && !term.EndsWith("??"))
             {
-                newContent = DocumentLine.NormalizeManx(term.TrimEnd('?'), allowQuestionMark: true);
+                newContent = DocumentLine.NormalizeManx(term.TrimEnd('?'), allowQuestionMark: true, preserveCase: preserveCase);
             }
             else
             {
-                newContent = DocumentLine.NormalizeManx(term, allowQuestionMark: true);
+                newContent = DocumentLine.NormalizeManx(term, allowQuestionMark: true, preserveCase: preserveCase);
             }
 
             HandleContentChange(newContent, termAtt);

--- a/CorpusSearch/Dependencies/Lucene/ManxTokenizer.cs
+++ b/CorpusSearch/Dependencies/Lucene/ManxTokenizer.cs
@@ -5,11 +5,15 @@ using System.IO;
 
 namespace CorpusSearch.Dependencies.Lucene;
 
-public sealed class ManxTokenizer(LuceneVersion matchVersion, TextReader input) : CharTokenizer(matchVersion, input)
+public sealed class ManxTokenizer(LuceneVersion matchVersion, TextReader input, bool preserveCase = false) : CharTokenizer(matchVersion, input)
 {
     protected override int Normalize(int c)
     {
-            // TODO: See comment on test 'SearchIsNotCaseSensitive'
+            // the default fields are case-folded; the cased fields back the case-sensitive option
+            if (preserveCase)
+            {
+                return c;
+            }
             char cc = (char)c;
             return char.ToLower(cc);
         }

--- a/CorpusSearch/Dependencies/Searcher.cs
+++ b/CorpusSearch/Dependencies/Searcher.cs
@@ -18,7 +18,12 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
     internal SearchResult SearchWork(string ident, string query, SearchOptions options)
     {
         // HACK: use the ScanOptions as they're the same for now
-        var scanOptionsHack = new ScanOptions { SearchType = options.Type, IgnoreHyphens = options.IgnoreHyphens };
+        var scanOptionsHack = new ScanOptions
+        {
+            SearchType = options.Type,
+            IgnoreHyphens = options.IgnoreHyphens,
+            CaseSensitive = options.CaseSensitive,
+        };
 
         // Detect '*' on the normalized*query to handle '.*'.
         // Intended for good faith use, not security hardening.
@@ -285,8 +290,8 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
     {
         switch (searchOptions.SearchType)
         {
-            case SearchType.Manx: return DocumentLine.NormalizeManx(value, allowQuestionMark: true);
-            case SearchType.English: return DocumentLine.NormalizeEnglish(value, allowQuestionMark: true);
+            case SearchType.Manx: return DocumentLine.NormalizeManx(value, allowQuestionMark: true, preserveCase: searchOptions.CaseSensitive);
+            case SearchType.English: return DocumentLine.NormalizeEnglish(value, allowQuestionMark: true, preserveCase: searchOptions.CaseSensitive);
             default: throw new ArgumentException("Unhandlded case: " + searchOptions.SearchType);
         }
     }
@@ -295,8 +300,10 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
     {
         switch (searchOptions.SearchType)
         {
-            case SearchType.Manx: return LuceneIndex.DOCUMENT_NORMALIZED_MANX;
-            case SearchType.English: return LuceneIndex.DOCUMENT_NORMALIZED_ENGLISH;
+            case SearchType.Manx:
+                return searchOptions.CaseSensitive ? LuceneIndex.DOCUMENT_CASED_MANX : LuceneIndex.DOCUMENT_NORMALIZED_MANX;
+            case SearchType.English:
+                return searchOptions.CaseSensitive ? LuceneIndex.DOCUMENT_CASED_ENGLISH : LuceneIndex.DOCUMENT_NORMALIZED_ENGLISH;
             default: throw new ArgumentException("Unhandlded case: " + searchOptions.SearchType);
         }
     }

--- a/CorpusSearch/Docs/searching.md
+++ b/CorpusSearch/Docs/searching.md
@@ -5,7 +5,7 @@ As the system is still in beta, these are subject to change.
 The search system is very flexible. Please raise an issue on GitHub if your use-case is not supported and we should be able to assist.
 
 * By default, the system does not differentiate between diacritical marks. `ç` matches `c`. A list can be found: https://github.com/david-allison-manx-corpus-search/blob/master/CorpusSearch/Service/DiacriticService.cs
-* By default, the search is case insensitive. `Ayns` matches `ayns` and vice-versa
+* By default, the search is case insensitive. `Ayns` matches `ayns` and vice-versa (see `Match case`)
 * Punctuation marks (except ?, - and ') are removed from the search index
 * It is currently not possible to search for the words: `and`, `or`, or `not`.
 * A query is limited to 30 characters. Please ask if you need this increased.
@@ -47,3 +47,11 @@ Ticking `Ignore hyphens` under `Advanced options` makes hyphens, spaces and join
 * `lhiamlhiat`
 
 The exception: a search with no hyphen or space (`lhiamlhiat`) will not match the spaced form (`lhiam lhiat`), as the system cannot know where the word would be split.
+
+## Match case
+
+By default, the search is case insensitive: `moir` matches `Moir`, `moir` and `MOIR`.
+
+Ticking `Match case` under `Advanced options` makes the search case sensitive: `Moir` no longer matches `moir`.
+
+Diacritics are still normalized independently of this option: with `Match case` ticked, `Chengey` matches `Çhengey`, but not `çhengey`.

--- a/CorpusSearch/Model/CorpusSearchWorkQuery.cs
+++ b/CorpusSearch/Model/CorpusSearchWorkQuery.cs
@@ -9,6 +9,8 @@ public class CorpusSearchWorkQuery(string query)
     public bool English { get; set; }
     /// <inheritdoc cref="ScanOptions.IgnoreHyphens"/>
     public bool IgnoreHyphens { get; set; }
+    /// <inheritdoc cref="ScanOptions.CaseSensitive"/>
+    public bool CaseSensitive { get; set; }
 
     internal bool IsValid()
     {

--- a/CorpusSearch/Model/DocumentLine.cs
+++ b/CorpusSearch/Model/DocumentLine.cs
@@ -48,19 +48,27 @@ public class DocumentLine
         }
     }
 
+    /// <summary>Case-preserving <see cref="NormalizedEnglish"/>: the case-sensitive indexed field text</summary>
+    [JsonIgnore]
+    public string NormalizedEnglishCased => " " + NormalizeEnglish(English, preserveCase: true) + " ";
+
+    /// <summary>Case-preserving <see cref="NormalizedManx"/>: the case-sensitive indexed field text</summary>
+    [JsonIgnore]
+    public string NormalizedManxCased => " " + NormalizeManx(Manx, preserveCase: true) + " ";
+
     /// <summary>The Line Number in the CSV</summary>
     public int CsvLineNumber { get; set; }
 
     // Trim: punctuation is replaced with spaces, so "jee." would otherwise become "jee " and never
     // match an indexed term (#237)
-    public static string NormalizeEnglish(string english, bool allowQuestionMark = false)
+    public static string NormalizeEnglish(string english, bool allowQuestionMark = false, bool preserveCase = false)
     {
-        return NormalizationMapper.NormalizeEnglishMapped(english, allowQuestionMark).Text;
+        return NormalizationMapper.NormalizeEnglishMapped(english, allowQuestionMark, preserveCase).Text;
     }
 
-    public static string NormalizeManx(string manx, bool allowQuestionMark = true)
+    public static string NormalizeManx(string manx, bool allowQuestionMark = true, bool preserveCase = false)
     {
-        return NormalizationMapper.NormalizeManxMapped(manx, allowQuestionMark).Text;
+        return NormalizationMapper.NormalizeManxMapped(manx, allowQuestionMark, preserveCase).Text;
     }
 
 }

--- a/CorpusSearch/Model/NormalizationMapper.cs
+++ b/CorpusSearch/Model/NormalizationMapper.cs
@@ -43,19 +43,21 @@ public static class NormalizationMapper
         ['…'] = "...",
     };
 
-    public static MappedText NormalizeManxMapped(string manx, bool allowQuestionMark = true) =>
-        Normalize(manx, allowQuestionMark, removeColon: true);
+    public static MappedText NormalizeManxMapped(string manx, bool allowQuestionMark = true, bool preserveCase = false) =>
+        Normalize(manx, allowQuestionMark, removeColon: true, preserveCase);
 
-    public static MappedText NormalizeEnglishMapped(string english, bool allowQuestionMark = false) =>
-        Normalize(english, allowQuestionMark, removeColon: false);
+    public static MappedText NormalizeEnglishMapped(string english, bool allowQuestionMark = false, bool preserveCase = false) =>
+        Normalize(english, allowQuestionMark, removeColon: false, preserveCase);
 
     /// <summary>Equivalent of <see cref="DocumentLine.NormalizedManx"/>: the indexed field text</summary>
-    public static MappedText PaddedManx(string manx) => NormalizeManxMapped(manx).Pad(" ", " ");
+    public static MappedText PaddedManx(string manx, bool preserveCase = false) =>
+        NormalizeManxMapped(manx, preserveCase: preserveCase).Pad(" ", " ");
 
     /// <summary>Equivalent of <see cref="DocumentLine.NormalizedEnglish"/>: the indexed field text</summary>
-    public static MappedText PaddedEnglish(string english) => NormalizeEnglishMapped(english).Pad(" ", " ");
+    public static MappedText PaddedEnglish(string english, bool preserveCase = false) =>
+        NormalizeEnglishMapped(english, preserveCase: preserveCase).Pad(" ", " ");
 
-    private static MappedText Normalize(string text, bool allowQuestionMark, bool removeColon)
+    private static MappedText Normalize(string text, bool allowQuestionMark, bool removeColon, bool preserveCase = false)
     {
         var mapped = MappedText.Identity(text)
             // RemovePunctuation
@@ -66,7 +68,7 @@ public static class NormalizationMapper
             .MapChars(c => MicrosoftWordQuotes.GetValueOrDefault(c) ?? c.ToString())
             // RemoveBrackets, RemoveColon (Manx only), RemoveDoubleQuotes
             .MapChars(c => c == '(' || c == ')' || c == '"' || (removeColon && c == ':') ? "" : c.ToString());
-        return ToLower(mapped).Trim();
+        return (preserveCase ? mapped : ToLower(mapped)).Trim();
     }
 
     private static bool IsPunctuation(char c, bool allowQuestionMark)

--- a/CorpusSearch/Model/ScanOptions.cs
+++ b/CorpusSearch/Model/ScanOptions.cs
@@ -16,6 +16,12 @@ public class ScanOptions
     /// 'lhiam-lhiat' matches 'lhiam lhiat' and 'lhiamlhiat' (and vice-versa)
     /// </summary>
     public bool IgnoreHyphens { get; set; }
+
+    /// <summary>
+    /// Whether case must match: 'Moir' does not match 'moir' (#19).
+    /// Independent of <see cref="NormalizeDiacritics"/>: 'Chengey' still matches 'Çhengey'.
+    /// </summary>
+    public bool CaseSensitive { get; set; }
     public DateTime MaxDate { get; internal set; }
     public DateTime MinDate { get; internal set; }
     public SearchType SearchType { get; internal set; }

--- a/CorpusSearch/Model/SearchOptions.cs
+++ b/CorpusSearch/Model/SearchOptions.cs
@@ -6,4 +6,6 @@ public class SearchOptions
     public bool ReturnTranscriptData { get; set; }
     /// <inheritdoc cref="ScanOptions.IgnoreHyphens"/>
     public bool IgnoreHyphens { get; set; }
+    /// <inheritdoc cref="ScanOptions.CaseSensitive"/>
+    public bool CaseSensitive { get; set; }
 }

--- a/CorpusSearch/Service/DiacriticService.cs
+++ b/CorpusSearch/Service/DiacriticService.cs
@@ -70,8 +70,15 @@ public class DiacriticService
             return new[] { ret };
         }
 
-        return reverseMap[input.ToString()].Select(x => x.ToString()).ToList();
+        var reversed = reverseMap[input.ToString()].Select(x => x.ToString()).ToList();
+        if (reversed.Count != 0 || !char.IsUpper(input))
+        {
+            return reversed;
+        }
 
+        // the map only lists lowercase: uppercase letters (which only reach here from
+        // case-sensitive queries, #19) fold like their lowercase forms - 'Ç' <-> 'C'
+        return Replace(char.ToLowerInvariant(input)).Select(x => x.ToUpperInvariant()).ToList();
     }
 
     public static string Replace(string input)

--- a/CorpusSearch/Service/DocumentSearchService.cs
+++ b/CorpusSearch/Service/DocumentSearchService.cs
@@ -88,6 +88,7 @@ public class DocumentSearchService(
         {
             Type = workQuery.Manx ? SearchType.Manx : SearchType.English,
             IgnoreHyphens = workQuery.IgnoreHyphens,
+            CaseSensitive = workQuery.CaseSensitive,
         };
     }
 }

--- a/CorpusSearch/Service/OverviewSearchService2.cs
+++ b/CorpusSearch/Service/OverviewSearchService2.cs
@@ -44,6 +44,7 @@ public class OverviewSearchService2(WorkService workService, Searcher searcher)
                     English = searchQuery.English,
                     MinDate = searchQuery.MinDate,
                     MaxDate = searchQuery.MaxDate,
+                    CaseSensitive = searchQuery.CaseSensitive,
                 });
                 count = results.Sum(x => x.Count);
             }
@@ -76,6 +77,7 @@ public class OverviewSearchService2(WorkService workService, Searcher searcher)
         options.MinDate = searchQuery.MinDate;
         options.SearchType = searchQuery.Manx ? SearchType.Manx : SearchType.English;
         options.IgnoreHyphens = searchQuery.IgnoreHyphens;
+        options.CaseSensitive = searchQuery.CaseSensitive;
 
         return options;
     }


### PR DESCRIPTION
Adds a 'Match case' checkbox under Advanced options, and to the individual document page.

The index was previously normalized, so a new index was created with the required data.

WARN: 1.65x growth of term vectors

- Fixes #19