### PR TITLE
dev!: move API routes under `/api`

### DIFF
--- a/CorpusSearch.Test/IMuseumNewspaperControllerTest.cs
+++ b/CorpusSearch.Test/IMuseumNewspaperControllerTest.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using CorpusSearch.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+[TestFixture]
+public class IMuseumNewspaperControllerTest
+{
+    /// <remarks>
+    /// /IMuseumNewspaper links are shared externally
+    /// </remarks>
+    [Test]
+    public void EndpointsAreUnchanged()
+    {
+        var controllerRoutes = typeof(IMuseumNewspaperController)
+            .GetCustomAttributes(typeof(RouteAttribute), inherit: true)
+            .Cast<RouteAttribute>()
+            .Select(x => x.Template!.Replace("[controller]", "IMuseumNewspaper"))
+            .ToList();
+
+        var actionRoutes = typeof(IMuseumNewspaperController).GetMethods()
+            .SelectMany(x => x.GetCustomAttributes(typeof(HttpGetAttribute), inherit: true))
+            .Cast<HttpGetAttribute>()
+            .Select(x => x.Template)
+            .ToList();
+
+        var servedUrls = controllerRoutes.SelectMany(c => actionRoutes.Select(a => $"/{c}/{a}"));
+
+        Assert.That(servedUrls, Is.EquivalentTo(new[]
+        {
+            "/api/IMuseumNewspaper/Image/V1",
+            "/api/IMuseumNewspaper/Chunk/V1",
+            "/api/IMuseumNewspaper/Component/V1",
+            "/IMuseumNewspaper/Image/V1",
+            "/IMuseumNewspaper/Chunk/V1",
+            "/IMuseumNewspaper/Component/V1",
+        }));
+    }
+}

--- a/CorpusSearch/ClientApp/src/api/CorpusStatistics.ts
+++ b/CorpusSearch/ClientApp/src/api/CorpusStatistics.ts
@@ -7,7 +7,7 @@ export type Statistics = {
 export const getCorpusStatistics = async (
     signal?: AbortSignal,
 ): Promise<Statistics> => {
-    const response = await fetch("statistics", { signal })
+    const response = await fetch("api/statistics", { signal })
     // TODO: Validation
     return (await response.json()) as Statistics
 }

--- a/CorpusSearch/ClientApp/src/api/Matches.ts
+++ b/CorpusSearch/ClientApp/src/api/Matches.ts
@@ -37,7 +37,7 @@ export const GetMatch = async (
     signal?: AbortSignal,
 ): Promise<MatchReference> => {
     const response = await fetch(
-        `search/Match/${params.docIdent}/?query=${params.query}&match=${params.match}&ignoreHyphens=${params.ignoreHyphens.toString()}&caseSensitive=${params.caseSensitive.toString()}&accentSensitive=${params.accentSensitive.toString()}`,
+        `api/search/Match/${params.docIdent}/?query=${params.query}&match=${params.match}&ignoreHyphens=${params.ignoreHyphens.toString()}&caseSensitive=${params.caseSensitive.toString()}&accentSensitive=${params.accentSensitive.toString()}`,
         { signal },
     )
     return (await response.json()) as MatchReference

--- a/CorpusSearch/ClientApp/src/api/SearchApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchApi.ts
@@ -72,7 +72,7 @@ export const search = async (
 ): Promise<SearchResponse> => {
     const query = encodeURIComponent(params.query)
     const response = await fetch(
-        `search/search/${query}?minDate=${params.minDate}&maxDate=${params.maxDate}&manx=${params.manx.toString()}&english=${params.english.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}&caseSensitive=${params.caseSensitive.toString()}&accentSensitive=${params.accentSensitive.toString()}`,
+        `api/search/search/${query}?minDate=${params.minDate}&maxDate=${params.maxDate}&manx=${params.manx.toString()}&english=${params.english.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}&caseSensitive=${params.caseSensitive.toString()}&accentSensitive=${params.accentSensitive.toString()}`,
         { signal },
     )
     if (!response.ok) {

--- a/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
@@ -74,7 +74,7 @@ export const searchWork = async (
 ): Promise<SearchWorkResponse> => {
     const searchValue = !params.value ? "*" : params.value
     const response = await fetch(
-        `search/searchWork/${params.docIdent}/${encodeURIComponent(searchValue)}?english=${params.searchEnglish.toString()}&manx=${params.searchManx.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}&caseSensitive=${params.caseSensitive.toString()}&accentSensitive=${params.accentSensitive.toString()}`,
+        `api/search/searchWork/${params.docIdent}/${encodeURIComponent(searchValue)}?english=${params.searchEnglish.toString()}&manx=${params.searchManx.toString()}&ignoreHyphens=${params.ignoreHyphens.toString()}&caseSensitive=${params.caseSensitive.toString()}&accentSensitive=${params.accentSensitive.toString()}`,
         { signal },
     )
     if (!response.ok) {
@@ -97,7 +97,7 @@ export const fetchLines = async (params: {
     fromEnd: boolean
 }): Promise<WorkLinesResponse> => {
     const response = await fetch(
-        `search/lines/${params.docIdent}?start=${params.start.toString()}&end=${params.end.toString()}&limit=${params.limit.toString()}&fromEnd=${params.fromEnd.toString()}`,
+        `api/search/lines/${params.docIdent}?start=${params.start.toString()}&end=${params.end.toString()}&limit=${params.limit.toString()}&fromEnd=${params.fromEnd.toString()}`,
     )
     if (!response.ok) {
         throw new Error(`line fetch failed: ${response.status}`)

--- a/CorpusSearch/ClientApp/vite.config.ts
+++ b/CorpusSearch/ClientApp/vite.config.ts
@@ -5,18 +5,13 @@ import react from "@vitejs/plugin-react"
 // site's API - no local backend, so no waiting for corpus indexing.
 const useProdBackend = process.env.BACKEND === "prod"
 const liveSite = "https://corpus.gaelg.im"
-// Everything the backend serves: fetch() targets (SearchController, api/*,
-// statistics) plus the non-SPA pages linked from the UI (Browse, Dictionary, ...)
-// TODO: Move all JSON endpoints under /api - this becomes /api + Razor Views
+// Everything the backend serves: /api and Razor View Pages
 const backendPaths = [
     "/api",
-    "/search",
-    "/statistics",
     "/Browse",
     "/Dictionary",
     "/MailingList",
-    "/Tags",
-    "/IMuseumNewspaper"
+    "/Tags"
 ]
 
 // https://vite.dev/config/

--- a/CorpusSearch/Controllers/IMuseumNewspaperController.cs
+++ b/CorpusSearch/Controllers/IMuseumNewspaperController.cs
@@ -4,7 +4,8 @@ using static CorpusSearch.Service.IMuseumNewspaperService;
 
 namespace CorpusSearch.Controllers;
 
-[Route("[controller]")]
+[Route("api/[controller]")]
+[Route("[controller]")] // (legacy) old /IMuseumNewspaper links were shared externally
 public class IMuseumNewspaperController : Controller
 {
     [HttpGet("Image/V1")]
@@ -26,7 +27,7 @@ public class IMuseumNewspaperController : Controller
 
     /// <summary>Redirects to a page where a user can view a full component (one or more pieces of Manx)</summary>
     /// <remarks>A Component and a chunk id are typically the same, but some chunks aren't components</remarks>
-    /// <remarks>sample call: /IMuseumNewspaper/Component/V1?newspaper=MNH&date=1845-01-08&id=Ar00318</remarks>
+    /// <remarks>sample call: /api/IMuseumNewspaper/Component/V1?newspaper=MNH&date=1845-01-08&id=Ar00318</remarks>
     [HttpGet("Component/V1")]
     public IActionResult Component([FromQuery] string newspaper, [FromQuery] string date, [FromQuery] string id)
     {

--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace CorpusSearch.Controllers;
 
 [ApiController]
-[Route("[controller]")]
+[Route("api/[controller]")]
 public partial class SearchController(
     DocumentSearchService documentSearchService,
     OverviewSearchService2 overviewSearchService,

--- a/CorpusSearch/Controllers/StatisticsController.cs
+++ b/CorpusSearch/Controllers/StatisticsController.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CorpusSearch.Controllers;
 
-[Route("[controller]")]
+[Route("api/[controller]")]
 public class StatisticsController : Controller
 {
     private static long _documentCount;

--- a/CorpusSearch/Controllers/TagsController.cs
+++ b/CorpusSearch/Controllers/TagsController.cs
@@ -15,10 +15,11 @@ namespace CorpusSearch.Controllers;
 /// </summary>
 /// <remarks>Currently only single tags. No Binary operations</remarks>
 /// <remarks>Only 1 level, not properly recursive</remarks>
+/// <remarks>Serves both the JSON API (absolute /api/Tags routes) and the HTML pages (/Tags)</remarks>
 [Route("[controller]")]
 public class TagsController(WorkService workService) : Controller
 {
-    [HttpGet("All")]
+    [HttpGet("/api/Tags/All")]
     public async Task<List<Tag>> GetTags()
     {
         var allDocuments = await workService.GetAll();
@@ -80,7 +81,7 @@ public class TagsController(WorkService workService) : Controller
         Predicate<IDocument> HasSource(string toFind) => doc => doc.Source?.Contains(toFind, StringComparison.OrdinalIgnoreCase) ?? false;
     }
 
-    [HttpGet("List/{tagName}")]
+    [HttpGet("/api/Tags/List/{tagName}")]
     public async Task<DocumentTree?> GetDocumentsWithTag(string tagName)
     {
         Tag? t = await LookupTag(tagName);

--- a/CorpusSearch/Docs/newspaper_images.md
+++ b/CorpusSearch/Docs/newspaper_images.md
@@ -1,6 +1,6 @@
 # Obtaining a good link to iMuseum newspaper images
 
-Example of the output: http://corpus.gaelg.im/IMuseumNewspaper/Component/V1?newspaper=IMT&date=1913-05-03&id=Ar00905
+Example of the output: http://corpus.gaelg.im/api/IMuseumNewspaper/Component/V1?newspaper=IMT&date=1913-05-03&id=Ar00905
 
 ## iMuseum steps
 
@@ -52,4 +52,4 @@ The link to the newspaper images appear in the corpus article under 'Additional 
 Example page: https://corpus.gaelg.im/docs/Manx-Gaelic-Gathering-first-chaglym
 
 * Example URL: 
-  * http://manxcorpus.com/IMuseumNewspaper/Component/V1?newspaper=IMT&date=1913-05-03&id=Ar00905 
+  * http://manxcorpus.com/api/IMuseumNewspaper/Component/V1?newspaper=IMT&date=1913-05-03&id=Ar00905 

--- a/CorpusSearch/Service/IMuseumNewspaperService.cs
+++ b/CorpusSearch/Service/IMuseumNewspaperService.cs
@@ -74,7 +74,7 @@ public class IMuseumNewspaperService
 
         internal string ToLocalUrl()
         {
-            return $"/IMuseumNewspaper/Component/V1?newspaper={Reference.NewspaperIdentifier}&date={Reference.Date:yyyy-MM-dd}&id={ComponentId}";
+            return $"/api/IMuseumNewspaper/Component/V1?newspaper={Reference.NewspaperIdentifier}&date={Reference.Date:yyyy-MM-dd}&id={ComponentId}";
         }
     }
 


### PR DESCRIPTION
Maintain '/IMuseumNewspaper/Component' so we don't break links

- Fixes #309