### PR TITLE
feat(ci): add permissions to workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - "master"
 
+permissions:
+  contents: read
+
 jobs:
   client-lint:
     name: Client Lint


### PR DESCRIPTION
Additional security hardening

Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {contents: read}

If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used.

Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.

- Fixes https://github.com/david-allison/manx-corpus-search/security/code-scanning/1 
- Fixes https://github.com/david-allison/manx-corpus-search/security/code-scanning/2 
- Fixes https://github.com/david-allison/manx-corpus-search/security/code-scanning/3 
- Fixes https://github.com/david-allison/manx-corpus-search/security/code-scanning/4