### PR TITLE
feat(document): show/collapse notes

### DIFF
--- a/CorpusSearch/ClientApp/e2e/fixtures/corpus/NotesFixture/document.csv
+++ b/CorpusSearch/ClientApp/e2e/fixtures/corpus/NotesFixture/document.csv
@@ -1,0 +1,4 @@
+English,Manx,Notes
+"They were on the headland of the Calf.","V’ad er Geaylin yn Cholloo. [1]","[1] Geaylin yn Cholloo - ‘headland on the Calf of Man’"
+"A line without a note.","Linney gyn notey.",
+"A line with an unlinked note.","Linney lesh notey gyn cowrey.","An editorial note with no marker in the text."

--- a/CorpusSearch/ClientApp/e2e/fixtures/corpus/NotesFixture/license.txt
+++ b/CorpusSearch/ClientApp/e2e/fixtures/corpus/NotesFixture/license.txt
@@ -1,0 +1,1 @@
+Synthetic test data. Public domain.

--- a/CorpusSearch/ClientApp/e2e/fixtures/corpus/NotesFixture/manifest.json.txt
+++ b/CorpusSearch/ClientApp/e2e/fixtures/corpus/NotesFixture/manifest.json.txt
@@ -1,0 +1,8 @@
+{
+  "created": "1900-01-01",
+  "ident": "e2e-notes-fixture",
+  "name": "Notes Fixture",
+  "original": "Manx",
+  "notes": "Synthetic document exercising the note rows of #132: one note linked to a [1] marker, one without a marker. Used by the Playwright end-to-end tests.",
+  "source": "e2e test fixture"
+}

--- a/CorpusSearch/ClientApp/e2e/notes.spec.ts
+++ b/CorpusSearch/ClientApp/e2e/notes.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test"
+
+// End-to-end coverage of #132: notes are hidden while reading, each collapsed behind
+// the "[1]" marker in its line; a note with no marker in the text never hides.
+
+const DOC = "/docs/e2e-notes-fixture"
+const linkedNote = "‘headland on the Calf of Man’"
+const unlinkedNote = "An editorial note with no marker in the text."
+const marker = ".doc-note-marker"
+
+test.describe("note rows (#132)", () => {
+    test("notes hide by default; an unlinked note shows as-is", async ({
+        page,
+    }) => {
+        await page.goto(DOC)
+        // a note with no marker cannot be revealed, so it is never hidden
+        await expect(page.getByText(unlinkedNote)).toBeVisible()
+        // the linked note is collapsed behind its marker
+        await expect(page.locator(marker)).toBeVisible()
+        await expect(page.getByText(linkedNote)).toHaveCount(0)
+    })
+
+    test("the [1] marker reveals its note and hides it again", async ({
+        page,
+    }) => {
+        await page.goto(DOC)
+        await page.locator(marker).click()
+        await expect(page.getByText(linkedNote)).toBeVisible()
+
+        await page.locator(marker).click()
+        await expect(page.getByText(linkedNote)).toHaveCount(0)
+    })
+
+    test("'Show notes' shows every note, and persists", async ({ page }) => {
+        await page.goto(DOC)
+        await page.locator("summary", { hasText: "Advanced options" }).click()
+        await page.getByLabel("Show notes").check()
+
+        await expect(page.getByText(linkedNote)).toBeVisible()
+        await expect(page.locator(".noteRow")).toHaveCount(2)
+
+        // the marker can still collapse an individual note
+        await page.locator(marker).click()
+        await expect(page.getByText(linkedNote)).toHaveCount(0)
+
+        // the preference survives a reload
+        await page.reload()
+        await expect(page.getByText(linkedNote)).toBeVisible()
+    })
+})

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
@@ -529,6 +529,116 @@ describe("dictionary popup (#51)", () => {
     })
 })
 
+describe("note rows", () => {
+    const notedLine = () =>
+        line({
+            manx: "Geaylin yn Cholloo. [1]",
+            english: "The headland on the Calf.",
+            notes: "[1] Geaylin yn Cholloo - ‘headland on the Calf of Man’",
+        })
+
+    beforeEach(() => {
+        mockGetSelectedWordOrPhrase.mockClear()
+    })
+
+    it("shows a linked note by default", () => {
+        const { container } = renderTable([notedLine()])
+        expect(container.querySelector(".noteRow")).not.toBeNull()
+    })
+
+    it("hides a linked note when 'Show notes' is off", () => {
+        const { container } = renderTable([notedLine()], { showNotes: false })
+        expect(container.querySelector(".noteRow")).toBeNull()
+    })
+
+    it("reveals a hidden note via its marker, and hides it again", () => {
+        const { container, getByTitle } = renderTable([notedLine()], {
+            showNotes: false,
+        })
+        fireEvent.click(getByTitle("Show note"))
+        expect(container.querySelector(".noteRow")).not.toBeNull()
+        fireEvent.click(getByTitle("Hide note"))
+        expect(container.querySelector(".noteRow")).toBeNull()
+    })
+
+    it("hides a shown note via its marker", () => {
+        const { container } = renderTable([notedLine()])
+        fireEvent.click(container.querySelector(".doc-note-marker")!)
+        expect(container.querySelector(".noteRow")).toBeNull()
+    })
+
+    it("always shows a note without a marker in the text", () => {
+        const unlinked = line({
+            manx: "gyn cowrey",
+            notes: "an editorial note",
+        })
+        const { container } = renderTable([unlinked], { showNotes: false })
+        expect(container.querySelector(".noteRow")).not.toBeNull()
+        expect(container.querySelector(".doc-note-marker")).toBeNull()
+    })
+
+    it("shows a note as-is when its marker is in a hidden column", () => {
+        // the marker sits in the Manx text, but only English is displayed
+        const { container } = renderTable([notedLine()], {
+            showNotes: false,
+            manxVisible: false,
+        })
+        expect(container.querySelector(".noteRow")).not.toBeNull()
+    })
+
+    it("shows a corrected (diffed) line's note as-is", () => {
+        // the diff view renders plain text: there is no marker to click
+        const diffed = line({
+            manx: "kiartit [1]",
+            manxOriginal: "kiartit[1]",
+            notes: "[1] a note",
+        })
+        const { container } = renderTable([diffed], { showNotes: false })
+        expect(container.querySelector(".noteRow")).not.toBeNull()
+    })
+
+    it("leaves markers as plain text on lines without notes", () => {
+        const { container } = renderTable([line({ manx: "cowrey [1] elley" })])
+        expect(container.querySelector(".doc-note-marker")).toBeNull()
+        expect(container.textContent).toContain("[1]")
+    })
+
+    it("does not open the dictionary popup when clicking a marker", () => {
+        const { container } = renderTable([notedLine()])
+        fireEvent.click(container.querySelector(".doc-note-marker")!)
+        expect(mockGetSelectedWordOrPhrase).not.toHaveBeenCalled()
+    })
+
+    it("keeps the note row off the Link column", () => {
+        const noted = notedLine()
+        const { container } = renderTable([noted], {
+            response: {
+                ...response([noted]),
+                gitHubLink: "https://github.com/x/y",
+            },
+        })
+        const cells = container.querySelectorAll(".noteRow td")
+        // the note band spans the two language columns; the Link cell stays empty
+        expect(cells).toHaveLength(2)
+        expect(cells[0].getAttribute("colspan")).toBe("2")
+        expect(cells[0].classList.contains("doc-note-band")).toBe(true)
+        expect(cells[1].textContent).toBe("")
+    })
+
+    it("keeps highlight offsets correct around a marker", () => {
+        // server offsets are into the full cell, including the marker
+        const { container } = renderTable([
+            line({
+                manx: "abc [1] cre def",
+                notes: "[1] a note",
+                manxHighlights: [{ start: 8, end: 11 }],
+            }),
+        ])
+        const marks = container.querySelectorAll("mark.textHighlight")
+        expect(Array.from(marks).map((x) => x.textContent)).toEqual(["cre"])
+    })
+})
+
 describe("segmentChunks", () => {
     it("shifts ranges into segment-local offsets", () => {
         // "abc\ncre def": segment 2 starts at offset 4

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -23,6 +23,12 @@ function escapeRegex(s: string) {
     return s.replace(/[/\-\\^$*+?.()|[\]{}]/g, "\\$&")
 }
 
+/** A note/citation marker such as "[1]", linking a line to its note row (#132) */
+const NOTE_MARKER = /\[\d+\]/
+// split() with the marker captured, so the markers survive as parts
+const NOTE_MARKER_SPLIT = /(\[\d+\])/
+const isNoteMarker = (part: string) => /^\[\d+\]$/.test(part)
+
 /**
  * Shifts server highlight ranges (offsets into the full line) into offsets local to one
  * newline-separated segment of it, clipping ranges which cross the boundary.
@@ -82,6 +88,102 @@ function markChunks(
     }
     return nodes
 }
+
+type NoteToggle = {
+    /** the linked note row is currently displayed */
+    noteVisible: boolean
+    toggle: () => void
+}
+
+/** A clickable "[1]" marker: shows/hides the note row it references (#132) */
+const NoteMarkerButton = (props: {
+    marker: string
+    noteToggle: NoteToggle
+}) => {
+    const { marker, noteToggle } = props
+    return (
+        <button
+            type="button"
+            className="doc-note-marker"
+            aria-expanded={noteToggle.noteVisible}
+            title={noteToggle.noteVisible ? "Hide note" : "Show note"}
+            onClick={(e) => {
+                e.stopPropagation() // not a dictionary lookup
+                noteToggle.toggle()
+            }}
+        >
+            {/* the chip already delimits the number: drop the brackets of "[1]" */}
+            {marker.slice(1, -1)}
+        </button>
+    )
+}
+
+/** One newline-separated segment of a cell: its highlighted text, with any
+ * "[1]" markers rendered as toggles for the note row (#132) */
+const SegmentText = (props: {
+    text: string
+    /** the segment's offset into the full cell: highlight ranges are cell-wide */
+    segmentStart: number
+    /** the server-matched ranges; null fuzzy-matches `searchWords` instead */
+    highlights: HighlightRange[] | null
+    searchWords: string[]
+    noteToggle?: NoteToggle
+}) => {
+    const { text, segmentStart, highlights, searchWords, noteToggle } = props
+    // note markers split the segment and become the note row's toggle
+    const parts = noteToggle ? text.split(NOTE_MARKER_SPLIT) : [text]
+    let partStart = segmentStart
+    return (
+        <>
+            {parts.map((part, key) => {
+                const start = partStart
+                partStart += part.length
+                if (noteToggle && isNoteMarker(part)) {
+                    return (
+                        <NoteMarkerButton
+                            key={key}
+                            marker={part}
+                            noteToggle={noteToggle}
+                        />
+                    )
+                }
+                if (part == "") {
+                    return null
+                }
+                const chunks = highlights
+                    ? segmentChunks(highlights, start, part.length)
+                    : null
+                return (
+                    <Highlighter
+                        key={key}
+                        highlightClassName={
+                            highlights
+                                ? "textHighlight"
+                                : "textHighlightAlternate"
+                        }
+                        searchWords={searchWords}
+                        autoEscape={false}
+                        findChunks={chunks ? () => chunks : undefined}
+                        textToHighlight={part}
+                    />
+                )
+            })}
+        </>
+    )
+}
+
+/** A "[1]" marker in a visible, undiffed cell links the line to its note row
+ * (#132). An unlinked note has no toggle, so it is always shown as-is. */
+const isNoteLinked = (
+    line: SearchWorkResult,
+    manxVisible: boolean,
+    englishVisible: boolean,
+): boolean =>
+    Boolean(line.notes) &&
+    ((manxVisible && !line.manxOriginal && NOTE_MARKER.test(line.manx)) ||
+        (englishVisible &&
+            !line.englishOriginal &&
+            NOTE_MARKER.test(line.english)))
 
 const formatTime = (seconds: number): string => {
     const m = Math.floor(seconds / 60)
@@ -203,6 +305,9 @@ export const ComparisonTable = (props: {
     docIdent?: string
     /** the "Show context" option: hides the expanders without dropping the docIdent */
     expandContext?: boolean
+    /** the "Show notes" option. When off, a note row linked to a "[1]"
+     * marker collapses behind it, and the marker reveals it */
+    showNotes?: boolean
 }) => {
     const {
         response,
@@ -214,6 +319,7 @@ export const ComparisonTable = (props: {
         translations,
         docIdent,
         expandContext,
+        showNotes,
     } = props
 
     const onClickWordForDictionaryLookup = (context: string) => {
@@ -261,11 +367,31 @@ export const ComparisonTable = (props: {
     // The original text (whether Manx -> English or English -> Manx)
     const originalManx = response.original != "English" // anything other than English is Manx
 
+    const notesShown = showNotes !== false
+    // notes the reader toggled via a "[1]" marker: these rows flip against the
+    // "Show notes" baseline, keyed by csvLineNumber (#132)
+    const [toggledNotes, setToggledNotes] = useState<Set<number>>(new Set())
+    useEffect(() => {
+        setToggledNotes((previous) =>
+            previous.size == 0 ? previous : new Set(),
+        )
+    }, [docIdent, notesShown])
+    const toggleNote = (lineNumber: number) => {
+        setToggledNotes((previous) => {
+            const next = new Set(previous)
+            if (!next.delete(lineNumber)) {
+                next.add(lineNumber)
+            }
+            return next
+        })
+    }
+
     const highlightText = (
         shouldHighlight: boolean,
         languageCode: "gv" | "en",
         lineValue: string,
         highlights?: HighlightRange[],
+        noteToggle?: NoteToggle,
     ) => {
         // The searched language: highlight the ranges the server matched (#40).
         // The other language: fuzzy-match the dictionary translations of the query.
@@ -282,9 +408,7 @@ export const ComparisonTable = (props: {
                 : []
         let segmentStart = 0
         return lineValue.split("\n").map((item, key) => {
-            const chunks = shouldHighlight
-                ? segmentChunks(highlights ?? [], segmentStart, item.length)
-                : null
+            const start = segmentStart
             segmentStart += item.length + 1 // + the removed "\n"
             return (
                 <div
@@ -296,16 +420,12 @@ export const ComparisonTable = (props: {
                     className="doc-line"
                     key={key}
                 >
-                    <Highlighter
-                        highlightClassName={
-                            shouldHighlight
-                                ? "textHighlight"
-                                : "textHighlightAlternate"
-                        }
+                    <SegmentText
+                        text={item}
+                        segmentStart={start}
+                        highlights={shouldHighlight ? (highlights ?? []) : null}
                         searchWords={searchWords}
-                        autoEscape={false}
-                        findChunks={chunks ? () => chunks : undefined}
-                        textToHighlight={item}
+                        noteToggle={noteToggle}
                     />
                     <br />
                 </div>
@@ -504,13 +624,13 @@ export const ComparisonTable = (props: {
             ).length > 0)
     const leftLang = originalManx ? "gv" : "en"
     const rightLang = originalManx ? "en" : "gv"
-    const visibleColumnCount = [
-        isVideo,
-        hasSpeakerColumn,
-        leftVisible,
-        rightVisible,
-        linkVisible,
-    ].filter(Boolean).length
+    // the expander and note bands cover the language columns only, leaving the
+    // video/speaker/Link cells uncoloured
+    const leadingCells = (isVideo ? 1 : 0) + (hasSpeakerColumn ? 1 : 0)
+    const languageColSpan = Math.max(
+        1,
+        (leftVisible ? 1 : 0) + (rightVisible ? 1 : 0),
+    )
     return (
         <>
             <div>
@@ -558,21 +678,33 @@ export const ComparisonTable = (props: {
                                         <ExpanderRow
                                             key={`gap-${entry.gap.start}`}
                                             gap={entry.gap}
-                                            leadingCells={
-                                                (isVideo ? 1 : 0) +
-                                                (hasSpeakerColumn ? 1 : 0)
-                                            }
-                                            languageColSpan={Math.max(
-                                                1,
-                                                (leftVisible ? 1 : 0) +
-                                                    (rightVisible ? 1 : 0),
-                                            )}
+                                            leadingCells={leadingCells}
+                                            languageColSpan={languageColSpan}
                                             hasLinkCell={Boolean(linkVisible)}
                                             onExpand={expand}
                                         />
                                     )
                                 }
                                 const { line, index, isContext } = entry
+                                const noteLinked = isNoteLinked(
+                                    line,
+                                    manxVisible,
+                                    englishVisible,
+                                )
+                                const noteVisible =
+                                    Boolean(line.notes) &&
+                                    (!noteLinked ||
+                                        notesShown !==
+                                            toggledNotes.has(
+                                                line.csvLineNumber,
+                                            ))
+                                const noteToggle = noteLinked
+                                    ? {
+                                          noteVisible,
+                                          toggle: () =>
+                                              toggleNote(line.csvLineNumber),
+                                      }
+                                    : undefined
                                 const manxText =
                                     diffCorrectedText(
                                         line.manxOriginal,
@@ -586,6 +718,7 @@ export const ComparisonTable = (props: {
                                         "gv",
                                         line.manx,
                                         line.manxHighlights,
+                                        noteToggle,
                                     )
                                 const englishText =
                                     diffCorrectedText(
@@ -600,6 +733,7 @@ export const ComparisonTable = (props: {
                                         "en",
                                         line.english,
                                         line.englishHighlights,
+                                        noteToggle,
                                     )
 
                                 return (
@@ -727,13 +861,21 @@ export const ComparisonTable = (props: {
                                                 </td>
                                             )}
                                         </tr>
-                                        {line.notes ? (
+                                        {noteVisible ? (
                                             <tr className="noteRow">
+                                                {Array.from(
+                                                    { length: leadingCells },
+                                                    (_, i) => (
+                                                        <td key={i} />
+                                                    ),
+                                                )}
                                                 <td
-                                                    colSpan={visibleColumnCount}
+                                                    className="doc-note-band"
+                                                    colSpan={languageColSpan}
                                                 >
                                                     {line.notes}
                                                 </td>
+                                                {linkVisible && <td />}
                                             </tr>
                                         ) : null}
                                     </Fragment>

--- a/CorpusSearch/ClientApp/src/routes/DocumentView.css
+++ b/CorpusSearch/ClientApp/src/routes/DocumentView.css
@@ -187,11 +187,44 @@
 }
 
 .doc-table .noteRow td {
-    background: var(--c-note-row);
     padding: 3px 10px;
+}
+
+/* the band covers the language columns only; the play/speaker/Link cells
+   around it stay uncoloured (like the expanders) */
+.doc-table .noteRow .doc-note-band {
+    background: var(--c-note-row);
     font-size: 13px;
     color: var(--c-secondary);
     text-align: center;
+}
+
+/* a "[1]" marker linking a line to its note (#132): clicking toggles the note row.
+   An outlined chip in a warm parchment tone - visible while reading, but lighter
+   than the text and distinct from the search-match marks */
+.doc-note-marker {
+    border: none;
+    cursor: pointer;
+    margin-left: 2px;
+    padding: 1px 6px;
+    border-radius: 8px;
+    font-size: 11px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    vertical-align: super;
+    background: transparent;
+    color: var(--c-secondary);
+    box-shadow: inset 0 0 0 1px var(--c-border-table-head);
+}
+
+.doc-note-marker:hover {
+    background: var(--c-border-input);
+}
+
+/* the note row is open: the chip fills with the note row's own colour,
+   keeping the outline of the closed state */
+.doc-note-marker[aria-expanded="true"] {
+    background: var(--c-note-row);
 }
 
 /* context lines revealed by an expander (#286): visibly not matches */
@@ -332,5 +365,4 @@ mark.textHighlightAlternate {
     .doc-speaker-time {
         display: block;
     }
-
 }

--- a/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
+++ b/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
@@ -215,6 +215,14 @@ export const DocumentView = () => {
         String,
     )
 
+    // notes distract while reading (#132): hidden by default, each collapsed
+    // behind its "[1]" marker; this option shows them all
+    const [notesEnabled, setNotesEnabled] = usePersistedState(
+        "showNotes",
+        (stored) => stored === "true",
+        String,
+    )
+
     // load the data
     useEffect(() => {
         if (!docIdent) {
@@ -378,6 +386,18 @@ export const DocumentView = () => {
                         />
                         Show context
                     </label>
+                    <label
+                        className="advanced-options-match"
+                        title="Shows all annotations. If disabled, tap the [1] marker to show a note."
+                    >
+                        <input
+                            id="showNotes"
+                            type="checkbox"
+                            checked={notesEnabled}
+                            onChange={(e) => setNotesEnabled(e.target.checked)}
+                        />
+                        Show notes
+                    </label>
                 </div>
             </details>
 
@@ -498,6 +518,7 @@ export const DocumentView = () => {
                         response={searchWorkResponse}
                         docIdent={docIdent}
                         expandContext={contextEnabled}
+                        showNotes={notesEnabled}
                         value={value}
                         highlightManx={searchManx}
                         highlightEnglish={searchEnglish}


### PR DESCRIPTION
Add an option to make the [1] of a note clickable.

Hidden by default, so users can read texts

Proposed by JH.

- Fixes #132