### PR TITLE
fix: cursor moves to end of search field after an edit

### DIFF
--- a/CorpusSearch/ClientApp/src/routes/Home.test.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.test.tsx
@@ -96,6 +96,34 @@ describe("match accents option", () => {
     })
 })
 
+describe("editing the query mid-string", () => {
+    // a real keystroke at the DOM level: the value gains a character with the
+    // cursor just after it, then an input event fires
+    const typeAt = (input: HTMLInputElement, pos: number, ch: string) => {
+        const next = input.value.slice(0, pos) + ch + input.value.slice(pos)
+        Object.getOwnPropertyDescriptor(
+            HTMLInputElement.prototype,
+            "value",
+        )?.set?.call(input, next)
+        input.setSelectionRange(pos + 1, pos + 1)
+        fireEvent.input(input)
+    }
+
+    it("keeps the edit and the cursor position", () => {
+        renderWithQuery("foldaragh")
+        const input = screen.getByPlaceholderText<HTMLInputElement>(/Search in/)
+        expect(input.value).toBe("foldaragh")
+
+        typeAt(input, 4, "x")
+
+        // router updates ride startTransition: when the input's value came
+        // from the URL, React restored the pre-keystroke text, losing the
+        // edit and kicking the cursor to the end
+        expect(input.value).toBe("foldxaragh")
+        expect(input.selectionStart).toBe(5)
+    })
+})
+
 const emptySearchResponse = (query: string): SearchResponse => ({
     results: [],
     query,

--- a/CorpusSearch/ClientApp/src/routes/Home.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.tsx
@@ -76,15 +76,28 @@ const toLangParam = (param: SearchLanguage): string => {
 
 export const Home = () => {
     const [searchParams, setSearchParams] = useSearchParams()
-    const query = searchParams.get("q") ?? ""
+    const urlQuery = searchParams.get("q") ?? ""
     const searchLanguage = parseLanguage(searchParams.get("lang")) ?? "Manx"
+
+    // The input needs useState: router updates are wrapped in
+    // startTransition, causing he cursor position to reset.
+    const [query, setQueryState] = useState(urlQuery)
+
+    // adopt external URL changes (back/forward, in-app links);
+    // after our own navigations the values already match, so this bails out
+    useEffect(() => {
+        setQueryState(urlQuery)
+    }, [urlQuery])
 
     const updateSearch = (q: string, lang: SearchLanguage) => {
         const nextParams: Record<string, string> =
             !q && lang === "Manx" ? {} : { q, lang: toLangParam(lang) }
         setSearchParams(nextParams, { replace: true })
     }
-    const setQuery = (next: string) => updateSearch(next, searchLanguage)
+    const setQuery = (next: string) => {
+        setQueryState(next)
+        updateSearch(next, searchLanguage)
+    }
     const setSearchLanguage = (next: SearchLanguage) =>
         updateSearch(query, next)
 


### PR DESCRIPTION
Caused by changes in React Router 7