### PR TITLE
feat: add discord link

### DIFF
--- a/CorpusSearch/ClientApp/src/routes/Home.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Home.tsx
@@ -336,6 +336,17 @@ const HomeIntro = ({
                     corpus-submissions@gaelg.im
                 </a>
                 .
+                <br />
+                You can also chat with Manx speakers and learners, including the
+                person behind the corpus, in the{" "}
+                <a
+                    href="https://discord.gg/MC96q3vwKu"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    Celtic Languages Discord
+                </a>
+                .
             </div>
         </>
     )


### PR DESCRIPTION
Links to `#gaelg-manx`; confirmed the mods are OK with it

Non-commercial, I've been there for several years and it's a truly solid resource. I also believe the it's the largest/best Manx Language Discord.