### PR TITLE
feat(document): add 'see more' for document-level notes

### DIFF
--- a/CorpusSearch/ClientApp/src/components/SeeMore.css
+++ b/CorpusSearch/ClientApp/src/components/SeeMore.css
@@ -1,0 +1,23 @@
+.see-more-clamped {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/* styled like .doc-meta-toggle; the surrounding text may be italic (.doc-note) */
+.see-more-toggle {
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: 0;
+    margin-top: 4px;
+    font-size: 12.5px;
+    font-style: normal;
+    color: var(--c-link);
+    white-space: nowrap;
+}
+
+.see-more-toggle:hover {
+    color: var(--c-link-hover);
+    text-decoration: underline;
+}

--- a/CorpusSearch/ClientApp/src/components/SeeMore.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/SeeMore.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { SeeMore } from "./SeeMore"
+
+afterEach(cleanup)
+
+// jsdom performs no layout: fake the heights driving the overflow detection
+const setHeights = (scrollHeight: number, clientHeight: number) => {
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+        configurable: true,
+        get: () => scrollHeight,
+    })
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+        configurable: true,
+        get: () => clientHeight,
+    })
+}
+
+afterEach(() => {
+    Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight")
+    Reflect.deleteProperty(HTMLElement.prototype, "clientHeight")
+})
+
+describe("SeeMore", () => {
+    it("collapses overflowing content behind a 'See more' toggle", () => {
+        setHeights(200, 80)
+        const { container } = render(<SeeMore>a long description</SeeMore>)
+
+        expect(container.querySelector(".see-more-clamped")).not.toBeNull()
+        screen.getByRole("button", { name: /See more/ })
+    })
+
+    it("expands on click, and collapses again", () => {
+        setHeights(200, 80)
+        const { container } = render(<SeeMore>a long description</SeeMore>)
+
+        fireEvent.click(screen.getByRole("button", { name: /See more/ }))
+        expect(container.querySelector(".see-more-clamped")).toBeNull()
+        const less = screen.getByRole("button", { name: /See less/ })
+        expect(less.getAttribute("aria-expanded")).toBe("true")
+
+        fireEvent.click(less)
+        expect(container.querySelector(".see-more-clamped")).not.toBeNull()
+        screen.getByRole("button", { name: /See more/ })
+    })
+
+    it("renders content that fits without a toggle", () => {
+        setHeights(80, 80)
+        render(<SeeMore>a short description</SeeMore>)
+
+        expect(screen.queryByRole("button")).toBeNull()
+    })
+})

--- a/CorpusSearch/ClientApp/src/components/SeeMore.tsx
+++ b/CorpusSearch/ClientApp/src/components/SeeMore.tsx
@@ -1,0 +1,59 @@
+import { ReactNode, useLayoutEffect, useRef, useState } from "react"
+import "./SeeMore.css"
+
+/** Clamps tall content to `lines` lines behind a "See more" toggle; content
+ * short enough to fit renders as-is, with no toggle. */
+export const SeeMore = (props: { lines?: number; children: ReactNode }) => {
+    const { lines = 4, children } = props
+    const [expanded, setExpanded] = useState(false)
+    // the collapsed content overflows its clamp: a toggle is needed
+    const [clamped, setClamped] = useState(false)
+    const content = useRef<HTMLDivElement>(null)
+
+    // new content (e.g. navigating to another document) starts collapsed
+    useLayoutEffect(() => {
+        setExpanded(false)
+    }, [children])
+
+    // measure while the clamp is applied; re-measure as resizes change the wrapping
+    useLayoutEffect(() => {
+        if (expanded) {
+            return
+        }
+        const element = content.current
+        if (element == null) {
+            return
+        }
+        const measure = () =>
+            setClamped(element.scrollHeight > element.clientHeight + 1)
+        measure()
+        if (typeof ResizeObserver == "undefined") {
+            return // jsdom
+        }
+        const observer = new ResizeObserver(measure)
+        observer.observe(element)
+        return () => observer.disconnect()
+    }, [children, expanded])
+
+    return (
+        <div>
+            <div
+                ref={content}
+                className={expanded ? undefined : "see-more-clamped"}
+                style={expanded ? undefined : { WebkitLineClamp: lines }}
+            >
+                {children}
+            </div>
+            {(clamped || expanded) && (
+                <button
+                    type="button"
+                    className="see-more-toggle"
+                    aria-expanded={expanded}
+                    onClick={() => setExpanded((x) => !x)}
+                >
+                    {expanded ? "See less ▴" : "See more ▾"}
+                </button>
+            )}
+        </div>
+    )
+}

--- a/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
+++ b/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
@@ -23,6 +23,7 @@ import { ManxEnglishSelector } from "../components/ManxEnglishSelector"
 import { metadataLookup } from "../api/MetadataApi"
 import { ComparisonTable } from "../components/ComparisonTable"
 import { SearchBar } from "../components/SearchBar"
+import { SeeMore } from "../components/SeeMore"
 import { BackChevron } from "../components/BackChevron"
 import { OptionCheckbox } from "../components/AdvancedOptions"
 import { parseSearchOptions } from "../api/SearchOptions"
@@ -528,7 +529,7 @@ export const DocumentView = () => {
 
                     {searchWorkResponse.notes && (
                         <div className="doc-note">
-                            {searchWorkResponse.notes}
+                            <SeeMore>{searchWorkResponse.notes}</SeeMore>
                         </div>
                     )}
 


### PR DESCRIPTION
Many were large, see: /docs/Skeealyn-Cheeil-Chiollee