### PR TITLE
SEO: more improvements and fixups

### DIFF
--- a/CorpusSearch.Test/SeoControllerTest.cs
+++ b/CorpusSearch.Test/SeoControllerTest.cs
@@ -50,7 +50,7 @@ public class SeoControllerTest
     }
 
     [Test]
-    public async Task SitemapListsServerRenderedPagesAndEveryDocument()
+    public async Task SitemapListsStaticPagesAndEveryDocument()
     {
         var controller = BuildController(WorkServiceWith("PargeiysCaillit", "Carn 130"));
 
@@ -62,9 +62,11 @@ public class SeoControllerTest
         Assert.That(result.Content, Does.Contain($"<loc>{BaseUrl}/Browse</loc>"));
         Assert.That(result.Content, Does.Contain($"<loc>{BaseUrl}/Tags</loc>"));
         Assert.That(result.Content, Does.Contain($"<loc>{BaseUrl}/Dictionary/Cregeen</loc>"));
-        Assert.That(result.Content, Does.Contain($"<loc>{BaseUrl}/Browse/PargeiysCaillit</loc>"));
+        Assert.That(result.Content, Does.Contain($"<loc>{BaseUrl}/docs/PargeiysCaillit</loc>"));
         // idents are not always URL-safe: 'Carn 130' must be escaped
-        Assert.That(result.Content, Does.Contain($"<loc>{BaseUrl}/Browse/Carn%20130</loc>"));
+        Assert.That(result.Content, Does.Contain($"<loc>{BaseUrl}/docs/Carn%20130</loc>"));
+        // /Browse/{id} pages canonicalise to /docs/{id}; only the canonical belongs here
+        Assert.That(result.Content, Does.Not.Contain($"{BaseUrl}/Browse/"));
     }
 
     [Test]

--- a/CorpusSearch/ClientApp/index.html
+++ b/CorpusSearch/ClientApp/index.html
@@ -4,9 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#FDF5E6" />
-    <!-- Resolve the app's relative API URLs (api/Metadata, search/..., statistics) against the
-         site root, not the current route. Without this, fetches on nested routes like
-         /docs/:id resolve to /docs/api/... and fall through to the SPA (HTML, not JSON). -->
+    <!-- Resolve relative API URLs (api/...) against the site root. -->
     <base href="/" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="shortcut icon" href="/favicon.ico" />

--- a/CorpusSearch/ClientApp/index.html
+++ b/CorpusSearch/ClientApp/index.html
@@ -11,7 +11,7 @@
     <!-- Chrome shared with the server-rendered pages (Browse, Cregeen) - see public/site-chrome.css -->
     <link rel="stylesheet" href="/site-chrome.css" />
     <title>Manx Corpus Search</title>
-    <meta name="description" content="Search for words &amp; phrases within over 500 translated texts, from 1610 to the present era. Free &amp; Open Source" />
+    <meta name="description" content="Search for words &amp; phrases within over 800 translated texts, from 1610 to the present era. Free &amp; Open Source" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/CorpusSearch/ClientApp/src/hooks/useDocumentHeadElements.test.tsx
+++ b/CorpusSearch/ClientApp/src/hooks/useDocumentHeadElements.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, renderHook } from "@testing-library/react"
 import { useDocumentHeadElements } from "./useDocumentHeadElements"
 
 const DEFAULT_DESCRIPTION =
-    "Search for words & phrases within over 500 translated texts, from 1610 to the present era. Free & Open Source"
+    "Search for words & phrases within over 800 translated texts, from 1610 to the present era. Free & Open Source"
 
 const description = () =>
     document.querySelector('meta[name="description"]')?.getAttribute("content")

--- a/CorpusSearch/ClientApp/src/hooks/useDocumentHeadElements.test.tsx
+++ b/CorpusSearch/ClientApp/src/hooks/useDocumentHeadElements.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, renderHook } from "@testing-library/react"
+import { useDocumentHeadElements } from "./useDocumentHeadElements"
+
+const DEFAULT_DESCRIPTION =
+    "Search for words & phrases within over 500 translated texts, from 1610 to the present era. Free & Open Source"
+
+const description = () =>
+    document.querySelector('meta[name="description"]')?.getAttribute("content")
+const canonical = () =>
+    document.querySelector('link[rel="canonical"]')?.getAttribute("href")
+
+// the static index.html head that the hook mutates
+beforeEach(() => {
+    document.title = "Manx Corpus Search"
+    const meta = document.createElement("meta")
+    meta.setAttribute("name", "description")
+    meta.setAttribute("content", DEFAULT_DESCRIPTION)
+    document.head.appendChild(meta)
+})
+
+afterEach(() => {
+    cleanup()
+    document
+        .querySelectorAll('meta[name="description"], link[rel="canonical"]')
+        .forEach((x) => x.remove())
+    vi.restoreAllMocks()
+})
+
+describe("useDocumentHeadElements", () => {
+    it("sets a per-document title", () => {
+        renderHook(() =>
+            useDocumentHeadElements("Yn-Nollick", "Yn Nollick", "1899"),
+        )
+        expect(document.title).toBe("Yn Nollick | Manx Corpus Search")
+    })
+
+    it("keeps the default title until the document loads", () => {
+        // " " is the loading placeholder (avoids a layout shift)
+        renderHook(() => useDocumentHeadElements("Yn-Nollick", " ", ""))
+        expect(document.title).toBe("Manx Corpus Search")
+        expect(description()).toBe(DEFAULT_DESCRIPTION)
+        expect(canonical()).toBeUndefined()
+    })
+
+    it("keeps the default title without a document ident", () => {
+        renderHook(() => useDocumentHeadElements(undefined, "Yn Nollick", ""))
+        expect(document.title).toBe("Manx Corpus Search")
+    })
+
+    it("describes the document, with its year", () => {
+        renderHook(() =>
+            useDocumentHeadElements("Yn-Nollick", "Yn Nollick", "1899"),
+        )
+        expect(description()).toBe(
+            "“Yn Nollick” (1899) — Manx and English parallel text from the Manx corpus.",
+        )
+    })
+
+    it("omits an unknown year from the description", () => {
+        renderHook(() =>
+            useDocumentHeadElements("Yn-Nollick", "Yn Nollick", ""),
+        )
+        expect(description()).toBe(
+            "“Yn Nollick” — Manx and English parallel text from the Manx corpus.",
+        )
+    })
+
+    it("links the canonical /docs URL, escaping the ident", () => {
+        renderHook(() => useDocumentHeadElements("Carn 130", "Carn 130", ""))
+        expect(canonical()).toBe(`${window.location.origin}/docs/Carn%20130`)
+    })
+
+    it("restores the head on unmount", () => {
+        const { unmount } = renderHook(() =>
+            useDocumentHeadElements("Yn-Nollick", "Yn Nollick", "1899"),
+        )
+        unmount()
+        expect(document.title).toBe("Manx Corpus Search")
+        expect(description()).toBe(DEFAULT_DESCRIPTION)
+        expect(canonical()).toBeUndefined()
+    })
+
+    it("replaces the previous document's head when navigating", () => {
+        const { rerender } = renderHook(
+            ({ ident, title }) => useDocumentHeadElements(ident, title, ""),
+            { initialProps: { ident: "Yn-Nollick", title: "Yn Nollick" } },
+        )
+        rerender({ ident: "A-Manx-Wedding", title: "A Manx Wedding" })
+        expect(document.title).toBe("A Manx Wedding | Manx Corpus Search")
+        expect(document.querySelectorAll('link[rel="canonical"]')).toHaveLength(
+            1,
+        )
+        expect(canonical()).toBe(
+            `${window.location.origin}/docs/A-Manx-Wedding`,
+        )
+    })
+})
+
+// React 19 hoisted <title> into <head>, but only applies it when children are a single string.
+describe("React 19 <title> handling", () => {
+    it("never applies a <title> with expression + text children", () => {
+        const BrokenTitle = ({ name }: { name: string }) => (
+            <title>{name} | Manx Corpus Search</title>
+        )
+
+        render(<BrokenTitle name="Yn Nollick" />)
+
+        // React hoists the tag but silently refuses its children: blank title
+        expect(document.title).toBe("")
+    })
+
+    it("keeps a stale title when a valid <title> re-renders into the broken form", () => {
+        // the exact pre-2026-07 DocumentView structure: a valid generic
+        // fallback while loading, the broken two-children form once loaded
+        const Doc = ({ title }: { title: string | null }) =>
+            title == null ? (
+                <title>Manx Corpus Search</title>
+            ) : (
+                <title>{title} | Manx Corpus Search</title>
+            )
+
+        const { rerender } = render(<Doc title={null} />)
+        expect(document.title).toBe("Manx Corpus Search")
+
+        rerender(<Doc title="Yn Nollick" />)
+
+        // the document "loads", yet the title stays generic — as seen on every
+        // page of the live site (and in Google's crawled-page capture)
+        expect(document.title).toBe("Manx Corpus Search")
+        expect(document.title).not.toContain("Yn Nollick")
+    })
+
+    it("applies a <title> whose child is a single string", () => {
+        const FixedTitle = ({ name }: { name: string }) => (
+            <title>{`${name} | Manx Corpus Search`}</title>
+        )
+
+        render(<FixedTitle name="Yn Nollick" />)
+
+        expect(document.title).toBe("Yn Nollick | Manx Corpus Search")
+    })
+})

--- a/CorpusSearch/ClientApp/src/hooks/useDocumentHeadElements.ts
+++ b/CorpusSearch/ClientApp/src/hooks/useDocumentHeadElements.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react"
+
+/**
+ * Sync the index.html tags (title, description, canonical) imperatively, as
+ * React 19 doesn't handle non-static strings in <title> — see
+ * useDocumentHeadElements.test.tsx, which characterises the React behaviour.
+ */
+export const useDocumentHeadElements = (
+    docIdent: string | undefined,
+    title: string,
+    yearLabel: string,
+) => {
+    useEffect(() => {
+        if (docIdent == null || title.trim() == "") {
+            return
+        }
+        document.title = `${title} | Manx Corpus Search`
+
+        const description = document.querySelector('meta[name="description"]')
+        const defaultDescription = description?.getAttribute("content") ?? null
+        const year = yearLabel ? ` (${yearLabel})` : ""
+        description?.setAttribute(
+            "content",
+            `“${title}”${year} — Manx and English parallel text from the Manx corpus.`,
+        )
+
+        const canonical = document.createElement("link")
+        canonical.rel = "canonical"
+        canonical.href = `${window.location.origin}/docs/${encodeURIComponent(docIdent)}`
+        document.head.appendChild(canonical)
+
+        return () => {
+            document.title = "Manx Corpus Search"
+            if (defaultDescription != null) {
+                description?.setAttribute("content", defaultDescription)
+            }
+            canonical.remove()
+        }
+    }, [docIdent, title, yearLabel])
+}

--- a/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
+++ b/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
@@ -309,18 +309,38 @@ export const DocumentView = () => {
             ? `${(response.totalMatches ?? 0).toLocaleString()} matches for “${value}” · ${response.numberOfResults.toLocaleString()} lines`
             : `${response.numberOfResults.toLocaleString()} lines`
 
+    // Sync the index.html tags (title, description, canonical) imperatively, as React 19
+    // doesn't handle non-static strings in <title>.
+    useEffect(() => {
+        if (docIdent == null || title.trim() == "") {
+            return
+        }
+        document.title = `${title} | Manx Corpus Search`
+
+        const description = document.querySelector('meta[name="description"]')
+        const defaultDescription = description?.getAttribute("content") ?? null
+        const year = yearLabel ? ` (${yearLabel})` : ""
+        description?.setAttribute(
+            "content",
+            `“${title}”${year} — Manx and English parallel text from the Manx corpus.`,
+        )
+
+        const canonical = document.createElement("link")
+        canonical.rel = "canonical"
+        canonical.href = `${window.location.origin}/docs/${encodeURIComponent(docIdent)}`
+        document.head.appendChild(canonical)
+
+        return () => {
+            document.title = "Manx Corpus Search"
+            if (defaultDescription != null) {
+                description?.setAttribute("content", defaultDescription)
+            }
+            canonical.remove()
+        }
+    }, [docIdent, title, yearLabel])
+
     return (
         <div>
-            {searchWorkResponse == null ? (
-                <title>Manx Corpus Search</title>
-            ) : (
-                <title>{title} | Manx Corpus Search</title>
-            )}
-            <meta
-                name="description"
-                content="Search for words &amp; phrases within over 500 translated texts, from 1610 to the present era. Free &amp; Open Source"
-            />
-
             <div className="search-row search-row-hero">
                 <SearchBar
                     query={value}

--- a/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
+++ b/CorpusSearch/ClientApp/src/routes/DocumentView.tsx
@@ -27,6 +27,7 @@ import { SeeMore } from "../components/SeeMore"
 import { BackChevron } from "../components/BackChevron"
 import { OptionCheckbox } from "../components/AdvancedOptions"
 import { parseSearchOptions } from "../api/SearchOptions"
+import { useDocumentHeadElements } from "../hooks/useDocumentHeadElements"
 import { useLanguageVisibility } from "../hooks/useLanguageVisibility"
 import { usePersistedState } from "../hooks/usePersistedState"
 import { iMuseumUrl } from "../utils/IMuseum"
@@ -309,35 +310,7 @@ export const DocumentView = () => {
             ? `${(response.totalMatches ?? 0).toLocaleString()} matches for “${value}” · ${response.numberOfResults.toLocaleString()} lines`
             : `${response.numberOfResults.toLocaleString()} lines`
 
-    // Sync the index.html tags (title, description, canonical) imperatively, as React 19
-    // doesn't handle non-static strings in <title>.
-    useEffect(() => {
-        if (docIdent == null || title.trim() == "") {
-            return
-        }
-        document.title = `${title} | Manx Corpus Search`
-
-        const description = document.querySelector('meta[name="description"]')
-        const defaultDescription = description?.getAttribute("content") ?? null
-        const year = yearLabel ? ` (${yearLabel})` : ""
-        description?.setAttribute(
-            "content",
-            `“${title}”${year} — Manx and English parallel text from the Manx corpus.`,
-        )
-
-        const canonical = document.createElement("link")
-        canonical.rel = "canonical"
-        canonical.href = `${window.location.origin}/docs/${encodeURIComponent(docIdent)}`
-        document.head.appendChild(canonical)
-
-        return () => {
-            document.title = "Manx Corpus Search"
-            if (defaultDescription != null) {
-                description?.setAttribute("content", defaultDescription)
-            }
-            canonical.remove()
-        }
-    }, [docIdent, title, yearLabel])
+    useDocumentHeadElements(docIdent, title, yearLabel)
 
     return (
         <div>

--- a/CorpusSearch/Controllers/BrowseController.cs
+++ b/CorpusSearch/Controllers/BrowseController.cs
@@ -4,16 +4,24 @@ using System.Threading.Tasks;
 using CorpusSearch.Model;
 using CorpusSearch.Service;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 
 namespace CorpusSearch.Controllers;
 
+/// <summary>
+/// Displays HTML documents, for archive.org and non-JS crawlers.
+/// </summary>
 [Route("[controller]")]
-public class BrowseController(DocumentSearchService documentSearchService, WorkService workService)
+public class BrowseController(
+    DocumentSearchService documentSearchService,
+    WorkService workService,
+    IConfiguration configuration)
     : Controller
 {
     public async Task<IActionResult> Index()
     {
         ViewData["Documents"] = await workService.GetAll();
+        ViewData["CanonicalUrl"] = SeoUrls.CanonicalBaseUrl(configuration, Request) + "/Browse";
         return View("~/Views/Browse/Index.cshtml");
     }
 
@@ -24,6 +32,10 @@ public class BrowseController(DocumentSearchService documentSearchService, WorkS
         {
             return Redirect("/Browse");
         }
+        // the interactive app page is the indexable version of each text; this
+        // server-rendered duplicate exists for crawlers that don't execute JS
+        ViewData["CanonicalUrl"] = SeoUrls.CanonicalBaseUrl(configuration, Request)
+                                   + "/docs/" + Uri.EscapeDataString(documentId);
         // trim the end in-case the CSV had excess blank lines
         var lines = documentSearchService.GetAllLines(documentId).TrimEnd(x => String.IsNullOrEmpty(x.English + x.Manx + x.Notes));
         var document = await workService.ByIdent(documentId);

--- a/CorpusSearch/Controllers/CregeenController.cs
+++ b/CorpusSearch/Controllers/CregeenController.cs
@@ -1,13 +1,16 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 
 namespace CorpusSearch.Controllers;
 
 [Route("Dictionary/[controller]")]
-public class CregeenController : Controller
+public class CregeenController(IConfiguration configuration) : Controller
 {
     public IActionResult Index()
     {
         ViewData["query"] = "A";
+        ViewData["CanonicalUrl"] = SeoUrls.CanonicalBaseUrl(configuration, Request) + "/Dictionary/Cregeen";
         return View();
     }
 
@@ -15,6 +18,8 @@ public class CregeenController : Controller
     public IActionResult Get(string s)
     {
         ViewData["query"] = s;
+        ViewData["CanonicalUrl"] = SeoUrls.CanonicalBaseUrl(configuration, Request)
+                                   + "/Dictionary/Cregeen/" + Uri.EscapeDataString(s);
         return View("~/Views/Cregeen/Index.cshtml");
     }
 }

--- a/CorpusSearch/Controllers/SeoController.cs
+++ b/CorpusSearch/Controllers/SeoController.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using CorpusSearch.Service;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 
@@ -34,13 +35,13 @@ public class SeoController(WorkService workService, IConfiguration configuration
     public async Task<ContentResult> Sitemap()
     {
         var baseUrl = CanonicalBaseUrl();
-        // Each text is listed as /Browse/{id}, not /docs/{id}: the sitemap should
-        // carry the server-rendered version; /docs/* is an empty shell until the
-        // client renders it, so it would be crawled as hundreds of identical pages.
+        // Each text is listed as /docs/{id}: the live app URLs, which Googlebot
+        // renders fully and historically indexed. The server-rendered /Browse/{id}
+        // duplicates declare rel=canonical to /docs, so they stay out of the sitemap.
         var documentPages = (await workService.GetAll())
             .Select(document => document.Ident)
             .OrderBy(ident => ident, StringComparer.Ordinal)
-            .Select(ident => $"/Browse/{Uri.EscapeDataString(ident)}");
+            .Select(ident => $"/docs/{Uri.EscapeDataString(ident)}");
 
         var urlSet = new XElement(SitemapNs + "urlset",
             StaticPages.Concat(documentPages).Select(page =>
@@ -51,16 +52,22 @@ public class SeoController(WorkService workService, IConfiguration configuration
             "application/xml", Encoding.UTF8);
     }
 
-    /// <summary>
-    /// Sitemaps and the robots.txt Sitemap directive require absolute URLs.
-    /// Configured in production: the origin sits behind Cloudflare, so the request's
-    /// scheme/host are the origin's, not the public https URL. Dev falls back to the request.
-    /// </summary>
-    private string CanonicalBaseUrl()
+    private string CanonicalBaseUrl() => SeoUrls.CanonicalBaseUrl(configuration, Request);
+}
+
+/// <summary>
+/// Sitemaps, the robots.txt Sitemap directive and rel=canonical links require
+/// absolute URLs. Configured in production: the origin sits behind Cloudflare, so
+/// the request's scheme/host are the origin's, not the public https URL.
+/// Dev falls back to the request.
+/// </summary>
+public static class SeoUrls
+{
+    public static string CanonicalBaseUrl(IConfiguration configuration, HttpRequest request)
     {
         var configured = configuration["Seo:CanonicalBaseUrl"];
         return string.IsNullOrEmpty(configured)
-            ? $"{Request.Scheme}://{Request.Host}"
+            ? $"{request.Scheme}://{request.Host}"
             : configured.TrimEnd('/');
     }
 }

--- a/CorpusSearch/Controllers/TagsController.cs
+++ b/CorpusSearch/Controllers/TagsController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using CorpusSearch.Model;
 using CorpusSearch.Service;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 
 namespace CorpusSearch.Controllers;
 
@@ -17,7 +18,7 @@ namespace CorpusSearch.Controllers;
 /// <remarks>Only 1 level, not properly recursive</remarks>
 /// <remarks>Serves both the JSON API (absolute /api/Tags routes) and the HTML pages (/Tags)</remarks>
 [Route("[controller]")]
-public class TagsController(WorkService workService) : Controller
+public class TagsController(WorkService workService, IConfiguration configuration) : Controller
 {
     [HttpGet("/api/Tags/All")]
     public async Task<List<Tag>> GetTags()
@@ -129,12 +130,13 @@ public class TagsController(WorkService workService) : Controller
     [HttpGet]
     public async Task<IActionResult> Get()
     {
+        ViewData["CanonicalUrl"] = SeoUrls.CanonicalBaseUrl(configuration, Request) + "/Tags";
         return View("~/Views/Browse/Tags.cshtml", new TagListModel(
-            Title: "Category List", 
+            Title: "Category List",
             Tags: await GetTags()
         ));
     }
-    
+
     [HttpGet("{tag}")]
     public async Task<IActionResult> Get(string tag)
     {
@@ -143,6 +145,8 @@ public class TagsController(WorkService workService) : Controller
         {
             return await Get();
         }
+        ViewData["CanonicalUrl"] = SeoUrls.CanonicalBaseUrl(configuration, Request)
+                                   + "/Tags/" + Uri.EscapeDataString(tag);
         return View("~/Views/Browse/ViewTag.cshtml", result);
     }
 }

--- a/CorpusSearch/Views/Browse/Browse.cshtml
+++ b/CorpusSearch/Views/Browse/Browse.cshtml
@@ -9,6 +9,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>@ViewData["Title"]</title>
+    @if (ViewData["CanonicalUrl"] != null)
+    {
+        <link rel="canonical" href="@ViewData["CanonicalUrl"]">
+    }
 
     <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
@@ -28,7 +32,7 @@
     </style>
 </head>
 <body>
-<h1 style="margin: 24px"><a href="javascript:history.back()" style="text-decoration: none">⇦</a> @ViewData["Title"]</h1>
+<h1 style="margin: 24px"><a href="/Browse" style="text-decoration: none">⇦</a> @ViewData["Title"]</h1>
 
 <div class="text-center d-flex justify-content-center" style="flex-wrap: wrap; margin-bottom: 20px">
     <a class="lead font-weight-bold" style="margin-right: 24px; margin-left: 24px; margin-bottom: 6px" href="/docs/@ViewData["docId"]">View in Corpus</a>

--- a/CorpusSearch/Views/Browse/Index.cshtml
+++ b/CorpusSearch/Views/Browse/Index.cshtml
@@ -6,6 +6,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Manx Corpus - Full Document Listing</title>
+    @if (ViewData["CanonicalUrl"] != null)
+    {
+        <link rel="canonical" href="@ViewData["CanonicalUrl"]">
+    }
     <link rel="shortcut icon" href="/favicon.ico">
     @* version query = server start time, so a rebuild+restart always busts cached CSS *@
     <link href="/site-chrome.css?v=@(System.Diagnostics.Process.GetCurrentProcess().StartTime.Ticks)" rel="stylesheet">

--- a/CorpusSearch/Views/Browse/Tags.cshtml
+++ b/CorpusSearch/Views/Browse/Tags.cshtml
@@ -9,6 +9,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>@Model.Title</title>
+    @if (ViewData["CanonicalUrl"] != null)
+    {
+        <link rel="canonical" href="@ViewData["CanonicalUrl"]">
+    }
 
     <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">

--- a/CorpusSearch/Views/Browse/ViewTag.cshtml
+++ b/CorpusSearch/Views/Browse/ViewTag.cshtml
@@ -10,6 +10,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>@ViewData["Title"]</title>
+    @if (ViewData["CanonicalUrl"] != null)
+    {
+        <link rel="canonical" href="@ViewData["CanonicalUrl"]">
+    }
 
     <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">

--- a/CorpusSearch/Views/Cregeen/Index.cshtml
+++ b/CorpusSearch/Views/Cregeen/Index.cshtml
@@ -7,6 +7,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Cregeen's Dictionary</title>
+    @if (ViewData["CanonicalUrl"] != null)
+    {
+        <link rel="canonical" href="@ViewData["CanonicalUrl"]">
+    }
     <link rel="shortcut icon" href="/favicon.ico">
     @* version query = server start time, so a rebuild+restart always busts cached CSS *@
     <link href="/site-chrome.css?v=@(System.Diagnostics.Process.GetCurrentProcess().StartTime.Ticks)" rel="stylesheet">


### PR DESCRIPTION
Use `/docs` after checking the Google Search Console and seeing the properly rendered HTML from the SPA + fixed titles

Added canonical URLs
