### PR TITLE
fix(statistics): add indicators for 'non-Manx' data in the Manx column

### DIFF
--- a/CorpusSearch.Test/DocumentLinePreparerTest.cs
+++ b/CorpusSearch.Test/DocumentLinePreparerTest.cs
@@ -9,18 +9,20 @@ using NUnit.Framework;
 namespace CorpusSearch.Test;
 
 /// <summary>
-/// Load-time resolution of the manifest's language contract: each line's effective
-/// language resolves as line value ⇒ collection default ⇒ "gv".
+/// Load-time honouring of the manifest's speaker-code and language contract:
+/// inline speaker codes move into Speaker, and each line's effective language
+/// resolves as line value ⇒ collection default ⇒ "gv".
 /// </summary>
 [TestFixture]
 public class DocumentLinePreparerTest
 {
-    private static OpenSourceDocument Manifest(string? manxColumnLanguage = null)
+    private static OpenSourceDocument Manifest(string? manxColumnLanguage = null, params string[] inlineSpeakerCodes)
         => new()
         {
             Name = "doc",
             Ident = "doc",
             ManxColumnLanguage = manxColumnLanguage,
+            InlineSpeakerCodes = inlineSpeakerCodes.Length == 0 ? null : inlineSpeakerCodes.ToList(),
         };
 
     private static DocumentLine Prepared(Document document, DocumentLine line)
@@ -64,14 +66,74 @@ public class DocumentLinePreparerTest
     }
 
     [Test]
-    public void ManifestFieldDeserializes()
+    public void SpeakerCodeMovesToSpeakerField()
+    {
+        var line = Prepared(Manifest(null, "NM", "WR"), new DocumentLine { Manx = "NM. Ta fys aym" });
+        Assert.That(line.Speaker, Is.EqualTo("NM"));
+        Assert.That(line.Manx, Is.EqualTo("Ta fys aym"));
+    }
+
+    [TestCase("nm: ta", "ta")]
+    [TestCase("NM ta", "ta")]
+    [TestCase("  NM.ta", "ta")]
+    public void ColonBareAndLowercaseMarkersAreStripped(string manx, string expected)
+    {
+        var line = Prepared(Manifest(null, "NM"), new DocumentLine { Manx = manx });
+        Assert.That(line.Speaker, Is.EqualTo("NM"));
+        Assert.That(line.Manx, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void CodeOnlyCellBecomesEmpty()
+    {
+        var line = Prepared(Manifest(null, "NM"), new DocumentLine { Manx = "NM." });
+        Assert.That(line.Speaker, Is.EqualTo("NM"));
+        Assert.That(line.Manx, Is.EqualTo(""));
+    }
+
+    [Test]
+    public void CodeMustBeAWholeWord()
+    {
+        var line = Prepared(Manifest(null, "Q"), new DocumentLine { Manx = "Quirk as Juan" });
+        Assert.That(line.Speaker, Is.Null);
+        Assert.That(line.Manx, Is.EqualTo("Quirk as Juan"));
+    }
+
+    [Test]
+    public void NoDeclaredCodesMeansNoStripping()
+    {
+        var line = Prepared(Manifest(), new DocumentLine { Manx = "NM. Ta fys aym" });
+        Assert.That(line.Speaker, Is.Null);
+        Assert.That(line.Manx, Is.EqualTo("NM. Ta fys aym"));
+    }
+
+    [Test]
+    public void FilledSpeakerColumnIsKept()
+    {
+        var line = Prepared(Manifest(null, "NM"), new DocumentLine { Manx = "NM. Ta", Speaker = "Ned Maddrell" });
+        Assert.That(line.Speaker, Is.EqualTo("Ned Maddrell"));
+        Assert.That(line.Manx, Is.EqualTo("Ta"));
+    }
+
+    [Test]
+    public void LongerCodeWinsOverItsPrefix()
+    {
+        var line = Prepared(Manifest(null, "J", "JTK"), new DocumentLine { Manx = "JTK: ta" });
+        Assert.That(line.Speaker, Is.EqualTo("JTK"));
+        Assert.That(line.Manx, Is.EqualTo("ta"));
+    }
+
+    [Test]
+    public void ManifestFieldsDeserialize()
     {
         const string json = """
-            {"name": "n", "ident": "i", "translated": "Rob Teare 2021", "manxColumnLanguage": "mixed"}
+            {"name": "n", "ident": "i", "translated": "Rob Teare 2021",
+             "inlineSpeakerCodes": ["NM", "Q"], "manxColumnLanguage": "mixed"}
             """;
         var document = JsonConvert.DeserializeObject<OpenSourceDocument>(json)!;
+        Assert.That(document.InlineSpeakerCodes, Is.EqualTo(new[] { "NM", "Q" }));
         Assert.That(document.ManxColumnLanguage, Is.EqualTo("mixed"));
-        // the new field binds to a property, not the extension data shown to users
+        // the new fields bind to properties, not the extension data shown to users
         Assert.That(document.ExtensionData.Keys, Is.EquivalentTo(new[] { "translated" }));
     }
 

--- a/CorpusSearch.Test/DocumentLinePreparerTest.cs
+++ b/CorpusSearch.Test/DocumentLinePreparerTest.cs
@@ -1,0 +1,101 @@
+using System.IO;
+using System.Linq;
+using CorpusSearch.Dependencies.CsvHelper;
+using CorpusSearch.Model;
+using CorpusSearch.Services;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+/// <summary>
+/// Load-time resolution of the manifest's language contract: each line's effective
+/// language resolves as line value ⇒ collection default ⇒ "gv".
+/// </summary>
+[TestFixture]
+public class DocumentLinePreparerTest
+{
+    private static OpenSourceDocument Manifest(string? manxColumnLanguage = null)
+        => new()
+        {
+            Name = "doc",
+            Ident = "doc",
+            ManxColumnLanguage = manxColumnLanguage,
+        };
+
+    private static DocumentLine Prepared(Document document, DocumentLine line)
+    {
+        DocumentLinePreparer.Prepare(document, [line]);
+        return line;
+    }
+
+    [Test]
+    public void LanguageDefaultsToManx()
+    {
+        var line = Prepared(Manifest(), new DocumentLine { Manx = "ta" });
+        Assert.That(line.Language, Is.EqualTo("gv"));
+        Assert.That(line.IsManxLanguage, Is.True);
+    }
+
+    [Test]
+    public void ManifestDefaultAppliesToUnmarkedLines()
+    {
+        var line = Prepared(Manifest(manxColumnLanguage: "en"), new DocumentLine { Manx = "the cat" });
+        Assert.That(line.Language, Is.EqualTo("en"));
+        Assert.That(line.IsManxLanguage, Is.False);
+    }
+
+    [Test]
+    public void LineValueBeatsManifestDefault()
+    {
+        var line = Prepared(Manifest(manxColumnLanguage: "mixed"), new DocumentLine { Manx = "ta", Language = "gv" });
+        Assert.That(line.Language, Is.EqualTo("gv"));
+        Assert.That(line.IsManxLanguage, Is.True);
+    }
+
+    [Test]
+    public void LanguageValuesAreNormalized()
+    {
+        var line = Prepared(Manifest(), new DocumentLine { Manx = "the cat", Language = " EN " });
+        Assert.That(line.Language, Is.EqualTo("en"));
+
+        var blank = Prepared(Manifest(manxColumnLanguage: "la"), new DocumentLine { Manx = "", Language = "  " });
+        Assert.That(blank.Language, Is.EqualTo("la"));
+    }
+
+    [Test]
+    public void ManifestFieldDeserializes()
+    {
+        const string json = """
+            {"name": "n", "ident": "i", "translated": "Rob Teare 2021", "manxColumnLanguage": "mixed"}
+            """;
+        var document = JsonConvert.DeserializeObject<OpenSourceDocument>(json)!;
+        Assert.That(document.ManxColumnLanguage, Is.EqualTo("mixed"));
+        // the new field binds to a property, not the extension data shown to users
+        Assert.That(document.ExtensionData.Keys, Is.EquivalentTo(new[] { "translated" }));
+    }
+
+    /// <summary>The CSV contract: the sparse column is ManxColumnLanguage, like the
+    /// manifest field it overrides — not a bare "Language"</summary>
+    [Test]
+    public void LanguageIsReadFromTheManxColumnLanguageCsvColumn()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path,
+                "English,Manx,ManxColumnLanguage\n" +
+                "I know,Ta fys aym,\n" +
+                "untranslated,the cat,en\n");
+
+            var lines = CsvHelperUtils.LoadCsv(path);
+
+            // a blank cell reads as "": Prepare() later replaces it with the default
+            Assert.That(lines.Select(x => x.Language), Is.EqualTo(new[] { "", "en" }));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/CorpusSearch.Test/LineLanguageIndexTest.cs
+++ b/CorpusSearch.Test/LineLanguageIndexTest.cs
@@ -7,7 +7,8 @@ namespace CorpusSearch.Test;
 
 /// <summary>
 /// Index-side half of the line-language contract: non-Manx lines stay searchable but
-/// no longer count towards Manx statistics, and their language is returned.
+/// no longer count towards Manx statistics, and their language (like any line's speaker)
+/// is returned.
 /// </summary>
 [TestFixture]
 public class LineLanguageIndexTest : QueryBase
@@ -19,8 +20,8 @@ public class LineLanguageIndexTest : QueryBase
         luceneIndex.Add(new TestDocument(DOC, DOC_DATE), lines);
     }
 
-    private static DocumentLine Line(int lineNumber, string manx, string? language = null)
-        => new() { Manx = manx, English = "", CsvLineNumber = lineNumber, Language = language };
+    private static DocumentLine Line(int lineNumber, string manx, string? language = null, string? speaker = null)
+        => new() { Manx = manx, English = "", CsvLineNumber = lineNumber, Language = language, Speaker = speaker };
 
     [Test]
     public void NonManxLinesDoNotCountAsManxTerms()
@@ -73,5 +74,18 @@ public class LineLanguageIndexTest : QueryBase
 
         var line = luceneIndex.GetAllLines(DOC, getTranscript: false).Single();
         Assert.That(line.Language, Is.Null);
+    }
+
+    [Test]
+    public void SpeakerIsReturnedWithoutTranscriptData()
+    {
+        AddLines(Line(2, "Ta fys aym", speaker: "NM"));
+
+        var browsed = luceneIndex.GetAllLines(DOC, getTranscript: false).Single();
+        Assert.That(browsed.Speaker, Is.EqualTo("NM"));
+
+        var searched = new Searcher(luceneIndex, parser).SearchWork(DOC, "fys",
+            new SearchOptions { SearchType = SearchType.Manx }, returnTranscriptData: false);
+        Assert.That(searched.Lines.Single().Speaker, Is.EqualTo("NM"));
     }
 }

--- a/CorpusSearch.Test/LineLanguageIndexTest.cs
+++ b/CorpusSearch.Test/LineLanguageIndexTest.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using CorpusSearch.Dependencies;
+using CorpusSearch.Model;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+/// <summary>
+/// Index-side half of the line-language contract: non-Manx lines stay searchable but
+/// no longer count towards Manx statistics, and their language is returned.
+/// </summary>
+[TestFixture]
+public class LineLanguageIndexTest : QueryBase
+{
+    private const string DOC = "doc";
+
+    private void AddLines(params DocumentLine[] lines)
+    {
+        luceneIndex.Add(new TestDocument(DOC, DOC_DATE), lines);
+    }
+
+    private static DocumentLine Line(int lineNumber, string manx, string? language = null)
+        => new() { Manx = manx, English = "", CsvLineNumber = lineNumber, Language = language };
+
+    [Test]
+    public void NonManxLinesDoNotCountAsManxTerms()
+    {
+        AddLines(
+            Line(2, "ta mee braew"),
+            Line(3, "the cat sat on the mat", language: "en"));
+
+        Assert.That(luceneIndex.CountManxTerms(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public void NonManxTermsAreExcludedFromTheFrequencyList()
+    {
+        AddLines(
+            Line(2, "ta mee braew"),
+            Line(3, "the cat sat on the mat", language: "en"));
+
+        var terms = luceneIndex.GetTermFrequencyList().Select(x => x.Item1).ToList();
+        Assert.That(terms, Is.EquivalentTo(new[] { "ta", "mee", "braew" }));
+    }
+
+    [Test]
+    public void ExplicitGvCountsAsManx()
+    {
+        AddLines(Line(2, "ta mee braew", language: "gv"));
+
+        Assert.That(luceneIndex.CountManxTerms(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public void NonManxLinesRemainSearchable()
+    {
+        AddLines(
+            Line(2, "ta mee braew"),
+            Line(3, "the cat sat on the mat", language: "en"));
+
+        var result = new Searcher(luceneIndex, parser).SearchWork(DOC, "cat",
+            new SearchOptions { SearchType = SearchType.Manx }, returnTranscriptData: false);
+
+        var line = result.Lines.Single();
+        Assert.That(line.Manx, Is.EqualTo("the cat sat on the mat"));
+        Assert.That(line.Language, Is.EqualTo("en"));
+    }
+
+    [Test]
+    public void ManxLinesHaveNoLanguageMarker()
+    {
+        AddLines(Line(2, "ta mee braew"));
+
+        var line = luceneIndex.GetAllLines(DOC, getTranscript: false).Single();
+        Assert.That(line.Language, Is.Null);
+    }
+}

--- a/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
+++ b/CorpusSearch/ClientApp/src/api/SearchWorkApi.ts
@@ -18,6 +18,9 @@ export type SearchWorkResult = {
     subStart?: number
     subEnd?: number
     speaker?: string
+    /** The line's language when its Manx column is not Manx, e.g. "en" for an
+     * untranslated row. Absent on Manx lines */
+    language?: string
     /** Ranges of `manx` which matched. Absent unless Manx was searched */
     manxHighlights?: HighlightRange[]
     /** Ranges of `english` which matched. Absent unless English was searched */

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
@@ -534,6 +534,17 @@ describe("dictionary popup (#51)", () => {
 
         await screen.findByText(/Could not find definition/)
     })
+
+    it("does not open from the English column", () => {
+        mockGetWordAtPoint.mockReturnValue("tongue")
+        const { getByText } = renderTable([
+            line({ manx: "Ta çhengey aym", english: "I have a tongue" }),
+        ])
+
+        fireEvent.click(getByText("I have a tongue"))
+
+        expect(mockDictionaryLookup).not.toHaveBeenCalled()
+    })
 })
 
 describe("dictionary popup on touch", () => {

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
@@ -535,6 +535,19 @@ describe("dictionary popup (#51)", () => {
         await screen.findByText(/Could not find definition/)
     })
 
+    it("does not open on a non-Manx row", () => {
+        // the Manx column of a row with a language marker is not Manx
+        // (an untranslated English passage): there is nothing to look up
+        mockGetWordAtPoint.mockReturnValue("cat")
+        const { getByText } = renderTable([
+            line({ manx: "the cat sat", language: "en" }),
+        ])
+
+        fireEvent.click(getByText("the cat sat"))
+
+        expect(mockDictionaryLookup).not.toHaveBeenCalled()
+    })
+
     it("does not open from the English column", () => {
         mockGetWordAtPoint.mockReturnValue("tongue")
         const { getByText } = renderTable([

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.test.tsx
@@ -784,3 +784,21 @@ describe("segmentChunks", () => {
         ])
     })
 })
+
+describe("speaker column", () => {
+    it("shows the speakers of a non-video document", () => {
+        // e.g. an interview transcription: speakers are not a video-only concept
+        const { getByText } = renderTable([
+            line({ manx: "Ta fys aym", speaker: "NM" }),
+        ])
+
+        getByText("Speaker")
+        getByText("NM")
+    })
+
+    it("has no Speaker column when no line names a speaker", () => {
+        const { queryByText } = renderTable([line({ manx: "Ta fys aym" })])
+
+        expect(queryByText("Speaker")).toBeNull()
+    })
+})

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -218,7 +218,6 @@ export const ComparisonTable = (props: {
                                         original={line.manxOriginal}
                                         highlights={line.manxHighlights}
                                         shouldHighlight={highlightManx}
-                                        languageCode="gv"
                                         translations={getTranslations("gv")}
                                         query={value}
                                         noteToggle={noteToggle}
@@ -231,11 +230,9 @@ export const ComparisonTable = (props: {
                                         original={line.englishOriginal}
                                         highlights={line.englishHighlights}
                                         shouldHighlight={highlightEnglish}
-                                        languageCode="en"
                                         translations={getTranslations("en")}
                                         query={value}
                                         noteToggle={noteToggle}
-                                        onWordClick={dictionary.openFromClick}
                                     />
                                 )
 

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -221,7 +221,13 @@ export const ComparisonTable = (props: {
                                         translations={getTranslations("gv")}
                                         query={value}
                                         noteToggle={noteToggle}
-                                        onWordClick={dictionary.openFromClick}
+                                        // a non-Manx row (line.language set, e.g. an untranslated
+                                        // English passage) has no Manx to look up
+                                        onWordClick={
+                                            line.language == null
+                                                ? dictionary.openFromClick
+                                                : undefined
+                                        }
                                     />
                                 )
                                 const englishText = (

--- a/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
+++ b/CorpusSearch/ClientApp/src/components/ComparisonTable.tsx
@@ -103,8 +103,8 @@ export const ComparisonTable = (props: {
         x.type == "line" ? [x.line] : [],
     )
 
+    // any document may carry speakers (interview transcriptions), not just videos
     const hasSpeakerColumn =
-        isVideo &&
         displayedLines.filter((x) => x.speaker != null && x.speaker != "")
             .length > 0
 

--- a/CorpusSearch/ClientApp/src/components/LineText.tsx
+++ b/CorpusSearch/ClientApp/src/components/LineText.tsx
@@ -173,7 +173,6 @@ export const isNoteLinked = (
 const HighlightedLine = (props: {
     /** highlight the server-matched ranges (the searched language) */
     shouldHighlight: boolean
-    languageCode: "gv" | "en"
     text: string
     highlights?: HighlightRange[]
     /** dictionary translations of the query, fuzzy-matched on the unsearched column */
@@ -181,11 +180,10 @@ const HighlightedLine = (props: {
     /** the raw query: no fuzzy highlighting without one */
     query: string
     noteToggle?: NoteToggle
-    onWordClick: (event: ReactMouseEvent, context: string) => void
+    onWordClick?: (event: ReactMouseEvent, context: string) => void
 }) => {
     const {
         shouldHighlight,
-        languageCode,
         text,
         highlights,
         translations,
@@ -212,11 +210,9 @@ const HighlightedLine = (props: {
                 segmentStart += item.length + 1 // + the removed "\n"
                 return (
                     <div
-                        onClick={(event) => {
-                            if (languageCode == "gv") {
-                                onWordClick(event, text)
-                            }
-                        }}
+                        onClick={
+                            onWordClick && ((event) => onWordClick(event, text))
+                        }
                         className="doc-line"
                         key={key}
                     >
@@ -248,7 +244,7 @@ const DiffedLine = (props: {
     original: string
     text: string
     highlights?: HighlightRange[]
-    onWordClick: (event: ReactMouseEvent, context: string) => void
+    onWordClick?: (event: ReactMouseEvent, context: string) => void
 }) => {
     const { original, text, highlights, onWordClick } = props
     const result = diffChars(original, text)
@@ -258,9 +254,7 @@ const DiffedLine = (props: {
     // TODO: Also apply justify to 'browse' screen
     return (
         <div
-            onClick={(event) => {
-                onWordClick(event, text)
-            }}
+            onClick={onWordClick && ((event) => onWordClick(event, text))}
             className="doc-line"
         >
             {result.map((part, index) => {
@@ -306,11 +300,12 @@ export const LineText = (props: {
     original?: string
     highlights?: HighlightRange[]
     shouldHighlight: boolean
-    languageCode: "gv" | "en"
     translations: string[]
     query: string
     noteToggle?: NoteToggle
-    onWordClick: (event: ReactMouseEvent, context: string) => void
+    /** opens the dictionary popup for the tapped word: only pass it for text
+     * which is actually Manx (not the English column or a non-Manx row) */
+    onWordClick?: (event: ReactMouseEvent, context: string) => void
 }) => {
     const { original, ...rest } = props
     if (original) {

--- a/CorpusSearch/Dependencies/CsvHelper/DocumentLineMap.cs
+++ b/CorpusSearch/Dependencies/CsvHelper/DocumentLineMap.cs
@@ -14,6 +14,9 @@ public class DocumentLineMap : ClassMap<DocumentLine>
         Map(m => m.SubStart).Optional();
         Map(m => m.SubEnd).Optional();
         Map(m => m.Speaker).Optional();
+        // named after the manifest field it overrides (manxColumnLanguage): a bare
+        // "Language" header would not say which column it describes
+        Map(m => m.Language).Name("ManxColumnLanguage").Optional();
         Map(m => m.CsvLineNumber).Convert(args => args.Row.Parser.RawRow);
         Map(m => m.ManxOriginal).Convert(args =>
         {

--- a/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
+++ b/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
@@ -40,6 +40,14 @@ public class LuceneIndex(IndexWriter indexWriter)
     public const string DOCUMENT_CREATED_START = "created_start";
     public const string DOCUMENT_CREATED_END = "created_end";
     public const string DOCUMENT_SPEAKER = "speaker";
+    /// <summary>The line's language when the Manx column is not Manx (e.g. "en" for an
+    /// untranslated row); absent on Manx lines. Not queried yet: ready for a search filter.</summary>
+    public const string DOCUMENT_LANGUAGE = "language";
+    /// <summary><see cref="DOCUMENT_NORMALIZED_MANX"/> restricted to lines whose Manx column
+    /// is really Manx: Manx-language statistics (<see cref="CountManxTerms"/>,
+    /// <see cref="GetTermFrequencyList"/>) read this field, so untranslated rows and speaker
+    /// codes don't count as Manx. Term frequencies only.</summary>
+    public const string DOCUMENT_MANX_GV = "manx_gv";
 
     public const string SUBTITLE_START = "subtitle_start";
     public const string SUBTITLE_END = "subtitle_end";
@@ -94,6 +102,12 @@ public class LuceneIndex(IndexWriter indexWriter)
             StoreTermVectorOffsets = true
         };
 
+        // the statistics field only sums term frequencies: no positions, vectors or storage
+        var statsFieldType = new FieldType(TextField.TYPE_NOT_STORED)
+        {
+            IndexOptions = IndexOptions.DOCS_AND_FREQS,
+        };
+
         foreach (var line in data)
         {
             var doc = new Document
@@ -120,6 +134,17 @@ public class LuceneIndex(IndexWriter indexWriter)
             AddField(DOCUMENT_NOTES, line.Notes);
             AddField(DOCUMENT_PAGE, line.Page.ToString());
             AddField(DOCUMENT_SPEAKER, line.Speaker);
+
+            // non-Manx lines stay searchable (the manx field above), but only Manx lines
+            // feed the Manx statistics
+            if (line.IsManxLanguage)
+            {
+                doc.Add(new Field(DOCUMENT_MANX_GV, line.NormalizedManx, statsFieldType));
+            }
+            else
+            {
+                AddField(DOCUMENT_LANGUAGE, line.Language);
+            }
 
             line.SubStart?.Let(start => doc.Add(new DoubleField(SUBTITLE_START, start, Field.Store.YES)));
             line.SubEnd?.Let(end => doc.Add(new DoubleField(SUBTITLE_END, end, Field.Store.YES)));
@@ -225,6 +250,7 @@ public class LuceneIndex(IndexWriter indexWriter)
                 SubStart = getTranscriptData ? document.GetField(SUBTITLE_START)?.GetDoubleValue() : null,
                 SubEnd = getTranscriptData ? document.GetField(SUBTITLE_END)?.GetDoubleValue() : null,
                 Speaker = getTranscriptData ? document.GetField(DOCUMENT_SPEAKER)?.GetStringValue() : null,
+                Language = document.GetField(DOCUMENT_LANGUAGE)?.GetStringValue(),
                 MatchesInLine = countInDoc
             };
         // document order: docID order is merge-dependent, so it cannot be relied on (#303)
@@ -527,7 +553,8 @@ public class LuceneIndex(IndexWriter indexWriter)
     {
         var fieldsToLoad = new HashSet<string> { DOCUMENT_REAL_MANX, DOCUMENT_REAL_ENGLISH, DOCUMENT_NOTES,
             DOCUMENT_PAGE,
-            DOCUMENT_LINE_NUMBER, DOCUMENT_ORIGINAL_MANX, DOCUMENT_ORIGINAL_ENGLISH };
+            DOCUMENT_LINE_NUMBER, DOCUMENT_ORIGINAL_MANX, DOCUMENT_ORIGINAL_ENGLISH,
+            DOCUMENT_LANGUAGE };
         if (getTranscript)
         {
             fieldsToLoad.Add(SUBTITLE_END);
@@ -549,14 +576,15 @@ public class LuceneIndex(IndexWriter indexWriter)
         EnglishOriginal = document.GetField(DOCUMENT_ORIGINAL_ENGLISH)?.GetStringValue(),
         SubStart = getTranscript ? document.GetField(SUBTITLE_START)?.GetDoubleValue() : null,
         SubEnd = getTranscript ? document.GetField(SUBTITLE_END)?.GetDoubleValue() : null,
-        Speaker = getTranscript ? document.GetField(DOCUMENT_SPEAKER)?.GetStringValue() : null
+        Speaker = getTranscript ? document.GetField(DOCUMENT_SPEAKER)?.GetStringValue() : null,
+        Language = document.GetField(DOCUMENT_LANGUAGE)?.GetStringValue()
     };
 
     public long CountManxTerms()
     {
         using var reader = UseReader();
         // the total occurrence count of all terms is a stored index statistic
-        var terms = MultiFields.GetTerms(reader, DOCUMENT_NORMALIZED_MANX);
+        var terms = MultiFields.GetTerms(reader, DOCUMENT_MANX_GV);
         return terms == null ? 0 : Math.Max(0, terms.SumTotalTermFreq);
     }
         
@@ -589,7 +617,7 @@ public class LuceneIndex(IndexWriter indexWriter)
         var termList = new List<(string, long)>();
 
         using var reader = UseReader();
-        var terms = MultiFields.GetTerms(reader, DOCUMENT_NORMALIZED_MANX);
+        var terms = MultiFields.GetTerms(reader, DOCUMENT_MANX_GV);
         if (terms == null)
         {
             // no documents were loaded: don't crash on startup

--- a/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
+++ b/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
@@ -249,7 +249,7 @@ public class LuceneIndex(IndexWriter indexWriter)
                 EnglishOriginal = document.GetField(DOCUMENT_ORIGINAL_ENGLISH)?.GetStringValue(),
                 SubStart = getTranscriptData ? document.GetField(SUBTITLE_START)?.GetDoubleValue() : null,
                 SubEnd = getTranscriptData ? document.GetField(SUBTITLE_END)?.GetDoubleValue() : null,
-                Speaker = getTranscriptData ? document.GetField(DOCUMENT_SPEAKER)?.GetStringValue() : null,
+                Speaker = document.GetField(DOCUMENT_SPEAKER)?.GetStringValue(),
                 Language = document.GetField(DOCUMENT_LANGUAGE)?.GetStringValue(),
                 MatchesInLine = countInDoc
             };
@@ -554,12 +554,11 @@ public class LuceneIndex(IndexWriter indexWriter)
         var fieldsToLoad = new HashSet<string> { DOCUMENT_REAL_MANX, DOCUMENT_REAL_ENGLISH, DOCUMENT_NOTES,
             DOCUMENT_PAGE,
             DOCUMENT_LINE_NUMBER, DOCUMENT_ORIGINAL_MANX, DOCUMENT_ORIGINAL_ENGLISH,
-            DOCUMENT_LANGUAGE };
+            DOCUMENT_SPEAKER, DOCUMENT_LANGUAGE };
         if (getTranscript)
         {
             fieldsToLoad.Add(SUBTITLE_END);
             fieldsToLoad.Add(SUBTITLE_START);
-            fieldsToLoad.Add(DOCUMENT_SPEAKER);
         }
 
         return fieldsToLoad;
@@ -576,7 +575,7 @@ public class LuceneIndex(IndexWriter indexWriter)
         EnglishOriginal = document.GetField(DOCUMENT_ORIGINAL_ENGLISH)?.GetStringValue(),
         SubStart = getTranscript ? document.GetField(SUBTITLE_START)?.GetDoubleValue() : null,
         SubEnd = getTranscript ? document.GetField(SUBTITLE_END)?.GetDoubleValue() : null,
-        Speaker = getTranscript ? document.GetField(DOCUMENT_SPEAKER)?.GetStringValue() : null,
+        Speaker = document.GetField(DOCUMENT_SPEAKER)?.GetStringValue(),
         Language = document.GetField(DOCUMENT_LANGUAGE)?.GetStringValue()
     };
 

--- a/CorpusSearch/Model/Document.cs
+++ b/CorpusSearch/Model/Document.cs
@@ -39,6 +39,13 @@ public abstract class Document : IDocument
 
     public string? Source { get; set; }
 
+    /// <summary>
+    /// The language of Manx-column cells without a line-level Language value:
+    /// "gv" if absent. A knowingly mixed collection declares "mixed" and relies on
+    /// the line-level column.
+    /// </summary>
+    public string? ManxColumnLanguage { get; set; }
+
     [JsonExtensionData]
     public IDictionary<string, object> ExtensionData { get; set; } = new Dictionary<string, object>();
 
@@ -50,5 +57,14 @@ public abstract class Document : IDocument
     internal virtual List<DocumentLine> LoadLocalFile()
     {
         return CsvHelperUtils.LoadCsv(Startup.GetLocalFile("Resources", CsvFileName));
+    }
+
+    /// <summary>The document's lines, with each line's effective language resolved
+    /// (see <see cref="DocumentLinePreparer"/>)</summary>
+    internal List<DocumentLine> LoadPreparedLines()
+    {
+        var lines = LoadLocalFile();
+        DocumentLinePreparer.Prepare(this, lines);
+        return lines;
     }
 }

--- a/CorpusSearch/Model/Document.cs
+++ b/CorpusSearch/Model/Document.cs
@@ -40,6 +40,13 @@ public abstract class Document : IDocument
     public string? Source { get; set; }
 
     /// <summary>
+    /// Speaker codes which may prefix the collection's Manx cells as `CODE.` / `CODE:`
+    /// markers (e.g. ["NM", "WR"] in interview transcriptions). Moved into
+    /// <see cref="DocumentLine.Speaker"/> at load time: see <see cref="DocumentLinePreparer"/>.
+    /// </summary>
+    public List<string>? InlineSpeakerCodes { get; set; }
+
+    /// <summary>
     /// The language of Manx-column cells without a line-level Language value:
     /// "gv" if absent. A knowingly mixed collection declares "mixed" and relies on
     /// the line-level column.
@@ -59,8 +66,8 @@ public abstract class Document : IDocument
         return CsvHelperUtils.LoadCsv(Startup.GetLocalFile("Resources", CsvFileName));
     }
 
-    /// <summary>The document's lines, with each line's effective language resolved
-    /// (see <see cref="DocumentLinePreparer"/>)</summary>
+    /// <summary>The document's lines, with the load-time cleanup its manifest declares
+    /// (effective language, inline speaker codes) applied</summary>
     internal List<DocumentLine> LoadPreparedLines()
     {
         var lines = LoadLocalFile();

--- a/CorpusSearch/Model/DocumentLine.cs
+++ b/CorpusSearch/Model/DocumentLine.cs
@@ -24,8 +24,21 @@ public class DocumentLine
 
     /// <summary>The name of the speaker in a transcription. Nullable</summary>
     public string? Speaker { get; set; }
-        
+
     public long? MatchesInLine { get; set; }
+
+    /// <summary>The language of the Manx column: "gv" unless the row is untranslated
+    /// English/Latin/mixed matter. Read from the sparse `ManxColumnLanguage` CSV column;
+    /// at load time the collection default (the manifest field of the same name, else
+    /// "gv") replaces an absent value.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Value of <see cref="Language"/> meaning the Manx column is really Manx</summary>
+    public const string ManxLanguageCode = "gv";
+
+    /// <summary>Whether the Manx column is Manx, so its tokens belong in Manx-language statistics</summary>
+    [JsonIgnore]
+    public bool IsManxLanguage => Language is null or ManxLanguageCode;
 
     [JsonIgnore]
     // TODO: NBSP?

--- a/CorpusSearch/Model/DocumentLinePreparer.cs
+++ b/CorpusSearch/Model/DocumentLinePreparer.cs
@@ -1,21 +1,42 @@
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace CorpusSearch.Model;
 
 /// <summary>
-/// Load-time resolution of each CSV line's effective Manx-column language: the
-/// line's own value (the `ManxColumnLanguage` CSV column) if present, else the
-/// manifest's collection default (else "gv").
+/// Load-time cleanup of a document's CSV lines under the manifest's contract:
+/// resolves each line's effective language (line value ⇒ collection default ⇒ "gv")
+/// and moves inline speaker codes ("NM. Ta fys aym..." in interview transcriptions)
+/// out of the Manx text into <see cref="DocumentLine.Speaker"/>, so they reach the
+/// UI as speakers instead of polluting the token stream.
 /// </summary>
 public static class DocumentLinePreparer
 {
     public static void Prepare(Document document, List<DocumentLine> lines)
     {
         var defaultLanguage = NormalizeLanguage(document.ManxColumnLanguage) ?? DocumentLine.ManxLanguageCode;
+        var speakerCode = BuildSpeakerCodeRegex(document.InlineSpeakerCodes);
 
         foreach (var line in lines)
         {
             line.Language = NormalizeLanguage(line.Language) ?? defaultLanguage;
+
+            if (speakerCode == null || line.Manx == null)
+            {
+                continue;
+            }
+            var match = speakerCode.Match(line.Manx);
+            if (!match.Success)
+            {
+                continue;
+            }
+            // a filled Speaker column wins; the marker is dropped from the text either way
+            if (string.IsNullOrWhiteSpace(line.Speaker))
+            {
+                line.Speaker = match.Groups["code"].Value.ToUpperInvariant();
+            }
+            line.Manx = line.Manx[match.Length..];
         }
     }
 
@@ -24,5 +45,28 @@ public static class DocumentLinePreparer
     {
         var trimmed = language?.Trim();
         return string.IsNullOrEmpty(trimmed) ? null : trimmed.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// A leading `CODE.` / `CODE:` (or bare `CODE`) marker, for the codes the manifest
+    /// declares; null when it declares none. The code must be a whole word: code "Q"
+    /// must not match "Quirk".
+    /// </summary>
+    internal static Regex? BuildSpeakerCodeRegex(IReadOnlyCollection<string>? codes)
+    {
+        var patterns = (codes ?? [])
+            .Where(code => !string.IsNullOrWhiteSpace(code))
+            .Select(code => code.Trim())
+            // longest first, so a code which prefixes another cannot shadow it
+            .OrderByDescending(code => code.Length)
+            .Select(Regex.Escape)
+            .ToList();
+        if (patterns.Count == 0)
+        {
+            return null;
+        }
+
+        return new Regex(@"^\s*(?<code>" + string.Join("|", patterns) + @")(?:[.:]\s*|\s+|$)",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
     }
 }

--- a/CorpusSearch/Model/DocumentLinePreparer.cs
+++ b/CorpusSearch/Model/DocumentLinePreparer.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace CorpusSearch.Model;
+
+/// <summary>
+/// Load-time resolution of each CSV line's effective Manx-column language: the
+/// line's own value (the `ManxColumnLanguage` CSV column) if present, else the
+/// manifest's collection default (else "gv").
+/// </summary>
+public static class DocumentLinePreparer
+{
+    public static void Prepare(Document document, List<DocumentLine> lines)
+    {
+        var defaultLanguage = NormalizeLanguage(document.ManxColumnLanguage) ?? DocumentLine.ManxLanguageCode;
+
+        foreach (var line in lines)
+        {
+            line.Language = NormalizeLanguage(line.Language) ?? defaultLanguage;
+        }
+    }
+
+    /// <summary>"gv", "en", ... - or null for a blank value, so `??` can apply the default</summary>
+    private static string? NormalizeLanguage(string? language)
+    {
+        var trimmed = language?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed.ToLowerInvariant();
+    }
+}

--- a/CorpusSearch/Startup.cs
+++ b/CorpusSearch/Startup.cs
@@ -292,7 +292,7 @@ public class Startup(IConfiguration configuration)
         {
             try
             {
-                List<DocumentLine> data = document.LoadLocalFile();
+                List<DocumentLine> data = document.LoadPreparedLines();
                 Parallel.ForEach(data.Chunk(linesPerChunk), chunk => searcher.AddDocument(document, chunk));
                 workService.AddWork(document);
             }


### PR DESCRIPTION
* `ManxColumnLanguage` column
  * Somewhat confusing, for a row: the language of the 'Manx' Column, if it's not Manx 
* inlineSpeakerCodes in the manifest

----

* Makes the 'words' statistic more honest
* Makes lexicography easier by removing obviously non-Manx tokens & lexemes
* Removes 'tap to translate' for non-Manx sentences.
