### PR TITLE
feat(verses): a verse names the dictionary entries quoting it

### DIFF
--- a/CorpusSearch.Test/SearchControllerTest.cs
+++ b/CorpusSearch.Test/SearchControllerTest.cs
@@ -16,7 +16,7 @@ public class SearchControllerTest
     private static readonly string TooLongQuery = new('a', CorpusSearchQuery.MAX_LENGTH + 1);
 
     /// <remarks>Services are not used here.</remarks>
-    private static SearchController GetController() => new(null!, null!, [], null!);
+    private static SearchController GetController() => new(null!, null!, [], null!, new VerseQuotationIndex([]));
 
     [Test]
     public async Task SearchCorpusRejectsTooLongQuery()
@@ -127,7 +127,7 @@ public class SearchControllerTest
     private static Dictionary<string, SearchController.DictionaryData> DictionaryLookup(QueryLanguages languages, string query = "moddey")
     {
         ISearchDictionary[] dictionaries = [new FakeDictionary("manxDictionary", "gv"), new FakeDictionary("englishDictionary", "en")];
-        var controller = new SearchController(null!, null!, dictionaries, null!);
+        var controller = new SearchController(null!, null!, dictionaries, null!, new VerseQuotationIndex([]));
         return controller.DictionaryLookup(query, languages);
     }
 

--- a/CorpusSearch.Test/VerseQuotationIndexTest.cs
+++ b/CorpusSearch.Test/VerseQuotationIndexTest.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using CorpusSearch.Service;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+/// <summary>
+/// The reverse of a dictionary entry's verse citations: a corpus verse line
+/// names the entries quoting it (quotes.nvh direction 2).
+/// </summary>
+[TestFixture]
+public class VerseQuotationIndexTest
+{
+    private sealed class QuotingFake(string identifier, string slug, params (string Word, string Text)[] entries)
+        : ISearchDictionary, IQuotingDictionary
+    {
+        public string Identifier => identifier;
+        public string Slug => slug;
+        public List<string> QueryLanguages => ["gv"];
+        public bool LinkToDictionary => true;
+        public IEnumerable<(string Word, string Text)> QuotableEntries => entries;
+        public IEnumerable<DictionarySummary> GetSummaries(string query, bool basic = false) => [];
+        public bool ContainsWord(string word) => false;
+        public IEnumerable<string> AllWords => [];
+        public IReadOnlyList<string> Headwords => [];
+    }
+
+    [Test]
+    public void AVerseNamesTheEntriesQuotingIt()
+    {
+        var index = new VerseQuotationIndex([
+            new QuotingFake("J Kelly Manx to English", "kelly-m2e",
+                ("aalid", "beauty, comeliness. Ta dty aalid, O Israel. Ps. 45, 12."),
+                ("baare", "the top; no citation here")),
+            new QuotingFake("Cregeen", "cregeen",
+                ("eh", "he, it, him. sometimes; 2 Kings xi. 2: as dollee ad eh")),
+        ]);
+
+        Assert.That(index.For("psalms.45.12"), Is.EqualTo(new[]
+        {
+            new VerseQuotation("J Kelly Manx to English", "kelly-m2e", "aalid", "Ps. 45, 12"),
+        }));
+        Assert.That(index.For("2-kings.11.2"), Is.EqualTo(new[]
+        {
+            new VerseQuotation("Cregeen", "cregeen", "eh", "2 Kings xi. 2"),
+        }));
+        Assert.That(index.For("psalms.23.1"), Is.Null);
+    }
+
+    [Test]
+    public void AnEntryQuotingTheSameVerseTwiceIsOneRow()
+    {
+        var index = new VerseQuotationIndex([
+            new QuotingFake("Cregeen", "cregeen",
+                ("foo", "Jud. xii. 6; and again Jud. xii, 6 differently printed")),
+        ]);
+
+        Assert.That(index.For("judges.12.6"), Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void ANonQuotingDictionaryIsIgnored()
+    {
+        var index = new VerseQuotationIndex([new PlainFake()]);
+
+        Assert.That(index.For("psalms.45.12"), Is.Null);
+    }
+
+    private sealed class PlainFake : ISearchDictionary
+    {
+        public string Identifier => "Plain";
+        public string Slug => "plain";
+        public List<string> QueryLanguages => ["gv"];
+        public bool LinkToDictionary => true;
+        public IEnumerable<DictionarySummary> GetSummaries(string query, bool basic = false) =>
+            [new DictionarySummary { Summary = "beauty. Ps. 45, 12.", PrimaryWord = "aalid" }];
+        public bool ContainsWord(string word) => false;
+        public IEnumerable<string> AllWords => [];
+        public IReadOnlyList<string> Headwords => [];
+    }
+}

--- a/CorpusSearch/ClientApp/src/api/VerseAlignmentApi.ts
+++ b/CorpusSearch/ClientApp/src/api/VerseAlignmentApi.ts
@@ -13,6 +13,18 @@ export type VerseAlignmentDocument = {
     english?: string
 }
 
+/** One dictionary entry quoting the verse ("aalid" quotes Ps. 45, 12) */
+export type VerseQuotation = {
+    /** display name of the dictionary ("Cregeen") */
+    dictionary: string
+    /** the dictionary's URL segment ("cregeen"): scopes the entry link */
+    slug: string
+    /** the quoting entry's headword */
+    word: string
+    /** the citation as the entry prints it ("Ps. 45, 12") */
+    citation: string
+}
+
 export type VerseAlignmentResponse = {
     /** the canonical "book.chapter[.verse]" key that was aligned */
     key: string
@@ -20,6 +32,8 @@ export type VerseAlignmentResponse = {
     display: string
     /** every document with the verse (or its chapter), oldest translation first */
     documents: VerseAlignmentDocument[]
+    /** dictionary entries quoting this verse; absent when none */
+    quotedBy?: VerseQuotation[]
 }
 
 /**

--- a/CorpusSearch/ClientApp/src/components/VerseVersionsModal.css
+++ b/CorpusSearch/ClientApp/src/components/VerseVersionsModal.css
@@ -50,3 +50,30 @@
 .verse-versions-none {
     color: var(--c-secondary, #5a6b72);
 }
+
+/* the entries quoting this verse: a compact afterword under the versions */
+.verse-versions-quoted-title {
+    margin: 14px 0 4px;
+    font-size: 0.8rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: var(--c-secondary, #5a6b72);
+}
+
+.verse-versions-quoted {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.verse-versions-quoted > li {
+    display: inline-block;
+    margin-right: 16px;
+    padding: 2px 0;
+}
+
+.verse-versions-quoted-dict {
+    margin-left: 6px;
+    color: var(--c-secondary, #5a6b72);
+    font-size: 0.85em;
+}

--- a/CorpusSearch/ClientApp/src/components/VerseVersionsModal.tsx
+++ b/CorpusSearch/ClientApp/src/components/VerseVersionsModal.tsx
@@ -126,6 +126,32 @@ export const VerseVersionsModal = (props: {
                         )}
                     </ul>
                 )}
+                {alignment?.quotedBy != null && (
+                    <>
+                        <h3 className="verse-versions-quoted-title">
+                            Quoted in the dictionaries
+                        </h3>
+                        <ul className="verse-versions-quoted">
+                            {alignment.quotedBy.map((q) => (
+                                <li key={`${q.slug}:${q.word}`}>
+                                    <Link
+                                        to={`/dictionary/in/${q.slug}/${encodeURIComponent(q.word)}`}
+                                        lang="gv"
+                                        onClick={() => {
+                                            onClose()
+                                            onNavigate?.()
+                                        }}
+                                    >
+                                        {q.word}
+                                    </Link>
+                                    <span className="verse-versions-quoted-dict">
+                                        {q.dictionary}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </>
+                )}
             </Box>
         </Modal>
     )

--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -15,7 +15,8 @@ public partial class SearchController(
     DocumentSearchService documentSearchService,
     OverviewSearchService2 overviewSearchService,
     IEnumerable<ISearchDictionary> dictionaryServices,
-    WorkService workService)
+    WorkService workService,
+    VerseQuotationIndex verseQuotations)
     : ControllerBase
 {
     public static string PUNCTUATION_REGEX = "[,.;!?\\s]";
@@ -188,6 +189,9 @@ public partial class SearchController(
         {
             return BadRequest("not a canonical reference key");
         }
+        // the reverse of a dictionary entry's verse citations: the popup also
+        // says which entries quote this verse
+        result.QuotedBy = verseQuotations.For(result.Key);
         return result;
     }
 

--- a/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
+++ b/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
@@ -11,7 +11,8 @@ using Newtonsoft.Json;
 
 namespace CorpusSearch.Service.Dictionaries;
 
-public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry> entries) : ISearchDictionary
+public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry> entries)
+    : ISearchDictionary, IQuotingDictionary
 {
     public static readonly Dictionary<char, string> LetterLookup = new(new CaseInsensitiveCharComparer())
     {
@@ -154,6 +155,18 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
     /// (see the PERF note below), and the index must not pay that.</summary>
     public IReadOnlyList<string> Headwords { get; } =
         entries.Select(x => x.Words.FirstOrDefault()).OfType<string>().ToList();
+
+    /// <summary>Every entry's decoded text (never the basic gloss, which drops
+    /// the quotations): the reverse verse lookup's input</summary>
+    public IEnumerable<(string Word, string Text)> QuotableEntries =>
+        entries.SelectMany(x => x.ChildrenRecursive)
+            .Where(e => e.Words.Count > 0 && !string.IsNullOrEmpty(e.EntryHtml))
+            .Select(e =>
+            {
+                HtmlDocument doc = new();
+                doc.LoadHtml(e.EntryHtml);
+                return (e.Words[0], HttpUtility.HtmlDecode(doc.DocumentNode.InnerText));
+            });
 
     public IEnumerable<DictionarySummary> GetSummaries(string query, bool basic)
     {

--- a/CorpusSearch/Service/Dictionaries/KellyManxToEnglishDictionaryService.cs
+++ b/CorpusSearch/Service/Dictionaries/KellyManxToEnglishDictionaryService.cs
@@ -10,8 +10,14 @@ using Newtonsoft.Json;
 namespace CorpusSearch.Service.Dictionaries;
 
 public class KellyManxToEnglishDictionaryService(ISet<string> allWords, IList<KellyManxToEnglishEntry> entries)
-    : ISearchDictionary
+    : ISearchDictionary, IQuotingDictionary
 {
+    /// <summary>Every entry's definition text: the reverse verse lookup's input</summary>
+    public IEnumerable<(string Word, string Text)> QuotableEntries =>
+        entries.SelectMany(x => x.ChildrenRecursive)
+            .Where(e => e.Words.Count > 0 && !string.IsNullOrEmpty(e.Definition))
+            .Select(e => (e.Words[0], e.Definition));
+
     public string Identifier => "J Kelly Manx to English";
 
     /// <summary>matches the data repo's own name (kelly-m2e-manx-dictionary-data):

--- a/CorpusSearch/Service/DocumentSearchService.cs
+++ b/CorpusSearch/Service/DocumentSearchService.cs
@@ -144,6 +144,10 @@ public class VerseAlignmentResult
     /// <summary>"Psalms 23:1"</summary>
     public required string Display { get; init; }
     public required List<VerseAlignmentDocument> Documents { get; init; }
+    /// <summary>Dictionary entries quoting this verse ("aalid" quotes Ps. 45,
+    /// 12): stamped by the controller from <see cref="VerseQuotationIndex"/>;
+    /// null when none</summary>
+    public List<VerseQuotation>? QuotedBy { get; set; }
 }
 
 /// <summary>One document's rendering of an aligned verse</summary>

--- a/CorpusSearch/Service/VerseQuotationIndex.cs
+++ b/CorpusSearch/Service/VerseQuotationIndex.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using CorpusSearch.Model;
+
+namespace CorpusSearch.Service;
+
+/// <summary>A dictionary whose entry text quotes scripture: what the reverse
+/// verse lookup (a corpus verse line → the entries quoting it) reads. The
+/// text is the full entry text, never a basic gloss — the citations ride the
+/// quotations the gloss drops.</summary>
+public interface IQuotingDictionary
+{
+    /// <summary>Every entry as (headword, the text its citations live in)</summary>
+    IEnumerable<(string Word, string Text)> QuotableEntries { get; }
+}
+
+/// <summary>One dictionary entry quoting a verse: "aalid (Cregeen), via
+/// 'Ps. 45, 12'". The client links the word into the dictionary.</summary>
+public sealed record VerseQuotation(string Dictionary, string Slug, string Word, string Citation);
+
+/// <summary>
+/// The reverse of a dictionary entry's verse citations (see
+/// <see cref="VerseCitations"/>): canonical verse key → the entries quoting
+/// that verse, so a corpus verse line can point back into the books
+/// (quotes.nvh direction 2). Built once, on first use.
+/// </summary>
+public class VerseQuotationIndex
+{
+    private readonly Dictionary<string, List<VerseQuotation>> byKey = [];
+
+    public VerseQuotationIndex(IEnumerable<ISearchDictionary> dictionaries)
+    {
+        foreach (var dictionary in dictionaries)
+        {
+            if (dictionary is not IQuotingDictionary quoting)
+            {
+                continue;
+            }
+            foreach (var (word, text) in quoting.QuotableEntries)
+            {
+                foreach (var citation in VerseCitations.FindAll(text) ?? [])
+                {
+                    if (!byKey.TryGetValue(citation.Key, out var quotations))
+                    {
+                        byKey[citation.Key] = quotations = [];
+                    }
+                    // an entry may print the same verse twice: one row each
+                    if (!quotations.Any(x => x.Slug == dictionary.Slug && x.Word == word))
+                    {
+                        quotations.Add(new VerseQuotation(
+                            dictionary.Identifier, dictionary.Slug, word, citation.Text));
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>The entries quoting the verse; null when none (kept off the wire)</summary>
+    public List<VerseQuotation>? For(string key) => byKey.GetValueOrDefault(key);
+}

--- a/CorpusSearch/Startup.cs
+++ b/CorpusSearch/Startup.cs
@@ -80,6 +80,9 @@ public class Startup(IConfiguration configuration)
         // resolves lazily on first lookup, after SetupDictionaries has loaded manx.json
         services.AddSingleton(provider => PhilKellyDictionaryService.Init());
         services.AddSingleton<ISearchDictionary>(provider => provider.GetRequiredService<PhilKellyDictionaryService>());
+        // verse key -> the dictionary entries quoting it (the reverse of the
+        // entries' verse citations): built once from the quoting dictionaries
+        services.AddSingleton(provider => new VerseQuotationIndex(provider.GetServices<ISearchDictionary>()));
         // eager: the lemma table is also the analyzer's, best loaded before indexing
         services.AddSingleton(LemmaTable.Instance);
         // eager for the same reason: the resolution layers narrow the lemma field


### PR DESCRIPTION
The reverse of the entries' verse citations (quotes.nvh direction 2, the verse-references handoff's phase 3): VerseQuotationIndex maps each canonical key to the entries whose text cites it, built once from the quoting dictionaries' full entry text (never the basic gloss, which drops the quotations). The Ref column's other-versions popup gains a 'Quoted in the dictionaries' afterword, each headword linking into its book - psalms.45.12 names Kelly's AALID, and Cregeen cites Ps. xviii. 45 under both cha and cho.

Sample link when this goes live: https://corpus.gaelg.im/docs/Psalms1765?ref=psalms.45.12 