### PR TITLE
feat(dev): 'recently added' shows a random sample in development

### DIFF
--- a/CorpusSearch/Services/OpenDataLoader.cs
+++ b/CorpusSearch/Services/OpenDataLoader.cs
@@ -106,6 +106,22 @@ public class OpenDataLoader
             .Select(x => new RecentDocument(x.Document!, x.Date))
             .ToList();
     }
+
+    /// <summary>
+    /// A random sample standing in for newdocs.txt, which only the deployment
+    /// generates: the development 'recently added' section shows these (dated
+    /// today and backwards, newest first) so there is something to develop
+    /// against.
+    /// </summary>
+    public static async Task<List<RecentDocument>> RandomRecentDocuments(WorkService workService, int count = 10)
+    {
+        var allDocuments = await workService.GetAll();
+        return allDocuments
+            .OrderBy(_ => Random.Shared.Next())
+            .Take(count)
+            .Select((document, index) => new RecentDocument(document, DateTime.Now.AddDays(-index)))
+            .ToList();
+    }
 }
 
 public static class ClosedDataLoader

--- a/CorpusSearch/Startup.cs
+++ b/CorpusSearch/Startup.cs
@@ -145,7 +145,11 @@ public class Startup(IConfiguration configuration)
 
         try
         {
-            var latestDocuments = OpenDataLoader.LoadRecentDocuments(workService).Result;
+            // the deployment generates newdocs.txt; a dev checkout has none, so
+            // 'recently added' shows a random sample to develop against
+            var latestDocuments = env.IsDevelopment()
+                ? OpenDataLoader.RandomRecentDocuments(workService).Result
+                : OpenDataLoader.LoadRecentDocuments(workService).Result;
             recentDocumentsService.Init(latestDocuments, log);
         }
         catch (Exception e)


### PR DESCRIPTION
The deployment generates newdocs.txt; a dev checkout has none, so the section rendered empty and there was nothing to develop against (#347). Development now samples ten random documents, dated today and backwards - a fresh list each boot.