### PR TITLE
feat(dictionary): add user feedback

### DIFF
--- a/CorpusSearch.Test/FeedbackControllerTest.cs
+++ b/CorpusSearch.Test/FeedbackControllerTest.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CorpusSearch.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+[TestFixture]
+public class FeedbackControllerTest
+{
+    private StubHandler handler = null!;
+
+    [SetUp]
+    public void SetUp() => handler = new StubHandler();
+
+    private FeedbackController Controller(string? appsScriptUrl = "https://script.example/exec") =>
+        new(new StubHttpClientFactory(handler), new FeedbackConfig { AppsScriptUrl = appsScriptUrl })
+        {
+            // the controller reads HttpContext.RequestAborted
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+    private static FeedbackController.FeedbackRequest Request(
+        string comments = "the plural is wrong",
+        string? name = null,
+        string? website = null) => new()
+    {
+        Name = name,
+        Comments = comments,
+        Dictionary = "Cregeen",
+        Headword = "aa",
+        Website = website,
+    };
+
+    [Test]
+    public async Task UnconfiguredIsDark()
+    {
+        var result = await Controller(appsScriptUrl: null).Post(Request());
+        Assert.That(result, Is.InstanceOf<NotFoundResult>());
+        Assert.That(handler.Requests, Is.Empty);
+    }
+
+    [Test]
+    public async Task BlankCommentsAreRejected()
+    {
+        var result = await Controller().Post(Request(comments: "   "));
+        Assert.That(result, Is.InstanceOf<BadRequestResult>());
+        Assert.That(handler.Requests, Is.Empty);
+    }
+
+    [Test]
+    public async Task HoneypotClaimsSuccessWithoutRelaying()
+    {
+        var result = await Controller().Post(Request(website: "https://spam.example"));
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+        Assert.That(handler.Requests, Is.Empty);
+    }
+
+    [Test]
+    public async Task RelaySuccess()
+    {
+        handler.Respond(HttpStatusCode.OK, """{"ok":true}""");
+        var result = await Controller().Post(Request(name: "Juan"));
+
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        Assert.That(handler.Bodies[0], Does.Contain("\"comments\":\"the plural is wrong\""));
+        Assert.That(handler.Bodies[0], Does.Contain("\"name\":\"Juan\""));
+        Assert.That(handler.Bodies[0], Does.Contain("\"dictionary\":\"Cregeen\""));
+        Assert.That(handler.Bodies[0], Does.Contain("\"headword\":\"aa\""));
+        // the honeypot marks bots on the way in; it is not the sheet's business
+        Assert.That(handler.Bodies[0], Does.Not.Contain("website"));
+    }
+
+    /// <remarks>An Apps Script that crashed still answers 200, with an HTML
+    /// error page: only the script's own marker means the row was written</remarks>
+    [Test]
+    public async Task OkWithoutMarkerIsAFailure()
+    {
+        handler.Respond(HttpStatusCode.OK, "<html>TypeError: ...</html>");
+        var result = await Controller().Post(Request());
+        Assert.That(result, Is.InstanceOf<StatusCodeResult>());
+        Assert.That(((StatusCodeResult)result).StatusCode, Is.EqualTo(502));
+    }
+
+    [Test]
+    public async Task NetworkFailureIsABadGateway()
+    {
+        handler.Throw(new HttpRequestException("no route to host"));
+        var result = await Controller().Post(Request());
+        Assert.That(result, Is.InstanceOf<StatusCodeResult>());
+        Assert.That(((StatusCodeResult)result).StatusCode, Is.EqualTo(502));
+    }
+
+    [Test]
+    public async Task OverLongFieldsAreTruncatedNotRejected()
+    {
+        handler.Respond(HttpStatusCode.OK, """{"ok":true}""");
+        var result = await Controller().Post(Request(comments: new string('x', 3000)));
+
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+        Assert.That(handler.Bodies[0], Does.Contain(new string('x', 2000)));
+        Assert.That(handler.Bodies[0], Does.Not.Contain(new string('x', 2001)));
+    }
+
+    private class StubHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+        public List<string> Bodies { get; } = [];
+        private HttpResponseMessage response = new(HttpStatusCode.OK);
+        private Exception? exception;
+
+        public void Respond(HttpStatusCode status, string body) =>
+            response = new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+
+        public void Throw(Exception e) => exception = e;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            // read now: the controller disposes the request before assertions run
+            Bodies.Add(request.Content == null
+                ? ""
+                : await request.Content.ReadAsStringAsync(cancellationToken));
+            if (exception != null)
+            {
+                throw exception;
+            }
+            return response;
+        }
+    }
+
+    private class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+}

--- a/CorpusSearch/ClientApp/src/api/FeedbackApi.ts
+++ b/CorpusSearch/ClientApp/src/api/FeedbackApi.ts
@@ -1,0 +1,34 @@
+/** A reader's report on one dictionary entry. Entries have no stable ids
+ * (identity is positional in the books), so the report names its entry by
+ * dictionary and headword only. */
+export type FeedbackRequest = {
+    name?: string
+    comments: string
+    dictionary: string
+    headword: string
+}
+
+export class FeedbackError extends Error {
+    readonly status: number
+
+    constructor(status: number) {
+        super(`feedback failed: ${status}`)
+        this.status = status
+    }
+}
+
+/** Sends the report; the server relays it to an external sheet. A 429 means
+ * the site-wide report budget is spent for now, not that anything is wrong
+ * with this report. */
+export const submitFeedback = async (
+    feedback: FeedbackRequest,
+): Promise<void> => {
+    const response = await fetch("api/Feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(feedback),
+    })
+    if (!response.ok) {
+        throw new FeedbackError(response.status)
+    }
+}

--- a/CorpusSearch/ClientApp/src/components/DictionaryFeedback.css
+++ b/CorpusSearch/ClientApp/src/components/DictionaryFeedback.css
@@ -1,0 +1,109 @@
+/* the offer in the title row: a link's colours at a fraction of the headword's
+   size (as .dict-page-heard), so it reads as an offer about the page rather
+   than as part of the word */
+.dict-feedback-open {
+    border: none;
+    background: none;
+    padding: 0;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    color: var(--c-link);
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.dict-feedback-open:hover {
+    text-decoration: underline;
+}
+
+.dict-feedback-open:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+}
+
+.dict-feedback-title {
+    margin: 0 0 8px;
+    font-family: Georgia, serif;
+    font-size: 20px;
+    color: var(--c-heading, inherit);
+}
+
+.dict-feedback-hint {
+    margin: 0;
+    font-size: 13px;
+    color: var(--c-secondary);
+}
+
+.dict-feedback-form {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+    font-size: 13px;
+}
+
+.dict-feedback-form input,
+.dict-feedback-form textarea {
+    font: inherit;
+    font-size: 13px;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 8px;
+    border: 1px solid var(--c-border-input);
+    border-radius: 4px;
+    background: var(--c-surface);
+    color: var(--c-ink);
+}
+
+.dict-feedback-form textarea {
+    resize: vertical;
+}
+
+/* the submit as a proper button in the dialog's action corner: the corpus's
+   red filled in, white text, squared */
+.dict-feedback-form button {
+    align-self: flex-end;
+    font: inherit;
+    font-size: 14px;
+    padding: 6px 18px;
+    background: var(--c-link);
+    color: #fff;
+    border: 1px solid var(--c-link-hover);
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.dict-feedback-form button:hover {
+    background: var(--c-link-hover);
+}
+
+.dict-feedback-form button:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+}
+
+/* disabled only mid-send: still itself, just briefly unavailable */
+.dict-feedback-form button:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.dict-feedback-sent,
+.dict-feedback-error {
+    margin: 0 0 8px;
+    font-size: 14px;
+}
+
+.dict-feedback-error {
+    margin: 0;
+    color: var(--c-link);
+}
+
+/* a note ends with its writer's name, set apart as a signature */
+.dict-feedback-signature {
+    margin: 12px 0 0;
+    font-family: Georgia, serif;
+    font-style: italic;
+    font-size: 15px;
+    color: var(--c-secondary);
+}

--- a/CorpusSearch/ClientApp/src/components/DictionaryFeedback.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/DictionaryFeedback.test.tsx
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+    cleanup,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from "@testing-library/react"
+import { DictionaryFeedback } from "./DictionaryFeedback"
+
+const fetchMock = vi.fn<typeof fetch>()
+vi.stubGlobal("fetch", fetchMock)
+
+beforeEach(() => {
+    fetchMock.mockReset()
+    localStorage.clear()
+})
+afterEach(cleanup)
+
+const respond = (status: number) =>
+    fetchMock.mockResolvedValue({ ok: status < 400, status } as Response)
+
+const openDialog = (dict?: string) => {
+    render(<DictionaryFeedback word="aa" dict={dict} />)
+    fireEvent.click(
+        screen.getByRole("button", { name: "✏️ suggest an improvement" }),
+    )
+}
+
+const typeSuggestion = (text: string) =>
+    fireEvent.change(screen.getByLabelText("Your suggestion"), {
+        target: { value: text },
+    })
+
+describe("DictionaryFeedback", () => {
+    it("keeps the form behind the offer, in a dialog named for the word", () => {
+        render(<DictionaryFeedback word="aa" />)
+        expect(screen.queryByLabelText("Your suggestion")).toBe(null)
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "✏️ suggest an improvement" }),
+        )
+        expect(
+            screen.getByRole("heading", { name: "Improve “aa”" }),
+        ).toBeTruthy()
+        expect(screen.getByLabelText("Your suggestion")).toBeTruthy()
+    })
+
+    it("sends the page's word and scope along, and thanks by name", async () => {
+        respond(204)
+        openDialog("cregeen")
+        fireEvent.change(screen.getByLabelText("Name (optional)"), {
+            target: { value: "Juan" },
+        })
+        typeSuggestion("the plural is missing")
+        fireEvent.click(screen.getByRole("button", { name: "Send" }))
+
+        await waitFor(() =>
+            expect(
+                screen.getByText("Thanks for the suggestion, Juan!"),
+            ).toBeTruthy(),
+        )
+        // the note asks them back if nothing changes, and signs off
+        expect(screen.getByRole("link", { name: "get in touch" })).toBeTruthy()
+        expect(screen.getByText("-- David")).toBeTruthy()
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        const [url, init] = fetchMock.mock.calls[0]
+        expect(url).toBe("api/Feedback")
+        expect(JSON.parse(init!.body as string)).toEqual({
+            name: "Juan",
+            comments: "the plural is missing",
+            dictionary: "cregeen",
+            headword: "aa",
+        })
+    })
+
+    it("reports the whole page as 'all' when no dictionary is scoped", async () => {
+        respond(204)
+        openDialog()
+        typeSuggestion("wrong")
+        fireEvent.click(screen.getByRole("button", { name: "Send" }))
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+        const body = JSON.parse(
+            fetchMock.mock.calls[0][1]!.body as string,
+        ) as Record<string, unknown>
+        expect(body.dictionary).toBe("all")
+        expect("name" in body).toBe(false)
+    })
+
+    it("remembers the reader's name for the next suggestion", () => {
+        openDialog()
+        fireEvent.change(screen.getByLabelText("Name (optional)"), {
+            target: { value: "Juan" },
+        })
+        cleanup()
+
+        openDialog()
+        expect(screen.getByLabelText("Name (optional)")).toHaveProperty(
+            "value",
+            "Juan",
+        )
+    })
+
+    it("will not send an empty suggestion", () => {
+        openDialog()
+        fireEvent.click(screen.getByRole("button", { name: "Send" }))
+        expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it("keeps the reader's text when the send fails", async () => {
+        respond(502)
+        openDialog()
+        typeSuggestion("the plural is missing")
+        fireEvent.click(screen.getByRole("button", { name: "Send" }))
+
+        await waitFor(() =>
+            expect(
+                screen.getByText("Could not send. Please try again."),
+            ).toBeTruthy(),
+        )
+        expect(screen.getByLabelText("Your suggestion")).toHaveProperty(
+            "value",
+            "the plural is missing",
+        )
+    })
+
+    it("says a full budget is the site's doing, not the reader's", async () => {
+        respond(429)
+        openDialog()
+        typeSuggestion("wrong")
+        fireEvent.click(screen.getByRole("button", { name: "Send" }))
+
+        await waitFor(() =>
+            expect(
+                screen.getByText(
+                    "Too many suggestions just now. Please try again later.",
+                ),
+            ).toBeTruthy(),
+        )
+    })
+
+    it("offers a fresh form after a sent suggestion, keeping the name", async () => {
+        respond(204)
+        openDialog()
+        fireEvent.change(screen.getByLabelText("Name (optional)"), {
+            target: { value: "Juan" },
+        })
+        typeSuggestion("first thought")
+        fireEvent.click(screen.getByRole("button", { name: "Send" }))
+        await waitFor(() =>
+            expect(
+                screen.getByText("Thanks for the suggestion, Juan!"),
+            ).toBeTruthy(),
+        )
+
+        // the dialog must close before the offer is reachable again
+        fireEvent.keyDown(screen.getByRole("presentation"), { key: "Escape" })
+        await waitFor(() =>
+            expect(screen.queryByText("Thanks for the suggestion, Juan!")).toBe(
+                null,
+            ),
+        )
+        fireEvent.click(
+            screen.getByRole("button", { name: "✏️ suggest an improvement" }),
+        )
+        expect(screen.getByLabelText("Your suggestion")).toHaveProperty(
+            "value",
+            "",
+        )
+        expect(screen.getByLabelText("Name (optional)")).toHaveProperty(
+            "value",
+            "Juan",
+        )
+    })
+})

--- a/CorpusSearch/ClientApp/src/components/DictionaryFeedback.tsx
+++ b/CorpusSearch/ClientApp/src/components/DictionaryFeedback.tsx
@@ -1,0 +1,164 @@
+import { FormEvent, useState } from "react"
+import { Box, Modal } from "@mui/material"
+import { FeedbackError, submitFeedback } from "../api/FeedbackApi"
+import { usePersistedState } from "../hooks/usePersistedState"
+import "./DictionaryFeedback.css"
+
+const style = {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    maxWidth: 440,
+    width: "calc(100% - 32px)",
+    maxHeight: "80vh",
+    overflowY: "auto",
+    bgcolor: "var(--c-surface, #fff)",
+    color: "var(--c-ink, inherit)",
+    borderRadius: 2,
+    boxShadow: 24,
+    p: 3,
+}
+
+type Status = "idle" | "submitting" | "sent" | "failed" | "throttled"
+
+/** The page's way to make the dictionary better: an offer in the title row
+ * opening a dialog for anything at all — corrections, additions, context,
+ * better wording — not only mistakes. The report carries the page's word and
+ * dictionary scope; the reader's name rides along and is remembered for the
+ * next suggestion. */
+export const DictionaryFeedback = ({
+    word,
+    dict,
+}: {
+    word: string
+    /** the page's dictionary scope; absent = all dictionaries */
+    dict?: string
+}) => {
+    const [open, setOpen] = useState(false)
+    const [name, setName] = usePersistedState(
+        "feedbackName",
+        (stored) => stored ?? "",
+        (value) => value,
+    )
+    const [comments, setComments] = useState("")
+    const [status, setStatus] = useState<Status>("idle")
+
+    const openDialog = () => {
+        if (status === "sent") {
+            // the last suggestion went: reopening offers a fresh form
+            setStatus("idle")
+            setComments("")
+        }
+        setOpen(true)
+    }
+
+    const submit = (e: FormEvent) => {
+        e.preventDefault()
+        if (!comments.trim() || status === "submitting") {
+            return
+        }
+        setStatus("submitting")
+        submitFeedback({
+            name: name.trim() || undefined,
+            comments: comments.trim(),
+            dictionary: dict ?? "all",
+            headword: word,
+        })
+            .then(() => setStatus("sent"))
+            .catch((error: unknown) =>
+                setStatus(
+                    error instanceof FeedbackError && error.status === 429
+                        ? "throttled"
+                        : "failed",
+                ),
+            )
+    }
+
+    return (
+        <>
+            <button
+                type="button"
+                className="dict-feedback-open"
+                onClick={openDialog}
+            >
+                ✏️ suggest an improvement
+            </button>
+            <Modal
+                open={open}
+                onClose={() => setOpen(false)}
+                aria-labelledby="dict-feedback-title"
+            >
+                <Box sx={style}>
+                    <h2
+                        id="dict-feedback-title"
+                        className="dict-feedback-title"
+                    >
+                        {`Improve “${word}”`}
+                    </h2>
+                    {status === "sent" ? (
+                        <div role="status">
+                            <p className="dict-feedback-sent">
+                                {name.trim()
+                                    ? `Thanks for the suggestion, ${name.trim()}!`
+                                    : "Thanks for the suggestion!"}
+                            </p>
+                            <p className="dict-feedback-sent">
+                                {
+                                    "I'll aim to get this done within the week. Please "
+                                }
+                                <a href="mailto:corpus-submissions@gaelg.im">
+                                    get in touch
+                                </a>
+                                {" if things haven't moved."}
+                            </p>
+                            <p className="dict-feedback-signature">-- David</p>
+                        </div>
+                    ) : (
+                        <form className="dict-feedback-form" onSubmit={submit}>
+                            <p className="dict-feedback-hint">
+                                Anything helps: a correction, a missing word or
+                                meaning, a better translation, or context this
+                                page should have.
+                            </p>
+                            <input
+                                type="text"
+                                aria-label="Name (optional)"
+                                placeholder="Name (optional)"
+                                maxLength={200}
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                            />
+                            <textarea
+                                aria-label="Your suggestion"
+                                placeholder="Your suggestion"
+                                required
+                                rows={4}
+                                maxLength={2000}
+                                value={comments}
+                                onChange={(e) => setComments(e.target.value)}
+                            />
+                            <button
+                                type="submit"
+                                disabled={status === "submitting"}
+                            >
+                                {status === "submitting" ? "Sending…" : "Send"}
+                            </button>
+                            {status === "failed" && (
+                                <p className="dict-feedback-error" role="alert">
+                                    Could not send. Please try again.
+                                </p>
+                            )}
+                            {status === "throttled" && (
+                                <p className="dict-feedback-error" role="alert">
+                                    Too many suggestions just now. Please try
+                                    again later.
+                                </p>
+                            )}
+                        </form>
+                    )}
+                </Box>
+            </Modal>
+        </>
+    )
+}

--- a/CorpusSearch/ClientApp/src/routes/Dictionary.css
+++ b/CorpusSearch/ClientApp/src/routes/Dictionary.css
@@ -91,6 +91,21 @@
     box-shadow: var(--focus-ring);
 }
 
+/* the title row's far corner: whatever there is to play, and the way to make
+   the page better beneath it (or alone in the corner when nothing plays) */
+.dict-page-corner {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+}
+
+.dict-page-corner-audio {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
 .dict-page-loading {
     display: flex;
     justify-content: center;

--- a/CorpusSearch/ClientApp/src/routes/Dictionary.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Dictionary.tsx
@@ -25,6 +25,7 @@ import { UnverifiedMark } from "../components/UnverifiedMark"
 import { DictionaryScope } from "../components/DictionaryScope"
 import { DictionaryLetters } from "../components/DictionaryLetters"
 import { DictionaryCoverage } from "../components/DictionaryCoverage"
+import { DictionaryFeedback } from "../components/DictionaryFeedback"
 import { isDictionaryHost } from "../utils/Host"
 import { WordSearch } from "../components/WordSearch"
 import { HeadwordNav } from "../components/HeadwordNav"
@@ -327,44 +328,54 @@ export const Dictionary = () => {
             </h1>
             {/* across the row from the word, not part of it: the corpus's
                 recording, beside the spoken dictionary's corner when both
-                have something to play */}
-            {heardDocs != null && (
-                <button
-                    type="button"
-                    className="dict-page-heard"
-                    title={`Hear it spoken: ${heardDocs.lead.title} (${heardDocs.lead.year.toString()})`}
-                    onClick={() => setHeardOpen(true)}
-                >
-                    🔊 audio
-                </button>
-            )}
-            {page?.audio && (
-                <div className="dict-page-audio-corner">
-                    <button
-                        className="dict-page-audio-main"
-                        aria-label={`Play pronunciation of ${word}`}
-                        title="Play pronunciation"
-                        onClick={() => {
-                            new Audio(page.audio!.url)
-                                .play()
-                                .catch(console.warn)
-                        }}
-                    >
-                        {"▶"}
-                    </button>
-                    {page.audio.sourceUrl && (
-                        <a
-                            className="dict-page-audio-credit"
-                            href={page.audio.sourceUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            <span>{page.audio.credit}</span>
-                            <span>{hostOf(page.audio.sourceUrl)}</span>
-                        </a>
-                    )}
-                </div>
-            )}
+                have something to play, with the way to make the page better
+                beneath whatever is there */}
+            <div className="dict-page-corner">
+                {(heardDocs != null || page?.audio != null) && (
+                    <div className="dict-page-corner-audio">
+                        {heardDocs != null && (
+                            <button
+                                type="button"
+                                className="dict-page-heard"
+                                title={`Hear it spoken: ${heardDocs.lead.title} (${heardDocs.lead.year.toString()})`}
+                                onClick={() => setHeardOpen(true)}
+                            >
+                                🔊 audio
+                            </button>
+                        )}
+                        {page?.audio && (
+                            <div className="dict-page-audio-corner">
+                                <button
+                                    className="dict-page-audio-main"
+                                    aria-label={`Play pronunciation of ${word}`}
+                                    title="Play pronunciation"
+                                    onClick={() => {
+                                        new Audio(page.audio!.url)
+                                            .play()
+                                            .catch(console.warn)
+                                    }}
+                                >
+                                    {"▶"}
+                                </button>
+                                {page.audio.sourceUrl && (
+                                    <a
+                                        className="dict-page-audio-credit"
+                                        href={page.audio.sourceUrl}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        <span>{page.audio.credit}</span>
+                                        <span>
+                                            {hostOf(page.audio.sourceUrl)}
+                                        </span>
+                                    </a>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                )}
+                {word != null && <DictionaryFeedback word={word} dict={dict} />}
+            </div>
         </div>
     )
 

--- a/CorpusSearch/Controllers/FeedbackController.cs
+++ b/CorpusSearch/Controllers/FeedbackController.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace CorpusSearch.Controllers;
+
+/// <summary>
+/// Relays a reader's report on a dictionary entry to a Google Apps Script,
+/// which appends it as a row to a sheet: the feedback store lives entirely off
+/// this server. Entries have no stable ids (identity is positional in the
+/// books), so a report names its entry by dictionary and headword only.
+/// Nothing from the body is ever logged — production runs with logging off
+/// for user privacy, and this endpoint carries free-typed user text.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[EnableRateLimiting("feedback")]
+public class FeedbackController(IHttpClientFactory httpClientFactory, FeedbackConfig config) : ControllerBase
+{
+    /// <summary>Covers an Apps Script cold start (a few seconds) without
+    /// letting an outage hold request threads for long</summary>
+    private static readonly TimeSpan RelayTimeout = TimeSpan.FromSeconds(10);
+
+    [HttpPost]
+    [RequestSizeLimit(16_384)]
+    public async Task<IActionResult> Post([FromBody] FeedbackRequest request)
+    {
+        if (string.IsNullOrEmpty(config.AppsScriptUrl))
+        {
+            // the relay target is not configured: the feature is dark
+            return NotFound();
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Comments))
+        {
+            return BadRequest();
+        }
+
+        if (!string.IsNullOrEmpty(request.Website))
+        {
+            // honeypot: the form never renders this field, so a value marks a
+            // bot filling every box. Claim success so it does not try harder.
+            return NoContent();
+        }
+
+        // truncate rather than reject: a heartfelt over-long report is still a
+        // report, and the sheet should not be spillable by one either
+        var payload = new
+        {
+            name = Truncate(request.Name, 200),
+            comments = Truncate(request.Comments, 2000),
+            dictionary = Truncate(request.Dictionary, 100),
+            headword = Truncate(request.Headword, 200),
+        };
+
+        var client = httpClientFactory.CreateClient();
+        client.Timeout = RelayTimeout;
+        try
+        {
+            // Apps Script answers the POST with a redirect to
+            // script.googleusercontent.com, which the handler follows as a GET —
+            // the append has already run by then. A script that crashed can
+            // still answer 200 with an HTML error page, so success is the
+            // script's own {"ok":true}, not the status line.
+            using var response = await client.PostAsJsonAsync(config.AppsScriptUrl, payload, HttpContext.RequestAborted);
+            var body = await response.Content.ReadAsStringAsync(HttpContext.RequestAborted);
+            if (!response.IsSuccessStatusCode || !body.Contains("\"ok\":true"))
+            {
+                return StatusCode(502);
+            }
+        }
+        catch (Exception e) when (e is HttpRequestException or TaskCanceledException)
+        {
+            // network failure or the timeout: the report was (probably) not
+            // recorded, and the form says so and keeps the reader's text
+            return StatusCode(502);
+        }
+
+        return NoContent();
+    }
+
+    private static string? Truncate(string? s, int max) => s != null && s.Length > max ? s[..max] : s;
+
+    public class FeedbackRequest
+    {
+        public string? Name { get; set; }
+        public required string Comments { get; set; }
+        public required string Dictionary { get; set; }
+        public required string Headword { get; set; }
+        /// <summary>Honeypot — the form never shows it; a value marks a bot</summary>
+        public string? Website { get; set; }
+    }
+}

--- a/CorpusSearch/Startup.cs
+++ b/CorpusSearch/Startup.cs
@@ -1,6 +1,8 @@
 using CorpusSearch.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -40,6 +42,18 @@ public class LoadConfig
     //public LoadConfig(bool videoOnlyConfig) => videoOnlyConfig = videoOnly;
 }
 
+/// <summary>Where dictionary-entry feedback goes: a Google Apps Script web app
+/// appending rows to a sheet, so the store lives off this server. The URL is
+/// the secret — unset (the default) the feature is dark and api/Feedback 404s.
+/// Production supplies it as the Feedback__AppsScriptUrl environment variable
+/// (see docker-compose.yml). The script's listing and the procedure to create
+/// or rotate it are in OPERATIONS.md, "Setting up (or rotating) the
+/// dictionary-feedback sheet".</summary>
+public class FeedbackConfig
+{
+    public string? AppsScriptUrl { get; set; }
+}
+
 public class Startup(IConfiguration configuration)
 {
     // set by SetupDictionaries before the server starts serving
@@ -64,6 +78,22 @@ public class Startup(IConfiguration configuration)
         });
         // the pronunciation relay (AudioController) fetches from learnmanx.com
         services.AddHttpClient();
+
+        // the feedback relay (FeedbackController) posts to a Google Sheet's script
+        services.AddSingleton(Configuration.GetSection("Feedback").Get<FeedbackConfig>() ?? new FeedbackConfig());
+        // the site's one unauthenticated write endpoint gets a site-wide budget
+        // rather than a per-IP one: behind nginx every request wears the proxy's
+        // address, so partitioning by IP would be one bucket in disguise
+        services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+            options.AddFixedWindowLimiter("feedback", o =>
+            {
+                o.Window = TimeSpan.FromMinutes(10);
+                o.PermitLimit = 10;
+                o.QueueLimit = 0;
+            });
+        });
 
         services.AddSingleton(provider => LuceneIndex.GetInstance());
         services.AddSingleton(provider => SearchParser.GetParser());
@@ -193,6 +223,10 @@ public class Startup(IConfiguration configuration)
         app.UseSpaStaticFiles(noCacheHtml);
 
         app.UseRouting();
+
+        // only the "feedback" policy is registered: every other endpoint (and the
+        // SPA middleware below) passes untouched
+        app.UseRateLimiter();
 
         app.UseEndpoints(endpoints =>
         {

--- a/CorpusSearch/appsettings.json
+++ b/CorpusSearch/appsettings.json
@@ -9,5 +9,8 @@
   "Seo": {
     "CanonicalBaseUrl": "https://corpus.gaelg.im"
   },
+  "Feedback": {
+    "AppsScriptUrl": ""
+  },
 "AllowedHosts": "*"
 }

--- a/CorpusSearch/docker-compose.yml
+++ b/CorpusSearch/docker-compose.yml
@@ -14,6 +14,11 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:5002:8080" # proxied by nginx
+    environment:
+      # dictionary-feedback relay target (a Google Apps Script /exec URL, and a
+      # secret): set FEEDBACK_APPS_SCRIPT_URL in an uncommitted .env beside this
+      # file on the server. Unset, the feedback feature is dark.
+      - Feedback__AppsScriptUrl=${FEEDBACK_APPS_SCRIPT_URL:-}
     # no logs; for user privacy
     logging:
       driver: "none"

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -28,6 +28,7 @@ The service can run unattended for years. Document uploads are done entirely thr
 | Hosting | Digital Ocean (droplet, 2GB RAM) | David Allison | David's Google Account | $12/month              |
 | Mailing list | Mailjet                          | David Allison | hello@gaelg.im |                        |
 | GitHub repositories | github.com/david-allison         | David Allison | | Multiple project repos |
+| Dictionary feedback sheet | Google Sheets + Apps Script      | David Allison | David's Google Account | Receives /api/Feedback reports via the script's `/exec` URL — a secret, set as `FEEDBACK_APPS_SCRIPT_URL` in an uncommitted `.env` beside `docker-compose.yml` on the droplet. Losing it only disables feedback. |
 
 Credentials are not in this document. To request a transfer, see "Roles" below.
 
@@ -88,6 +89,38 @@ Next renewal due 28/12/2032.
 1. Log into nic.im (account: David's personal email).
 2. Renew `corpus.gaelg.im` for the desired term.
 3. Update the renewal date in the Accounts table and Minimum viable maintenance section above.
+
+### Setting up (or rotating) the dictionary-feedback sheet
+
+The "report an issue" form on dictionary entries posts to `/api/Feedback`, which relays each report to a Google Apps Script that appends a row to a Google Sheet. The script's `/exec` URL is the only secret; the server reads it from the `Feedback__AppsScriptUrl` environment variable and the feature stays dark while it is unset. Follow this to recreate the sheet from nothing, or to rotate the URL.
+
+1. Create a Google Sheet with the header row: `Timestamp | Name | Comments | Dictionary | Headword`.
+2. In the sheet: Extensions → Apps Script, replace the editor's contents with:
+
+   ```javascript
+   function doPost(e) {
+     var data = JSON.parse(e.postData.contents);
+     SpreadsheetApp.getActiveSpreadsheet().getSheets()[0].appendRow([
+       new Date(), data.name || "", data.comments || "",
+       data.dictionary || "", data.headword || "",
+     ]);
+     return ContentService.createTextOutput(JSON.stringify({ ok: true }))
+       .setMimeType(ContentService.MimeType.JSON);
+   }
+   ```
+
+   The server checks the response for `"ok":true` — an Apps Script that crashes still answers HTTP 200 with an HTML error page, so the script must return exactly this marker on success.
+3. Deploy → New deployment → type **Web app** → Execute as: **Me** → Who has access: **Anyone** (must be "Anyone", not "Anyone with a Google account": the server posts anonymously) → authorize → copy the `/exec` URL.
+4. On the droplet, put the URL in an uncommitted `.env` file beside `docker-compose.yml`:
+
+   ```
+   FEEDBACK_APPS_SCRIPT_URL=https://script.google.com/macros/s/…/exec
+   ```
+
+   then `docker compose up -d`.
+5. Verify: submit a report from any `/dictionary/` page on the live site and watch the row appear in the sheet.
+
+⚠️ To edit the script later, use *Manage deployments → edit → Version: New version*, which keeps the same URL. Creating a *new* deployment mints a different URL and the one in `.env` silently goes stale (the form then shows "could not send"). To rotate a leaked URL, that is exactly what you want: archive the old deployment, make a new one, update `.env`.
 
 ### Roles
 


### PR DESCRIPTION
The report-an-issue link on every entry becomes one offer in the title row, where the audio sits (or beneath it, when a word has something to play): 'suggest an improvement', because the door is for anything that would make the page better, not only faults. It opens a dialog rather than unfolding in the entry; the reader's name is remembered for their next suggestion, and the thank-you answers in David's own voice, with a week's promise and a way to write to him if nothing changes. The report now names the page's word and dictionary scope. Send is a real button in the corpus's red, and it stays red and clickable while the box is still empty: an empty send is refused with the browser's own prompt, not with a greyed-out mystery.

A 'report an issue' toggle on each dictionary-page entry opens a name-and-comments form in place. The server relays the report — with the dictionary and headword riding along — to a Google Apps Script that appends it to a sheet, so the store lives entirely off this server. The script's /exec URL is the secret: unset, the feature is dark. The site's first unauthenticated write endpoint arrives with the site's first rate limiter (10 reports per 10 minutes, one bucket: behind nginx every caller wears the proxy's address) and a honeypot field that lets bots believe they were heard.