### PR TITLE
style(dictionary): improve landing page margins

### DIFF
--- a/CorpusSearch/ClientApp/src/components/DictionaryCoverage.css
+++ b/CorpusSearch/ClientApp/src/components/DictionaryCoverage.css
@@ -1,18 +1,20 @@
 /* the coverage under the dictionary's front door: the numbers counted out
-   loud, a small bar drawing each share, the counts beside it */
-.dict-coverage {
+   loud, a small bar drawing each share, the counts beside it. -grid, never
+   bare .dict-coverage: that name belongs to the token debug overlay's spans
+   (CoverageText.css), and the two styles must not meet */
+.dict-coverage-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 22px 18px;
     max-width: 620px;
-    margin: 34px auto 0;
+    margin: 52px auto 0;
     padding-top: 22px;
     border-top: 1px solid var(--c-border-meta);
     text-align: center;
 }
 
 @media (max-width: 600px) {
-    .dict-coverage {
+    .dict-coverage-grid {
         grid-template-columns: minmax(0, 1fr);
     }
 }

--- a/CorpusSearch/ClientApp/src/components/DictionaryCoverage.tsx
+++ b/CorpusSearch/ClientApp/src/components/DictionaryCoverage.tsx
@@ -93,7 +93,7 @@ export const DictionaryCoverage = () => {
     return (
         <>
             <section
-                className="dict-coverage"
+                className="dict-coverage-grid"
                 aria-label="Coverage of the corpus"
             >
                 <Card


### PR DESCRIPTION
More margin between the sampler and the numbers: the landing's two halves were shoulder to shoulder. And the grid's class stops being .dict-coverage, which already belongs to the token debug overlay's spans (CoverageText.css): one global name, two unrelated styles, and whichever stylesheet loaded last dressed the other's element.