### PR TITLE
feat: 6 more dictionary improvements

### DIFF
--- a/CorpusSearch.Test/DictionaryAttestationServiceTest.cs
+++ b/CorpusSearch.Test/DictionaryAttestationServiceTest.cs
@@ -176,8 +176,8 @@ public class DictionaryAttestationServiceTest : QueryBase
         });
     }
 
-    /// <summary>The walk says whether a recording's transcript carries its
-    /// clock: the word page's audio link prefers a recording it can jump
+    /// <summary>The walk says whether a recording's uses of the word carry
+    /// timestamps: the word page's audio link prefers a recording it can jump
     /// into, and print is not asked the question at all</summary>
     [Test]
     public void ARecordingSaysWhetherItsTranscriptIsTimed()
@@ -206,6 +206,30 @@ public class DictionaryAttestationServiceTest : QueryBase
             Assert.That(walk.Documents.Single(x => x.Ident == "🎥 Untimed").Timed, Is.False);
             Assert.That(walk.Documents.Single(x => x.Ident == "Print").Timed, Is.Null);
         });
+    }
+
+    /// <summary>A transcript may carry its clock on some lines and not others,
+    /// and only the word's own lines can answer for it: Skeealyn Vannin Disk 1
+    /// Track 2 is timed, but its one use of 'geddyn' is not, and the audio
+    /// link leading with it opened a popup it could not cue (showing ??:??
+    /// while recordings it could jump into sat behind the arrows)</summary>
+    [Test]
+    public void APartiallyTimedTranscriptAnswersForTheWordsOwnLines()
+    {
+        var document = new TestDocument("🎥 Partial", new DateTime(1948, 1, 1));
+        workService.AddWork(document);
+        luceneIndex.Add(document, [
+            new DocumentLine { Manx = "Ta mee aase", English = "", CsvLineNumber = 2 },
+            new DocumentLine
+            {
+                Manx = "Cha nel eh", English = "", CsvLineNumber = 3,
+                SubStart = 5.0, SubEnd = 7.0,
+            },
+        ]);
+
+        var walk = Service().Attestations("aase");
+
+        Assert.That(walk.Documents.Single().Timed, Is.False);
     }
 
     /// <summary>The spelling fallback keeps them too: a word the lemma table

--- a/CorpusSearch.Test/DictionaryBrowseServiceTest.cs
+++ b/CorpusSearch.Test/DictionaryBrowseServiceTest.cs
@@ -255,6 +255,52 @@ public class DictionaryBrowseServiceTest
         Assert.That(n.Next, Is.Null);
     }
 
+    /// <summary>A span sends the windows either side along whole — previous
+    /// pages nearest-first, then next pages nearest-first, each with its own
+    /// arrows — so the walk's client steps through them without asking again</summary>
+    [Test]
+    public void ASpanCarriesTheWindowsEitherSide()
+    {
+        var service = Service(new FakeDictionary("d", "aa", "baa", "caa", "daa", "eairk"));
+
+        var n = service.Neighbours("d", "caa", span: 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(n.Nearby.Select(x => x.Word),
+                Is.EqualTo(new[] { "baa", "aa", "daa", "eairk" }));
+            var daa = n.Nearby.Single(x => x.Word == "daa");
+            Assert.That(daa.Previous, Is.EqualTo("caa"));
+            Assert.That(daa.Next, Is.EqualTo("eairk"));
+            Assert.That(n.Nearby.Single(x => x.Word == "aa").Previous, Is.Null);
+            // nothing rides along unasked: the row's own answer stays light
+            Assert.That(service.Neighbours("d", "caa").Nearby, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void ASpanStopsAtTheBookEnds()
+    {
+        var n = Service(new FakeDictionary("d", "aa", "baa"))
+            .Neighbours("d", "aa", span: 5);
+
+        Assert.That(n.Nearby.Select(x => x.Word), Is.EqualTo(new[] { "baa" }));
+    }
+
+    /// <summary>Same-spelled headwords are one page, so they are one step of
+    /// the span too: it must walk the way the arrows walk</summary>
+    [Test]
+    public void ASpanCollapsesSameSpelledHeadwordsAsTheArrowsDo()
+    {
+        var service = Service(
+            new FakeDictionary("d", "baar-aadjin", "baare", "baare", "baarelagh"));
+
+        var n = service.Neighbours("d", "baar-aadjin", span: 3);
+
+        Assert.That(n.Nearby.Select(x => x.Word),
+            Is.EqualTo(new[] { "baare", "baarelagh" }), "the twin 'baare' is one step");
+    }
+
     /// <summary>The dictionary JSON is downloaded on deployment: without it the
     /// dictionary is empty rather than broken, and so is its index</summary>
     [Test]

--- a/CorpusSearch.Test/DictionaryHostTest.cs
+++ b/CorpusSearch.Test/DictionaryHostTest.cs
@@ -1,0 +1,55 @@
+using CorpusSearch.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+/// <summary>
+/// The dictionary host's front door is "/", so its bare /dictionary
+/// permanently moves there; every sub-page stays under the prefix, and the
+/// corpus host is left alone entirely.
+/// </summary>
+[TestFixture]
+public class DictionaryHostTest
+{
+    private static HttpRequest Request(string host, string path, string query = "")
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Host = new HostString(host);
+        context.Request.Path = path;
+        context.Request.QueryString = new QueryString(query);
+        return context.Request;
+    }
+
+    [TestCase("/dictionary")]
+    [TestCase("/dictionary/")]
+    [TestCase("/Dictionary")]
+    public void TheBareLandingMovesToTheRoot(string path)
+    {
+        Assert.That(
+            DictionaryHost.RootRedirectTarget(Request("dictionary.gaelg.im", path)),
+            Is.EqualTo("/"));
+    }
+
+    [Test]
+    public void TheQueryStringRidesAlong()
+    {
+        Assert.That(
+            DictionaryHost.RootRedirectTarget(
+                Request("dictionary.gaelg.im", "/dictionary", "?q=geddyn")),
+            Is.EqualTo("/?q=geddyn"));
+    }
+
+    // the sub-pages stay under the prefix on both hosts, and the corpus host
+    // keeps its landing where it is
+    [TestCase("dictionary.gaelg.im", "/dictionary/geddyn")]
+    [TestCase("dictionary.gaelg.im", "/dictionary/browse/cregeen")]
+    [TestCase("dictionary.gaelg.im", "/")]
+    [TestCase("dictionary.gaelg.im", "/dictionaryextra")]
+    [TestCase("gaelg.im", "/dictionary")]
+    [TestCase("localhost", "/dictionary")]
+    public void NothingElseMoves(string host, string path)
+    {
+        Assert.That(DictionaryHost.RootRedirectTarget(Request(host, path)), Is.Null);
+    }
+}

--- a/CorpusSearch/ClientApp/src/api/DictionaryApi.ts
+++ b/CorpusSearch/ClientApp/src/api/DictionaryApi.ts
@@ -268,8 +268,9 @@ export type AttestationDocument = {
      * AttestationDocument on the server). Absent for an ambiguous word, whose
      * uses are counted a document at a time as `useCount` */
     uses?: number | null
-    /** whether a recording's transcript says when its lines are spoken
-     * (Skeealyn Vannin Track 12's does not); null for anything in print */
+    /** whether the word's uses in the recording say when they are spoken: a
+     * transcript timed elsewhere may still write no clock at the word's own
+     * lines (Skeealyn Vannin Disk 1 Track 2 and 'geddyn'); null for print */
     timed?: boolean | null
 }
 

--- a/CorpusSearch/ClientApp/src/api/DictionaryApi.ts
+++ b/CorpusSearch/ClientApp/src/api/DictionaryApi.ts
@@ -598,18 +598,28 @@ export type DictionaryNeighboursResponse = {
      * the one next door: half of Phil Kelly is unattested */
     previousUsed?: string | null
     nextUsed?: string | null
+    /** the complete windows of the nearest pages either side, when a span was
+     * asked for: previous pages nearest-first, then next pages nearest-first.
+     * The walk steps through these without asking again. */
+    nearby?: DictionaryNeighboursResponse[] | null
 }
 
 /** @param dict optional slug: one book's own order. Without it, the union
- * across every dictionary in collation order */
+ * across every dictionary in collation order
+ * @param span complete windows either side to send along, for stepping
+ * through without asking again */
 export const dictionaryNeighbours = async (
     word: string,
     dict?: string,
     signal?: AbortSignal,
+    span?: number,
 ): Promise<DictionaryNeighboursResponse> => {
     const params = new URLSearchParams({ word })
     if (dict) {
         params.set("dict", dict)
+    }
+    if (span) {
+        params.set("span", span.toString())
     }
     const response = await fetch(
         `/api/Dictionary/neighbours?${params.toString()}`,

--- a/CorpusSearch/ClientApp/src/components/DictionaryFeedback.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/DictionaryFeedback.test.tsx
@@ -109,6 +109,50 @@ describe("DictionaryFeedback", () => {
         expect(fetchMock).not.toHaveBeenCalled()
     })
 
+    it("sends on Cmd+Enter from the suggestion", async () => {
+        respond(204)
+        openDialog()
+        typeSuggestion("the plural is missing")
+        fireEvent.keyDown(screen.getByLabelText("Your suggestion"), {
+            key: "Enter",
+            metaKey: true,
+        })
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    })
+
+    it("sends on Ctrl+Enter, and from the name field too", async () => {
+        respond(204)
+        openDialog()
+        typeSuggestion("the plural is missing")
+        fireEvent.keyDown(screen.getByLabelText("Name (optional)"), {
+            key: "Enter",
+            ctrlKey: true,
+        })
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    })
+
+    it("keeps a bare Enter as a newline, never a send", () => {
+        openDialog()
+        typeSuggestion("line one")
+        fireEvent.keyDown(screen.getByLabelText("Your suggestion"), {
+            key: "Enter",
+        })
+
+        expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it("sends nothing on Cmd+Enter while the suggestion is empty", () => {
+        openDialog()
+        fireEvent.keyDown(screen.getByLabelText("Your suggestion"), {
+            key: "Enter",
+            metaKey: true,
+        })
+
+        expect(fetchMock).not.toHaveBeenCalled()
+    })
+
     it("keeps the reader's text when the send fails", async () => {
         respond(502)
         openDialog()

--- a/CorpusSearch/ClientApp/src/components/DictionaryFeedback.tsx
+++ b/CorpusSearch/ClientApp/src/components/DictionaryFeedback.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from "react"
+import { FormEvent, KeyboardEvent, useState } from "react"
 import { Box, Modal } from "@mui/material"
 import { FeedbackError, submitFeedback } from "../api/FeedbackApi"
 import { usePersistedState } from "../hooks/usePersistedState"
@@ -75,6 +75,14 @@ export const DictionaryFeedback = ({
             )
     }
 
+    // Cmd/Ctrl+Enter sends from anywhere in the form: Enter alone must not —
+    // in the textarea it is a newline, and a suggestion is a place for them
+    const submitKey = (e: KeyboardEvent) => {
+        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            submit(e)
+        }
+    }
+
     return (
         <>
             <button
@@ -115,7 +123,11 @@ export const DictionaryFeedback = ({
                             <p className="dict-feedback-signature">-- David</p>
                         </div>
                     ) : (
-                        <form className="dict-feedback-form" onSubmit={submit}>
+                        <form
+                            className="dict-feedback-form"
+                            onSubmit={submit}
+                            onKeyDown={submitKey}
+                        >
                             <p className="dict-feedback-hint">
                                 Anything helps: a correction, a missing word or
                                 meaning, a better translation, or context this

--- a/CorpusSearch/ClientApp/src/components/DictionaryLetters.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/DictionaryLetters.test.tsx
@@ -36,6 +36,45 @@ const respond = (letters: string[]) =>
     )
 
 describe("DictionaryLetters", () => {
+    /* First in the file: the dictionary list is cached at module scope once
+       fetched, and any earlier test would cache the empty list this one needs
+       to be a row of books */
+    it("marks no book active: the landing has selected nothing", async () => {
+        fetchMock.mockImplementation((url) =>
+            Promise.resolve({
+                ok: true,
+                json: () =>
+                    Promise.resolve(
+                        hrefOf(url).includes("/browse")
+                            ? {
+                                  dictionary: "Cregeen",
+                                  slug: "cregeen",
+                                  letters: ["A"],
+                                  letter: "A",
+                                  chapters: [],
+                              }
+                            : hrefOf(url).includes("/dictionaries")
+                              ? [
+                                    { slug: "cregeen", name: "Cregeen" },
+                                    { slug: "kelly-m2e", name: "J Kelly" },
+                                ]
+                              : [],
+                    ),
+            } as Response),
+        )
+        render(
+            <MemoryRouter>
+                <DictionaryLetters />
+            </MemoryRouter>,
+        )
+
+        // the letters are Cregeen's, but the book is not thereby chosen: the
+        // active mark is the browse pages' "you are here"
+        const cregeen = await screen.findByRole("link", { name: "Cregeen" })
+        expect(cregeen.getAttribute("aria-current")).toBeNull()
+        expect(cregeen.className).not.toContain("active")
+    })
+
     it("offers the letters as links into the browse", async () => {
         respond(["A", "B"])
         render(

--- a/CorpusSearch/ClientApp/src/components/DictionaryLetters.tsx
+++ b/CorpusSearch/ClientApp/src/components/DictionaryLetters.tsx
@@ -18,7 +18,11 @@ const BROWSE_DICT = "cregeen"
  * The books are named above the letters because the letters are one book's. They
  * were Cregeen's before too, and said so nowhere — an unlabelled A|B|C that gave
  * a reader no way to know whose index they were reading, nor that there were
- * others to read. */
+ * others to read.
+ *
+ * No name is marked active, though: the active mark is the browse pages' "you
+ * are here", and the landing has chosen nothing for the reader yet — a bolded
+ * Cregeen read as a selection already made. */
 export const DictionaryLetters = () => {
     const [letters, setLetters] = useState<string[]>([])
 
@@ -34,7 +38,7 @@ export const DictionaryLetters = () => {
 
     return (
         <>
-            <DictionaryBooks active={BROWSE_DICT} />
+            <DictionaryBooks />
             {letters.length > 0 && (
                 <nav
                     className="dict-letters-home"

--- a/CorpusSearch/ClientApp/src/components/HeadwordNav.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/HeadwordNav.test.tsx
@@ -6,7 +6,13 @@ import { HeadwordNav } from "./HeadwordNav"
 const fetchMock = vi.fn<typeof fetch>()
 vi.stubGlobal("fetch", fetchMock)
 
-beforeEach(() => fetchMock.mockReset())
+beforeEach(() => {
+    fetchMock.mockReset()
+    // anything not answered explicitly stays on its way: the component
+    // prefetches the windows either side, and a test that has said all it
+    // means to say should leave those hanging rather than erroring
+    fetchMock.mockReturnValue(new Promise(() => {}))
+})
 afterEach(cleanup)
 
 /** Cregeen files 'faar-y-chaagh' among the 'caa' words, so it really is what
@@ -55,12 +61,71 @@ describe("HeadwordNav", () => {
         await screen.findByTitle("caa")
 
         // the step's own neighbours never arrive: the row must ride it out
-        fetchMock.mockReturnValueOnce(new Promise(() => {}))
         rerender(nav("faar-y-chaagh"))
 
         expect(
             screen.getByRole("navigation", { name: "Headwords" }),
         ).toBeTruthy()
+    })
+
+    /** The row used to ride out a step showing the last page's window, whose
+     * "next" was the page already on screen: a second tap went nowhere until
+     * the fetch landed, and a reader walking briskly was stopped every step */
+    it("re-points the arrow back at the page just left, mid-step", async () => {
+        responding(neighbours("caag", "caa", "faar-y-chaagh"))
+        const { rerender } = render(nav("caag"))
+        await screen.findByTitle("caa")
+
+        // the step's own window never arrives; the shift cannot wait for it
+        rerender(nav("faar-y-chaagh"))
+
+        expect(screen.getByTitle("caag").getAttribute("href")).toBe(
+            "/dictionary/caag",
+        )
+        // what lies ahead is genuinely unknown: the slot holds empty for the
+        // beat rather than pointing at the page already on screen
+        expect(screen.queryByTitle("faar-y-chaagh")).toBeNull()
+    })
+
+    it("answers a step within the span from memory", async () => {
+        responding({
+            ...neighbours("caag", "caa", "faar-y-chaagh"),
+            // every answer carries the whole windows either side
+            nearby: [
+                neighbours("caa", "bab", "caag"),
+                neighbours("faar-y-chaagh", "caag", "gaaue"),
+            ],
+        })
+        const { rerender } = render(nav("caag"))
+        await screen.findByTitle("caa")
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock.mock.calls[0][0]).toContain("span=5")
+
+        rerender(nav("caa"))
+
+        // synchronously: no fetch could have answered between those two lines
+        expect(screen.getByTitle("bab").getAttribute("href")).toBe(
+            "/dictionary/bab",
+        )
+        expect(screen.getByTitle("caag")).toBeTruthy()
+    })
+
+    it("re-centres the span as a step nears its edge", async () => {
+        responding({
+            ...neighbours("caag", "caa", "faar-y-chaagh"),
+            // 'faar-y-chaagh' is the span's edge: what follows it is unknown
+            nearby: [neighbours("faar-y-chaagh", "caag", "gaaue")],
+        })
+        const { rerender } = render(nav("caag"))
+        await screen.findByTitle("caa")
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+
+        rerender(nav("faar-y-chaagh"))
+
+        // the step itself was answered from memory; the walk asks again in
+        // the background so the reader never reaches the edge
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+        expect(fetchMock.mock.calls[1][0]).toContain("word=faar-y-chaagh")
     })
 
     it("shows nothing for a word that is in no book to step through", async () => {

--- a/CorpusSearch/ClientApp/src/components/HeadwordNav.tsx
+++ b/CorpusSearch/ClientApp/src/components/HeadwordNav.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from "react"
+import { ReactNode, useEffect, useRef, useState } from "react"
 import {
     dictionaryNeighbours,
     DictionaryNeighboursResponse,
@@ -6,12 +6,27 @@ import {
 import { dictionaryWordUrl } from "../utils/DictionaryEntries"
 import { PrevNextLinks } from "./PrevNextLinks"
 
+/** How many windows either side ride along with each answer: a reader can tap
+ * this many steps ahead of the network before the walk has to catch up, and
+ * the re-centring below means they never do at a walking pace. */
+const SPAN = 5
+
 /** The headwords either side of this one: the dictionary as a book you turn a
  * page in.
  *
  * Scoped to one dictionary the order is that book's own. Across all of them it
  * is the union in collation order — nobody's printed order, but the only one
  * several books can share.
+ *
+ * The walk is meant to be tapped through faster than its answers arrive, so
+ * three things keep the arrows live between them: every answer brings the
+ * complete windows of the pages either side (SPAN of them each way, stepped
+ * through from memory and re-centred as the reader nears the edge), every
+ * window seen is remembered (a step back must not wait on the network), and a
+ * step ahead of all of it re-points what it can — the arrow back is the page
+ * just left. Without this the row rode out each step showing the *last*
+ * page's neighbours, whose "next" was the page already on screen: a tap on it
+ * went nowhere, and a reader walking briskly was stopped once per fetch.
  *
  * The way out of the walk and back to the index is not here: it belongs to the
  * page rather than to the walk, and sits by the search box.
@@ -31,28 +46,109 @@ export const HeadwordNav = ({
      * else to distinguish it from this row */
     children: ReactNode
 }) => {
-    const [near, setNear] = useState<DictionaryNeighboursResponse | null>(null)
     const scope = spoken ? "spoken" : dict
-    const urlOf = (to: string) =>
-        spoken
-            ? `${dictionaryWordUrl(to)}?nav=spoken`
-            : dictionaryWordUrl(to, dict)
+    // the windows this walk has seen or prefetched, by scope and word: the
+    // headword lists are fixed at deploy, so a window once fetched is final
+    const seen = useRef(new Map<string, DictionaryNeighboursResponse>())
+    const inFlight = useRef(new Set<string>())
+    // the last answered step: what the optimistic shift and the stale hold
+    // below are read off while this word's own window is on its way
+    const [settled, setSettled] = useState<{
+        key: string
+        word: string
+        near: DictionaryNeighboursResponse
+    } | null>(null)
 
     useEffect(() => {
-        // the step you just took must not blank this row first. This row *is*
-        // what you clicked: dropping it to nothing and growing it back a moment
-        // later takes the arrows out from under the cursor and slides the page
-        // up into the gap, and the walk is meant to be clicked through. The
-        // neighbours you stepped from ride the beat until the new ones land —
-        // they are about to be replaced by their own neighbours anyway.
+        const keyOf = (w: string) => `${scope ?? ""}|${w}`
+
+        // one answer seeds the whole span: the word's own window and the
+        // complete windows either side, arrows and skips included
+        const seed = (near: DictionaryNeighboursResponse) => {
+            seen.current.set(keyOf(near.word), near)
+            for (const window of near.nearby ?? []) {
+                seen.current.set(keyOf(window.word), window)
+            }
+        }
+
+        // re-centres the span on this word, in the background: fired from a
+        // cache hit whose neighbour is missing — the span's edge is near, and
+        // the reader must not reach it before the next span lands
+        const extend = () => {
+            const k = keyOf(word)
+            if (inFlight.current.has(k)) {
+                return
+            }
+            inFlight.current.add(k)
+            dictionaryNeighbours(word, scope, undefined, SPAN)
+                .then(seed)
+                .catch(() => undefined)
+                .finally(() => inFlight.current.delete(k))
+        }
+
+        const k = keyOf(word)
+        const cached = seen.current.get(k)
+        if (cached) {
+            setSettled((previous) =>
+                previous?.key === k ? previous : { key: k, word, near: cached },
+            )
+            if (
+                [cached.previous, cached.next].some(
+                    (target) =>
+                        target != null && !seen.current.has(keyOf(target)),
+                )
+            ) {
+                extend()
+            }
+            return
+        }
         const abort = new AbortController()
-        dictionaryNeighbours(word, scope, abort.signal)
-            .then(setNear)
+        dictionaryNeighbours(word, scope, abort.signal, SPAN)
+            .then((near) => {
+                seed(near)
+                setSettled({ key: k, word, near })
+            })
             .catch((e) => {
                 if (!abort.signal.aborted) console.warn(e)
             })
         return () => abort.abort()
     }, [word, scope])
+
+    // this word's window: its own if known — the effect above may not have
+    // settled a prefetched answer yet, so the cache is read directly — else
+    // what the step it came by already knew, else the row it left riding
+    // (a jump from the search box has nothing to shift; the stale row holds
+    // the space, exactly as it did before the answer beat it here)
+    const cached = seen.current.get(`${scope ?? ""}|${word}`)
+    const near =
+        cached ??
+        (settled == null
+            ? null
+            : settled.near.next === word
+              ? // stepped forward: the way back is the page just left. What
+                // lies ahead is genuinely unknown, and the slot holds empty
+                // for the beat rather than pointing somewhere wrong.
+                {
+                    word,
+                    attested: true,
+                    previous: settled.word,
+                    previousAttested: settled.near.attested,
+                    nextAttested: false,
+                }
+              : settled.near.previous === word
+                ? {
+                      word,
+                      attested: true,
+                      next: settled.word,
+                      nextAttested: settled.near.attested,
+                      previousAttested: false,
+                  }
+                : settled.near)
+
+    const urlOf = (to: string) =>
+        spoken
+            ? `${dictionaryWordUrl(to)}?nav=spoken`
+            : dictionaryWordUrl(to, dict)
 
     // a word with nothing either side is not in a book we can step through
     if (near == null || (!near.previous && !near.next)) {

--- a/CorpusSearch/ClientApp/src/components/LineText.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/LineText.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render } from "@testing-library/react"
+import { LineText } from "./LineText"
+
+// vitest globals are off, so testing-library does not clean up by itself; without this,
+// document-wide queries see the renders of earlier tests
+afterEach(cleanup)
+
+const renderDiff = (
+    original: string,
+    text: string,
+    extra?: Partial<Parameters<typeof LineText>[0]>,
+) =>
+    render(
+        <LineText
+            text={text}
+            original={original}
+            shouldHighlight={true}
+            translations={[]}
+            query=""
+            {...extra}
+        />,
+    )
+
+describe("a corrected line", () => {
+    it("diffs a word the correction only added characters to inline", () => {
+        const { container } = renderDiff(
+            "cha nel eh er yarrood me.",
+            "cha nel eh er yarrood mee.",
+        )
+        expect(container.querySelector("button")).toBeNull()
+        const added = [...container.querySelectorAll(".part-added")]
+        expect(added.map((x) => x.textContent)).toEqual(["e"])
+        expect(container.textContent).toBe("cha nel eh er yarrood mee.")
+    })
+
+    it("diffs a word the correction only removed characters from inline", () => {
+        const { container } = renderDiff("Cummal seoise", "Cummal seose")
+        expect(container.querySelector("button")).toBeNull()
+        const removed = [...container.querySelectorAll(".part-removed")]
+        expect(removed.map((x) => x.textContent)).toEqual(["i"])
+        // the removed character is struck, not hidden: both spellings read
+        expect(container.textContent).toBe("Cummal seoise")
+    })
+
+    it("shows only the correction of a rewritten word", () => {
+        const { container, queryByText } = renderDiff(
+            "cloan ny moadea!",
+            "cloan ny moddee!",
+        )
+        // a character diff would render the unreadable jumble "moaddeae";
+        // the "±" chip after the word reveals the original
+        expect(container.textContent).toBe("cloan ny moddee±!")
+        expect(queryByText("moadea")).toBeNull()
+        expect(container.querySelector(".doc-correction")?.textContent).toBe(
+            "moddee",
+        )
+        const chip = container.querySelector("button.doc-correction-marker")
+        expect(chip?.getAttribute("aria-expanded")).toBe("false")
+    })
+
+    it("reveals and hides a rewritten word's original from the chip", () => {
+        const { container, getByRole } = renderDiff(
+            "cloan ny moadea!",
+            "cloan ny moddee!",
+        )
+        const chip = getByRole("button", { name: "Show original text" })
+        fireEvent.click(chip)
+        expect(chip.getAttribute("aria-expanded")).toBe("true")
+        const removed = container.querySelector(".part-removed")
+        expect(removed?.textContent).toBe("moadea")
+        expect(container.textContent).toBe("cloan ny moadea moddee±!")
+
+        fireEvent.click(chip)
+        expect(chip.getAttribute("aria-expanded")).toBe("false")
+        expect(container.textContent).toBe("cloan ny moddee±!")
+    })
+
+    it("opens the dictionary from the word but not from the chip", () => {
+        const onWordClick = vi.fn()
+        const { getByRole, getByText } = renderDiff(
+            "cloan ny moadea!",
+            "cloan ny moddee!",
+            { onWordClick },
+        )
+        fireEvent.click(getByRole("button"))
+        expect(onWordClick).not.toHaveBeenCalled()
+
+        // the rewritten word itself is plain text: tapping it looks up
+        // the dictionary like any other word (a regression in #310's redesign)
+        fireEvent.click(getByText("moddee"))
+        expect(onWordClick).toHaveBeenCalledOnce()
+    })
+
+    it("marks server match ranges against the corrected text", () => {
+        // "moddee" is chars 9-15 of the correction; "gys" follows at 16-19
+        const { container } = renderDiff(
+            "cloan ny moadea gys",
+            "cloan ny moddee gys",
+            { highlights: [{ start: 9, end: 15 }] },
+        )
+        const mark = container.querySelector("mark.textHighlight")
+        expect(mark?.textContent).toBe("moddee")
+        expect(mark?.closest(".doc-correction")).not.toBeNull()
+    })
+
+    it("marks a match after an inline diff at its corrected offset", () => {
+        // the correction removes " " from "vaik ym": later offsets shift left
+        const { container } = renderDiff(
+            "cha vaik ym oo",
+            "cha vaikym oo",
+            // "oo" is chars 11-13 of the corrected text
+            { highlights: [{ start: 11, end: 13 }] },
+        )
+        const mark = container.querySelector("mark.textHighlight")
+        expect(mark?.textContent).toBe("oo")
+    })
+})

--- a/CorpusSearch/ClientApp/src/routes/Dictionary.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Dictionary.tsx
@@ -198,8 +198,9 @@ export const Dictionary = () => {
     const [heard, setHeard] = useState<{
         word: string
         docs: AttestationDocument[]
-        /** the recording the link opens: the earliest whose transcript can be
-         * jumped into, or — only when there is no such thing — an untimed one */
+        /** the recording the link opens: the earliest whose uses of the word
+         * can be jumped into, or — only when there is no such thing — an
+         * untimed one */
         lead: AttestationDocument
     } | null>(null)
     const [heardOpen, setHeardOpen] = useState(false)
@@ -243,9 +244,10 @@ export const Dictionary = () => {
                 const docs = walk.documents.filter((d) =>
                     d.title.startsWith("🎥"),
                 )
-                // the link leads with a recording it can jump into: an untimed
-                // transcript (Skeealyn Vannin Track 12) plays only from the
-                // top, so it leads only when it is the only recording there is
+                // the link leads with a recording it can jump into: one whose
+                // uses of the word carry no timestamp (an untimed transcript,
+                // or an untimed corner of a timed one) plays only from the
+                // top, so it leads only when there is nothing better
                 const lead = docs.find((d) => d.timed !== false) ?? docs[0]
                 // an answer either way: the last word's recordings must not
                 // linger on a word nothing says (the render checks the word too,

--- a/CorpusSearch/ClientApp/src/utils/Selection.test.ts
+++ b/CorpusSearch/ClientApp/src/utils/Selection.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { getSelectedWordOrPhrase } from "./Selection"
+
+afterEach(() => {
+    document.body.innerHTML = ""
+})
+
+/** A collapsed caret in `node` at `offset`, as a click places one */
+const caretAt = (node: Node, offset: number): Selection =>
+    ({
+        rangeCount: 1,
+        toString: () => "",
+        anchorNode: node,
+        anchorOffset: offset,
+    }) as unknown as Selection
+
+/** A revealed correction, as DiffedLine renders it:
+ * "cloan ny ~moadea~ moddee[±]!" */
+const revealedLine = () => {
+    document.body.innerHTML =
+        '<div><span>cloan ny </span><span class="part-removed">moadea</span> ' +
+        '<span class="doc-correction part-added">moddee</span>' +
+        "<button>±</button><span>!</span></div>"
+    return document.body
+}
+
+describe("a click in a diffed line", () => {
+    it("reads the corrected text around unchanged words", () => {
+        const line = revealedLine()
+        const cloan = line.querySelector("span")!.firstChild!
+        expect(getSelectedWordOrPhrase(caretAt(cloan, 2))).toBe("cloan")
+    })
+
+    it("reads the correction when the click lands on it", () => {
+        const line = revealedLine()
+        const moddee = line.querySelector(".doc-correction")!.firstChild!
+        // the struck "moadea" beside it is not part of the corrected reading
+        expect(getSelectedWordOrPhrase(caretAt(moddee, 3))).toBe("moddee!")
+    })
+
+    it("reads the original when the click lands on struck text", () => {
+        const line = revealedLine()
+        const moadea = line.querySelector(".part-removed")!.firstChild!
+        // the corrected "moddee" beside it is not part of the original reading
+        expect(getSelectedWordOrPhrase(caretAt(moadea, 3))).toBe("moadea")
+    })
+})

--- a/CorpusSearch/Controllers/DictionaryController.cs
+++ b/CorpusSearch/Controllers/DictionaryController.cs
@@ -173,10 +173,14 @@ public class DictionaryController(
     /// </summary>
     /// <param name="dict">optional slug: one book's own order. Without it, the
     /// union across every dictionary, in collation order</param>
+    /// <param name="span">complete windows either side to send along, for the
+    /// walk to step through without asking again. Clamped: the span serves a
+    /// reader's tapping hand, not a bulk export.</param>
     [HttpGet("neighbours")]
-    public DictionaryNeighbours Neighbours([FromQuery] string word, [FromQuery] string? dict = null)
+    public DictionaryNeighbours Neighbours([FromQuery] string word,
+        [FromQuery] string? dict = null, [FromQuery] int span = 0)
     {
-        return browseService.Neighbours(dict, word);
+        return browseService.Neighbours(dict, word, Math.Clamp(span, 0, 25));
     }
 
     /// <summary>

--- a/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
+++ b/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
@@ -436,7 +436,13 @@ public class LuceneIndex(IndexWriter indexWriter)
         return new HashSet<DocId>(searcher.AllDocIds(query));
     }
 
-    public ScanResult Scan(SpanQuery query, SpanQuery? referenceQuery = null)
+    /// <param name="checkTranscriptTimings">also answer, per recording, whether
+    /// the matched lines say when they are spoken (<see cref="QueryDocumentResult.Timed"/>):
+    /// the attestation walk's audio link wants a recording it can jump into.
+    /// Off by default — the answer costs a stored-field read per matched line
+    /// of every recording, which a Home page scan has no use for.</param>
+    public ScanResult Scan(SpanQuery query, SpanQuery? referenceQuery = null,
+        bool checkTranscriptTimings = false)
     {
         using var reader = UseReader();
         // tests scan without compacting; production builds the lookup in Compact()
@@ -466,9 +472,20 @@ public class LuceneIndex(IndexWriter indexWriter)
         // sample is the first line by line number: docID order is merge-dependent, so it
         // cannot be relied on (#303)
         var corpusDocuments = new Dictionary<Ident, (DocId SampleDocId, int SampleLineNumber, int Count)>();
+        // the matched lines by corpus document, kept only when the timing
+        // question will be asked of them: a big scan matches too many to hold
+        var matchedLines = checkTranscriptTimings ? new Dictionary<Ident, List<DocId>>() : null;
         foreach (var docId in distinctDocuments.Concat(referenceCounts.Keys))
         {
             var (ident, lineNumber) = lookup.Get(docId);
+            if (matchedLines != null)
+            {
+                if (!matchedLines.TryGetValue(ident, out var lines))
+                {
+                    matchedLines[ident] = lines = [];
+                }
+                lines.Add(docId);
+            }
             var count = referenceCounts.TryGetValue(docId, out var referenceCount)
                 ? referenceCount
                 : spanCollection.GetCount(docId);
@@ -500,16 +517,18 @@ public class LuceneIndex(IndexWriter indexWriter)
             DateTime? endDate = doc.GetDateTime(DOCUMENT_CREATED_END);
 
             var sample = doc.RequireString(DOCUMENT_REAL_MANX);
+            var name = doc.RequireString(DOCUMENT_NAME);
 
             return new QueryDocumentResult
             {
                 Ident = kvp.Key,
-                DocumentName = doc.RequireString(DOCUMENT_NAME),
+                DocumentName = name,
                 Sample = sample,
                 SampleHighlights = ComputeHighlights(reader, sampleDocId, spanQuery.Field, sample,
                     highlightTokenSpans.GetValueOrDefault(sampleDocId)),
                 EndDate = endDate,
                 StartDate = startDate,
+                Timed = TimedOrNull(reader, name, matchedLines?[kvp.Key]),
                 Count = count
             };
         });
@@ -522,6 +541,20 @@ public class LuceneIndex(IndexWriter indexWriter)
             DocumentResults = samples.ToList(),
         };
     }
+
+    private static readonly HashSet<string> SubtitleStartOnly = [SUBTITLE_START];
+
+    /// <summary>Whether the matched lines of a recording (the 🎥 name, as the
+    /// Audio tag reads it) say when they are spoken. A transcript may carry its
+    /// clock on some lines and not others (Skeealyn Vannin Disk 1 Track 2), so
+    /// only *these* lines can answer for the word being jumpable-to. Null for
+    /// print, and when the scan was not asked: reading every matched line of
+    /// the Psalms to answer a question nobody asks of a book would be waste.</summary>
+    private static bool? TimedOrNull(IndexReader reader, string name, List<DocId>? lines) =>
+        lines != null && name.StartsWith("🎥")
+            ? lines.Any(docId =>
+                reader.Document(docId, SubtitleStartOnly).GetDouble(SUBTITLE_START) != null)
+            : null;
 
     public List<DocumentLine> GetAllLines(Ident ident, bool getTranscript)
     {

--- a/CorpusSearch/Dependencies/Searcher.cs
+++ b/CorpusSearch/Dependencies/Searcher.cs
@@ -166,10 +166,14 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
 
     /// <summary>The corpus documents attesting a lexeme, with their dates and counts.
     /// Empty when the word has no lemma reading to search for.</summary>
-    public ScanResult ScanLemma(IReadOnlyCollection<string> lemmaIds)
+    /// <param name="checkTranscriptTimings">also say, per recording, whether the
+    /// lexeme's matched lines carry timestamps (see <see cref="LuceneIndex.Scan"/>)</param>
+    public ScanResult ScanLemma(IReadOnlyCollection<string> lemmaIds, bool checkTranscriptTimings = false)
     {
         var query = LemmaQuery(lemmaIds);
-        return query == null ? new ScanResult() : luceneIndex.Scan(query);
+        return query == null
+            ? new ScanResult()
+            : luceneIndex.Scan(query, checkTranscriptTimings: checkTranscriptTimings);
     }
 
     /// <summary>Every use of a lexeme within one document, surface words highlighted.
@@ -187,24 +191,20 @@ public class Searcher(LuceneIndex luceneIndex, SearchParser parser)
     public List<DocumentLine> AllLines(string ident) =>
         luceneIndex.GetAllLines(ident, getTranscript: false);
 
-    /// <summary>Whether any line of the document says when it is spoken: a
-    /// transcript may be written down without its clock (Skeealyn Vannin Track
-    /// 12), and a player offered such a recording can only start from the top</summary>
-    public bool HasTranscriptTimings(string ident) =>
-        luceneIndex.GetAllLines(ident, getTranscript: true).Any(x => x.SubStart != null);
-
     public ScanResult Scan(string query)
     {
         return Scan(query, SearchOptions.Default);
     }
 
-    public ScanResult Scan(string query, SearchOptions searchOptions)
+    /// <param name="checkTranscriptTimings">also say, per recording, whether the
+    /// query's matched lines carry timestamps (see <see cref="LuceneIndex.Scan"/>)</param>
+    public ScanResult Scan(string query, SearchOptions searchOptions, bool checkTranscriptTimings = false)
     {
         // parse the string into a Result<Expression>
         var parsed = parser.Parse(query);
 
         var (spanQuery, referenceQuery) = BuildQueries(query, parsed, searchOptions);
-        return luceneIndex.Scan(spanQuery, referenceQuery);
+        return luceneIndex.Scan(spanQuery, referenceQuery, checkTranscriptTimings);
     }
 
 

--- a/CorpusSearch/Infrastructure/DictionaryHost.cs
+++ b/CorpusSearch/Infrastructure/DictionaryHost.cs
@@ -1,0 +1,56 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace CorpusSearch.Infrastructure;
+
+/// <summary>
+/// The dictionary's own host (dictionary.gaelg.im), whose front door is the
+/// dictionary landing at "/" (see App.tsx): /dictionary there names the same
+/// page over. The sub-pages stay under /dictionary/, so new corpus routes can
+/// be added without contesting the root. Mirrors the client's utils/Host.ts,
+/// and like it counts any `dictionary.` host, so that dictionary.localhost
+/// tries it on a dev machine without touching DNS.
+/// </summary>
+internal static class DictionaryHost
+{
+    public static bool Is(HttpRequest request) =>
+        request.Host.Host.StartsWith("dictionary.", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Permanently moves the bare /dictionary to "/" on the dictionary host,
+    /// query string and all: one address for the front door, not two.
+    ///
+    /// Sits after the MVC endpoints, so the server-rendered legacy pages
+    /// (/Dictionary/Cregeen) are answered before it and stay where they are.
+    /// Runs in Development too, unlike SpaRouteGuard: the redirect is the
+    /// behaviour, not a production hardening.
+    /// </summary>
+    public static void UseDictionaryHostRootRedirect(this IApplicationBuilder app)
+    {
+        app.Use(async (context, next) =>
+        {
+            var target = RootRedirectTarget(context.Request);
+            if (target != null)
+            {
+                context.Response.Redirect(target, permanent: true);
+                return;
+            }
+            await next(context);
+        });
+    }
+
+    /// <summary>"/" (with the query string riding along) for the dictionary
+    /// host's bare /dictionary — or null where nothing moves: another host, or
+    /// any sub-page, which lives under the prefix on both hosts</summary>
+    internal static string? RootRedirectTarget(HttpRequest request)
+    {
+        var path = request.Path.Value?.TrimEnd('/');
+        if (!Is(request)
+            || !string.Equals(path, "/dictionary", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+        return "/" + request.QueryString.ToUriComponent();
+    }
+}

--- a/CorpusSearch/Model/QueryDocumentResult.cs
+++ b/CorpusSearch/Model/QueryDocumentResult.cs
@@ -10,6 +10,11 @@ public class QueryDocumentResult : Countable
     public DateTime? StartDate { get; set; }
     public DateTime? EndDate { get; set; }
     public int Count { get; set; }
+
+    /// <summary>Whether the matched lines of a recording say when they are spoken.
+    /// Null for print, and unless the scan was asked to look
+    /// (<see cref="Dependencies.Lucene.LuceneIndex.Scan"/>'s checkTranscriptTimings).</summary>
+    public bool? Timed { get; internal set; }
     /// <summary>
     /// A sample of the first manx result.
     /// </summary>

--- a/CorpusSearch/Service/DictionaryAttestationService.cs
+++ b/CorpusSearch/Service/DictionaryAttestationService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -28,19 +27,6 @@ namespace CorpusSearch.Service;
 public class DictionaryAttestationService(
     Searcher searcher, LemmaTable lemmaTable, WorkService workService)
 {
-    /// <summary>Whether a recording's transcript carries timings, by ident —
-    /// remembered, since a transcript's clock does not change under a running
-    /// server. Only recordings are ever asked about (see <see cref="TimedOrNull"/>).</summary>
-    private readonly ConcurrentDictionary<string, bool> timedTranscripts = new();
-
-    /// <summary>Whether the recording's transcript says when its lines are
-    /// spoken — the word page's audio link prefers a recording it can jump
-    /// into. Null for print: reading every line of the Psalms to answer a
-    /// question nobody asks of a book would be waste.</summary>
-    private bool? TimedOrNull(string name, string ident) =>
-        name.StartsWith("🎥")
-            ? timedTranscripts.GetOrAdd(ident, searcher.HasTranscriptTimings)
-            : null;
     /// <summary>The lemma ids whose uses the walk should show. A word that is a
     /// headword itself keeps only its own lexeme: walking 'ass' (out) must not step
     /// through the demutation guess fass, the way
@@ -120,7 +106,7 @@ public class DictionaryAttestationService(
                     Ident = x.Ident,
                     Title = x.DocumentName,
                     Year = x.StartDate!.Value.Year,
-                    Timed = TimedOrNull(x.DocumentName, x.Ident),
+                    Timed = x.Timed,
                     // the scan counts span matches, and an OR over several
                     // readings scores one token once per reading claiming it:
                     // only a lone term can be counted from here without
@@ -138,13 +124,16 @@ public class DictionaryAttestationService(
     /// the first-seen band counts by.</summary>
     private ScanResult ScanFor(string word, IReadOnlyList<string> lemmaIds)
     {
+        // timings ride along: the walk's audio link needs to know which
+        // recordings it could jump into (AttestationDocument.Timed)
         if (lemmaIds.Count > 0)
         {
-            return searcher.ScanLemma(lemmaIds);
+            return searcher.ScanLemma(lemmaIds, checkTranscriptTimings: true);
         }
         try
         {
-            return searcher.Scan(CorpusQueryFor(word));
+            return searcher.Scan(CorpusQueryFor(word), SearchOptions.Default,
+                checkTranscriptTimings: true);
         }
         catch (Exception)
         {
@@ -331,9 +320,11 @@ public class AttestationDocument
     public required string Title { get; set; }
     public int Year { get; set; }
 
-    /// <summary>Whether the recording's transcript says when its lines are
-    /// spoken (Skeealyn Vannin Track 12's does not, and a player can only
-    /// start it from the top). Null for anything that is not a recording.</summary>
+    /// <summary>Whether the word's uses in the recording say when they are
+    /// spoken. A transcript may carry its clock on some lines and not others
+    /// (Skeealyn Vannin Disk 1 Track 2 is timed, but its one use of 'geddyn'
+    /// is not), and a player can only jump to a use with a timestamp. Null
+    /// for anything that is not a recording.</summary>
     public bool? Timed { get; set; }
 
     /// <summary>

--- a/CorpusSearch/Service/DictionaryBrowse.cs
+++ b/CorpusSearch/Service/DictionaryBrowse.cs
@@ -204,4 +204,13 @@ public class DictionaryNeighbours
     /// says. Null when there is none left in that direction.</summary>
     public string? PreviousUsed { get; set; }
     public string? NextUsed { get; set; }
+
+    /// <summary>The complete windows of the nearest pages either side, when a
+    /// span was asked for: previous pages nearest-first, then next pages
+    /// nearest-first, each carrying its own arrows and skips. The walk's
+    /// client steps through these without asking again, so a reader tapping
+    /// faster than a round trip is never stopped. Empty without a span, and
+    /// for a word that is not a headword (its first step lands on one, whose
+    /// own answer brings a span).</summary>
+    public List<DictionaryNeighbours> Nearby { get; set; } = [];
 }

--- a/CorpusSearch/Service/DictionaryBrowseService.cs
+++ b/CorpusSearch/Service/DictionaryBrowseService.cs
@@ -18,6 +18,17 @@ public class DictionaryBrowseService(
 
     private readonly ISearchDictionary[] dictionaries = dictionaryServices.ToArray();
 
+    /// <summary>The cross-dictionary union in collation order, built once: the
+    /// headword lists are fixed at deploy, and the walk's prefetching client
+    /// asks for neighbours three windows at a time — re-sorting a hundred
+    /// thousand headwords per request would be the cost of every word page</summary>
+    private readonly Lazy<List<string>> unionHeadwords = new(() => dictionaryServices
+        .Where(x => x.QueryLanguages.Contains("gv"))
+        .SelectMany(x => x.Headwords)
+        .Distinct(StringComparer.InvariantCultureIgnoreCase)
+        .OrderBy(DictionaryBrowse.CollationKey, StringComparer.Ordinal)
+        .ToList());
+
     public ISearchDictionary? Find(string slug) =>
         dictionaries.FirstOrDefault(x =>
             string.Equals(x.Slug, slug, StringComparison.OrdinalIgnoreCase));
@@ -161,7 +172,10 @@ public class DictionaryBrowseService(
     /// across all of them it is the union in collation order, which is nobody's
     /// printed order but is the only one they can share.
     /// </summary>
-    public DictionaryNeighbours Neighbours(string? slug, string word)
+    /// <param name="span">how many complete windows either side to send along
+    /// (<see cref="DictionaryNeighbours.Nearby"/>): the walk's client steps
+    /// through them without asking again. 0 keeps the answer to the word's own.</param>
+    public DictionaryNeighbours Neighbours(string? slug, string word, int span = 0)
     {
         List<string> ordered;
         if (string.Equals(slug, SpokenSlug, StringComparison.OrdinalIgnoreCase))
@@ -183,12 +197,7 @@ public class DictionaryBrowseService(
                 ? scope.Headwords.ToList()
                 // no book's order can be kept across books, so the union takes the
                 // reader's: a word in several dictionaries is one step, not three
-                : dictionaries
-                    .Where(x => x.QueryLanguages.Contains("gv"))
-                    .SelectMany(x => x.Headwords)
-                    .Distinct(StringComparer.InvariantCultureIgnoreCase)
-                    .OrderBy(DictionaryBrowse.CollationKey, StringComparer.Ordinal)
-                    .ToList();
+                : unionHeadwords.Value;
         }
         if (ordered.Count == 0)
         {
@@ -199,25 +208,9 @@ public class DictionaryBrowseService(
             string.Equals(x, word, StringComparison.InvariantCultureIgnoreCase));
         if (at >= 0)
         {
-            // a step to a headword spelled as this one is a step to where you
-            // already are: the URL is the spelling, so Cregeen's two 'baare' and
-            // Kelly's five 'A' are each one page, however many entries they are
-            var back = Step(ordered, at, -1, word, used: false);
-            var forward = Step(ordered, at, +1, word, used: false);
-            return new DictionaryNeighbours
-            {
-                Word = word,
-                Attested = vocabulary.IsAttested(word),
-                Previous = back,
-                PreviousAttested = back != null && vocabulary.IsAttested(back),
-                Next = forward,
-                NextAttested = forward != null && vocabulary.IsAttested(forward),
-                // the nearest word either side the corpus uses is rarely the one
-                // next door: stepping through Phil Kelly one headword at a time
-                // walks a long way through words no text says
-                PreviousUsed = Step(ordered, at, -1, word, used: true),
-                NextUsed = Step(ordered, at, +1, word, used: true),
-            };
+            var window = WindowAt(ordered, at, word);
+            window.Nearby = NearbyWindows(ordered, at, word, span);
+            return window;
         }
 
         // not a headword: file it, and take the entries it would sit between.
@@ -288,6 +281,14 @@ public class DictionaryBrowseService(
     /// </summary>
     private string? Step(List<string> ordered, int at, int step, string word, bool used)
     {
+        var found = StepIndex(ordered, at, step, word, used);
+        return found < 0 ? null : ordered[found];
+    }
+
+    /// <summary>As <see cref="Step"/>, but saying where the page found sits:
+    /// the span walk steps on from it. -1 where there is nothing left.</summary>
+    private int StepIndex(List<string> ordered, int at, int step, string word, bool used)
+    {
         for (var i = at + step; i >= 0 && i < ordered.Count; i += step)
         {
             if (string.Equals(ordered[i], word, StringComparison.InvariantCultureIgnoreCase))
@@ -296,9 +297,64 @@ public class DictionaryBrowseService(
             }
             if (!used || vocabulary.IsAttested(ordered[i]))
             {
-                return ordered[i];
+                return i;
             }
         }
-        return null;
+        return -1;
+    }
+
+    /// <summary>The whole window of the page at <paramref name="at"/>: its
+    /// arrows, their attestation, and the skips to the nearest words the
+    /// corpus uses. A step to a headword spelled as this one is a step to
+    /// where you already are — the URL is the spelling, so Cregeen's two
+    /// 'baare' and Kelly's five 'A' are each one page, however many entries
+    /// they are.</summary>
+    /// <param name="word">the page's display spelling: the requested word for
+    /// the centre window, the headword itself for a nearby one</param>
+    private DictionaryNeighbours WindowAt(List<string> ordered, int at, string word)
+    {
+        var back = Step(ordered, at, -1, word, used: false);
+        var forward = Step(ordered, at, +1, word, used: false);
+        return new DictionaryNeighbours
+        {
+            Word = word,
+            Attested = vocabulary.IsAttested(word),
+            Previous = back,
+            PreviousAttested = back != null && vocabulary.IsAttested(back),
+            Next = forward,
+            NextAttested = forward != null && vocabulary.IsAttested(forward),
+            // the nearest word either side the corpus uses is rarely the one
+            // next door: stepping through Phil Kelly one headword at a time
+            // walks a long way through words no text says
+            PreviousUsed = Step(ordered, at, -1, word, used: true),
+            NextUsed = Step(ordered, at, +1, word, used: true),
+        };
+    }
+
+    /// <summary>The complete windows of up to <paramref name="span"/> pages
+    /// either side of <paramref name="at"/>, walked the way the arrows walk:
+    /// page by distinct page, so a run of same-spelled headwords is one step
+    /// here as it is there. Previous pages first, each side nearest-first.</summary>
+    private List<DictionaryNeighbours> NearbyWindows(
+        List<string> ordered, int at, string word, int span)
+    {
+        var windows = new List<DictionaryNeighbours>();
+        foreach (var direction in (int[]) [-1, +1])
+        {
+            var from = at;
+            var page = word;
+            for (var taken = 0; taken < span; taken++)
+            {
+                var found = StepIndex(ordered, from, direction, page, used: false);
+                if (found < 0)
+                {
+                    break;
+                }
+                page = ordered[found];
+                windows.Add(WindowAt(ordered, found, page));
+                from = found;
+            }
+        }
+        return windows;
     }
 }

--- a/CorpusSearch/Startup.cs
+++ b/CorpusSearch/Startup.cs
@@ -235,6 +235,10 @@ public class Startup(IConfiguration configuration)
                 pattern: "{controller}/{action=Index}/{id?}");
         });
 
+        // the dictionary host's front door is "/": its bare /dictionary
+        // permanently redirects there (see DictionaryHost)
+        app.UseDictionaryHostRootRedirect();
+
         if (!env.IsDevelopment())
         {
             // URLs which are neither a server route nor a SPA page must 404 rather


### PR DESCRIPTION
Two default-selection fixes, a walk responsiveness fix, the subdomain's front door, keyboard submit, and test coverage for the corrected-line rendering.

## Audio popup no longer defaults to a recording it cannot cue
  
The walk's `Timed` flag answered for the whole transcript, so a partially timed recording (Skeealyn Vannin Disk 1 Track 2, timed elsewhere but not at its one use of "geddyn") led the listening popup and showed a lone ??:?? row, while 14 recordings with real timestamps sat behind the arrows. The scan now checks the matched lines themselves, one stored field at a time with an early exit, and only when asked: the Home page scan pays nothing. Untimed lines and recordings still display exactly as before, ??:?? and all; only the default changed.

## The landing bolds no book

The letters row marked Cregeen active on the landing page, but the active mark is the browse pages' "you are here": on a landing that has selected nothing, a bolded Cregeen read as a selection already made.

## The subdomain's LP is its root

dictionary.gaelg.im/dictionary named the landing the subdomain already names: the bare /dictionary now permanently redirects to "/" there, query string and all. Sub-pages stay under /dictionary/, leaving the root free for future routes; the corpus host and the server-rendered legacy pages (/Dictionary/Cregeen) are untouched. The redirect keys on the Host header, which Cloudflare passes through by default.

  ## The walk's arrows keep up with a brisk reader

The headword row rode out each step showing the last page's window, whose "next" was the page already on screen: a tap on it went nowhere until the fetch landed. Each answer now carries the complete windows of the five pages either side (`?span=`), walked page by distinct page the way the arrows walk — Cregeen's twin "baare" is one step in the span as it is on screen, and every window brings its own attested flags and skip targets. The client steps through the span from memory and re-centres it in the background as the reader nears its edge, so a tapping hand is never stopped; a jump outside the span still re-points the arrow back at the page just left. The cross-dictionary union is built once on the server instead of re-sorting ~100k headwords per request (96ms → ~3ms on repeat calls).

## Cmd/Ctrl+Enter sends the suggestion form
  
From either field; Enter alone stays a newline in the textarea.

## Tests for the corrected line

Covers the inline character diff, the rewritten word's ± chip, highlight offsets against the corrected text, and what a click selects among struck and corrected words.

## Verification

- Server: 717 tests passing, including new coverage for per-word timing semantics, the landing redirect, and the span walk (contents and ordering, book-end bounds, twin-headword collapse)
- Client: 359 tests passing, including keyboard submit, the unmarked landing row, and the walk's memory, mid-step re-pointing and re-centring
- Redirect behaviour probed with curl against both hostnames on a Production boot; the span verified live ("geddyn": three correctly chained windows each side in ~6ms); the mid-step back arrow verified in a real browser with the neighbours endpoint stalled.