### PR TITLE
fix(dictionary): ignore query string in subdomain redirect

### DIFF
--- a/CorpusSearch.Test/DictionaryHostTest.cs
+++ b/CorpusSearch.Test/DictionaryHostTest.cs
@@ -31,13 +31,16 @@ public class DictionaryHostTest
             Is.EqualTo("/"));
     }
 
+    /// <summary>The query string is dropped, not carried: the landing reads no
+    /// query parameters, and a Location reflecting request data is an
+    /// open-redirect shape a constant target does not have</summary>
     [Test]
-    public void TheQueryStringRidesAlong()
+    public void TheQueryStringDoesNotRideAlong()
     {
         Assert.That(
             DictionaryHost.RootRedirectTarget(
                 Request("dictionary.gaelg.im", "/dictionary", "?q=geddyn")),
-            Is.EqualTo("/?q=geddyn"));
+            Is.EqualTo("/"));
     }
 
     // the sub-pages stay under the prefix on both hosts, and the corpus host

--- a/CorpusSearch/Infrastructure/DictionaryHost.cs
+++ b/CorpusSearch/Infrastructure/DictionaryHost.cs
@@ -18,8 +18,8 @@ internal static class DictionaryHost
         request.Host.Host.StartsWith("dictionary.", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Permanently moves the bare /dictionary to "/" on the dictionary host,
-    /// query string and all: one address for the front door, not two.
+    /// Permanently moves the bare /dictionary to "/" on the dictionary host:
+    /// one address for the front door, not two.
     ///
     /// Sits after the MVC endpoints, so the server-rendered legacy pages
     /// (/Dictionary/Cregeen) are answered before it and stay where they are.
@@ -40,9 +40,15 @@ internal static class DictionaryHost
         });
     }
 
-    /// <summary>"/" (with the query string riding along) for the dictionary
-    /// host's bare /dictionary — or null where nothing moves: another host, or
-    /// any sub-page, which lives under the prefix on both hosts</summary>
+    /// <summary>"/" for the dictionary host's bare /dictionary — or null where
+    /// nothing moves: another host, or any sub-page, which lives under the
+    /// prefix on both hosts.
+    ///
+    /// The query string is dropped, not carried: the landing reads no query
+    /// parameters, so there is nothing to lose — and a Location built from
+    /// request data is an open-redirect shape
+    /// (CodeQL cs/web/unvalidated-url-redirection), where a constant is
+    /// provably not.</summary>
     internal static string? RootRedirectTarget(HttpRequest request)
     {
         var path = request.Path.Value?.TrimEnd('/');
@@ -51,6 +57,6 @@ internal static class DictionaryHost
         {
             return null;
         }
-        return "/" + request.QueryString.ToUriComponent();
+        return "/";
     }
 }


### PR DESCRIPTION
The landing reads no query parameters, and this fixes an open redirect issue.

(CodeQL cs/web/unvalidated-url-redirection).