### PR TITLE
fix(dictionary): 'crank'

### DIFF
--- a/CorpusSearch.Test/DictionaryAttestationServiceTest.cs
+++ b/CorpusSearch.Test/DictionaryAttestationServiceTest.cs
@@ -158,9 +158,11 @@ public class DictionaryAttestationServiceTest : QueryBase
     }
 
     /// <summary>'daase' carries only the verb, so the verb's group holds both
-    /// lines while the noun's holds one: each reading shows what it claims</summary>
+    /// lines while the noun's holds one: each reading shows what it claims.
+    /// 'aase' is also faase.a demutated, so its line is offered after the
+    /// settled daase line, whatever order the document wrote them in.</summary>
     [Test]
-    public void EveryUseInADocumentIsReturnedInLineOrder()
+    public void EveryUseInADocumentIsReturnedSettledFirst()
     {
         AddDated("Doc", 1748, "Ta mee aase", "Cha nel eh", "Daase yn billey");
 
@@ -174,8 +176,8 @@ public class DictionaryAttestationServiceTest : QueryBase
             // counted twice for being claimed by both the noun and the verb
             Assert.That(found.UseCount, Is.EqualTo(2));
             Assert.That(verb.Lines.Select(x => x.Manx),
-                Is.EqualTo(new[] { "Ta mee aase", "Daase yn billey" }));
-            Assert.That(verb.Lines.Select(x => x.CsvLineNumber), Is.Ordered);
+                Is.EqualTo(new[] { "Daase yn billey", "Ta mee aase" }));
+            Assert.That(verb.UncertainLineNumbers, Is.EqualTo(new[] { 2 }));
         });
     }
 
@@ -246,6 +248,26 @@ public class DictionaryAttestationServiceTest : QueryBase
             Assert.That(walk.Documents.Single(x => x.Ident == "🎥 Timed").Timed, Is.True);
             Assert.That(walk.Documents.Single(x => x.Ident == "🎥 Untimed").Timed, Is.False);
             Assert.That(walk.Documents.Single(x => x.Ident == "Print").Timed, Is.Null);
+        });
+    }
+
+    /// <summary>The settled lines lead a step's sample: 'cronk' is shared with
+    /// cronk.n (the hill) and unsettled, while 'crank' can only be this word.
+    /// A document in the known walk must not open on the occurrences its
+    /// potential twin holds, however early in the text they come.</summary>
+    [Test]
+    public void TheSettledLinesLeadTheSample()
+    {
+        AddDated("Doc", 1819, "ayns cronk Seir", "va crank ayn");
+
+        var found = Service().InDocument("crank", "Doc").Result!;
+        var noun = found.Groups.Single(x => x.LemmaIds.Contains("crank.n"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(noun.Lines.Select(x => x.Manx),
+                Is.EqualTo(new[] { "va crank ayn", "ayns cronk Seir" }));
+            Assert.That(noun.UncertainLineNumbers, Is.EqualTo(new[] { 2 }));
         });
     }
 

--- a/CorpusSearch/ClientApp/src/components/AttestationWalker.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/AttestationWalker.test.tsx
@@ -394,11 +394,14 @@ describe("AttestationWalker", () => {
         expect(line.textContent).toBe("Daase yn billey▶ 0:12")
         fireEvent.click(line)
 
-        expect(
-            (
-                await screen.findByRole("link", { name: "Full document ›" })
-            ).getAttribute("href"),
-        ).toBe("/docs/Psalms1610?line=2")
+        // the link exists before the popup's lines arrive and only then cues
+        // the tapped line: the href is awaited, not the link alone
+        const full = await screen.findByRole("link", {
+            name: "Full document ›",
+        })
+        await waitFor(() =>
+            expect(full.getAttribute("href")).toBe("/docs/Psalms1610?line=2"),
+        )
     })
 
     it("offers no play link where the text is not a recording", async () => {
@@ -420,11 +423,14 @@ describe("AttestationWalker", () => {
         expect(line.textContent).toBe("Daase yn billey▶ ??:??")
         fireEvent.click(line)
 
-        expect(
-            (
-                await screen.findByRole("link", { name: "Full document ›" })
-            ).getAttribute("href"),
-        ).toBe("/docs/Psalms1610?line=2")
+        // the link exists before the popup's lines arrive and only then cues
+        // the tapped line: the href is awaited, not the link alone
+        const full = await screen.findByRole("link", {
+            name: "Full document ›",
+        })
+        await waitFor(() =>
+            expect(full.getAttribute("href")).toBe("/docs/Psalms1610?line=2"),
+        )
     })
 
     it("offers an audio tab when recordings use the word", async () => {
@@ -558,22 +564,38 @@ describe("AttestationWalker", () => {
     })
 
     it("offers rather than asserts the potential walk's steps", async () => {
-        respondWithDocuments([
-            {
-                ident: "Psalms1610",
-                title: "Psalms",
-                year: 1610,
-                uses: 9,
-                sureUses: 0,
-            },
-            {
-                ident: "Coyrle",
-                title: "Coyrle Sodjey",
-                year: 1707,
-                uses: 3,
-                sureUses: 3,
-            },
+        const offered = withGroups(9, [
+            { sureCount: 0, uncertainLineNumbers: [2] },
         ])
+        fetchMock.mockImplementation((url) =>
+            Promise.resolve({
+                ok: true,
+                json: () =>
+                    Promise.resolve(
+                        hrefOf(url).includes("/attestations/")
+                            ? offered
+                            : {
+                                  ...walk,
+                                  documents: [
+                                      {
+                                          ident: "Psalms1610",
+                                          title: "Psalms",
+                                          year: 1610,
+                                          uses: 9,
+                                          sureUses: 0,
+                                      },
+                                      {
+                                          ident: "Coyrle",
+                                          title: "Coyrle Sodjey",
+                                          year: 1707,
+                                          uses: 3,
+                                          sureUses: 3,
+                                      },
+                                  ],
+                              },
+                    ),
+            } as Response),
+        )
         renderWalker("aase", "?potential=1")
         await screen.findByText("Daase")
 
@@ -584,6 +606,67 @@ describe("AttestationWalker", () => {
         expect(row?.querySelector("abbr")?.getAttribute("title")).toBe(
             "Only as a spelling shared with another word: these occurrences may not be this one",
         )
+    })
+
+    it("walks a text holding both kinds in both walks, each showing its own", async () => {
+        // the Bible's cronkal is settled, its cronk hills are not: the known
+        // step shows the settled row and counts 4, the potential step shows
+        // the offered row and counts the rest
+        const both = withGroups(172, [
+            { lemmaIds: ["crank.v"], count: 4, sureCount: 4 },
+            {
+                lemmaIds: ["crank.n"],
+                count: 168,
+                sureCount: 0,
+                lines: [
+                    {
+                        manx: "ayns cronk Seir",
+                        english: "",
+                        manxHighlights: [],
+                        csvLineNumber: 9,
+                    },
+                ],
+                uncertainLineNumbers: [9],
+                sharedWith: ["cronk"],
+            },
+        ])
+        const respondBoth = (search = "") =>
+            fetchMock.mockImplementation((url) =>
+                Promise.resolve({
+                    ok: true,
+                    json: () =>
+                        Promise.resolve(
+                            hrefOf(url).includes("/attestations/")
+                                ? both
+                                : {
+                                      ...walk,
+                                      documents: [
+                                          {
+                                              ident: "Bible",
+                                              title: "Bible",
+                                              year: 1819,
+                                              uses: 172,
+                                              sureUses: 4,
+                                          },
+                                      ],
+                                  },
+                        ),
+                } as Response),
+            ) && renderWalker("crank", search)
+
+        respondBoth()
+        await screen.findByText("Daase")
+        // the known step: the settled row, its count, and no hills
+        expect(screen.getByText(/· 4 uses/)).toBeTruthy()
+        expect(screen.queryByText("ayns cronk Seir")).toBeNull()
+        cleanup()
+        fetchMock.mockReset()
+
+        respondBoth("?potential=1")
+        await screen.findByText("ayns cronk Seir")
+        // the potential step: the offered row, the remainder counted
+        expect(screen.getByText(/· 168 uses/)).toBeTruthy()
+        expect(screen.queryByText("Daase")).toBeNull()
     })
 
     it("keeps one walk when nothing is settled", async () => {

--- a/CorpusSearch/ClientApp/src/components/AttestationWalker.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/AttestationWalker.test.tsx
@@ -525,9 +525,10 @@ describe("AttestationWalker", () => {
         )
     })
 
-    it("offers rather than asserts a step held only as shared spellings", async () => {
+    it("keeps a step held only as shared spellings out of the known walk", async () => {
         // Psalms holds the word solely as spellings another lexeme also uses:
-        // the step stays in the walk, muted, and the mark carries the doubt
+        // the known walk opens at the settled text, and the offer waits
+        // behind its own tab (cronk 'hill' must not open crank's walk)
         respondWithDocuments([
             {
                 ident: "Psalms1610",
@@ -547,11 +548,69 @@ describe("AttestationWalker", () => {
         renderWalker()
         await screen.findByText("Daase")
 
+        expect(screen.getByText("Coyrle Sodjey")).toBeTruthy()
+        expect(document.querySelector(".attest-step-uncertain")).toBeNull()
+        expect(
+            screen
+                .getByRole("link", { name: "potential ×1" })
+                .getAttribute("href"),
+        ).toBe("/dictionary/aase?potential=1")
+    })
+
+    it("offers rather than asserts the potential walk's steps", async () => {
+        respondWithDocuments([
+            {
+                ident: "Psalms1610",
+                title: "Psalms",
+                year: 1610,
+                uses: 9,
+                sureUses: 0,
+            },
+            {
+                ident: "Coyrle",
+                title: "Coyrle Sodjey",
+                year: 1707,
+                uses: 3,
+                sureUses: 3,
+            },
+        ])
+        renderWalker("aase", "?potential=1")
+        await screen.findByText("Daase")
+
+        // the offered text is the step, muted, the mark carrying the doubt
+        expect(screen.getByText("Psalms")).toBeTruthy()
         const row = document.querySelector(".attest-step-uncertain")
         expect(row).toBeTruthy()
         expect(row?.querySelector("abbr")?.getAttribute("title")).toBe(
             "Only as a spelling shared with another word: these occurrences may not be this one",
         )
+    })
+
+    it("keeps one walk when nothing is settled", async () => {
+        respondWithDocuments([
+            {
+                ident: "Psalms1610",
+                title: "Psalms",
+                year: 1610,
+                uses: 9,
+                sureUses: 0,
+            },
+            {
+                ident: "Coyrle",
+                title: "Coyrle Sodjey",
+                year: 1707,
+                uses: 3,
+                sureUses: 0,
+            },
+        ])
+        renderWalker()
+        await screen.findByText("Daase")
+
+        // nothing to step apart from: no tab, and the single walk still
+        // opens at the earliest text, marked
+        expect(screen.queryByText(/potential ×/)).toBeNull()
+        expect(screen.getByText("Psalms")).toBeTruthy()
+        expect(document.querySelector(".attest-step-uncertain")).toBeTruthy()
     })
 
     it("leaves a settled step unmarked", async () => {

--- a/CorpusSearch/ClientApp/src/components/AttestationWalker.tsx
+++ b/CorpusSearch/ClientApp/src/components/AttestationWalker.tsx
@@ -180,62 +180,64 @@ const LemmaGroup = ({
     audio: boolean
     /** opens the listening popup at a tapped use's line */
     onPlay: (csvLineNumber: number) => void
-}) => (
-    <div className="attest-group">
-        <p className="attest-group-head">
-            <em className="attest-group-lemma">{group.lemma}</em>
-            {classes && (
-                <span className="attest-group-class">{` ${classes}`}</span>
-            )}
-            <span className="attest-group-count">
-                {` ×${group.count.toLocaleString()}`}
-            </span>
-        </p>
-        <div className="attest-group-lines">
-            {group.lines.map((line) => (
-                <UseLine
-                    key={line.csvLineNumber}
-                    manx={line.manx}
-                    english={line.english}
-                    highlights={line.manxHighlights}
-                    // a line the resolver has not settled wears the mark,
-                    // naming the other headwords its spelling answers to:
-                    // the occurrence is offered to this row, not proven its
-                    mark={
-                        group.uncertainLineNumbers.includes(
-                            line.csvLineNumber,
-                        ) ? (
-                            <SharedMark
-                                title={
-                                    group.sharedWith.length > 0
-                                        ? `This spelling is shared with another word (${group.sharedWith.join(", ")}): the occurrence may not be this one`
-                                        : undefined
-                                }
-                            />
-                        ) : undefined
-                    }
-                    play={
-                        audio || line.subStart != null
-                            ? {
-                                  at: line.subStart ?? null,
-                                  open: () => onPlay(line.csvLineNumber),
-                              }
-                            : undefined
-                    }
-                />
-            ))}
-            {group.count > group.lines.length && (
-                <p className="attest-more">
-                    <Link
-                        to={`/docs/${ident}?q=${encodeURIComponent(group.lemma)}`}
-                    >
-                        {`All ${plural(group.count, "use", "uses")} in this text ›`}
-                    </Link>
-                </p>
-            )}
+}) => {
+    return (
+        <div className="attest-group">
+            <p className="attest-group-head">
+                <em className="attest-group-lemma">{group.lemma}</em>
+                {classes && (
+                    <span className="attest-group-class">{` ${classes}`}</span>
+                )}
+                <span className="attest-group-count">
+                    {` ×${group.count.toLocaleString()}`}
+                </span>
+            </p>
+            <div className="attest-group-lines">
+                {group.lines.map((line) => (
+                    <UseLine
+                        key={line.csvLineNumber}
+                        manx={line.manx}
+                        english={line.english}
+                        highlights={line.manxHighlights}
+                        // a line the resolver has not settled wears the mark,
+                        // naming the other headwords its spelling answers to:
+                        // the occurrence is offered to this row, not proven its
+                        mark={
+                            group.uncertainLineNumbers.includes(
+                                line.csvLineNumber,
+                            ) ? (
+                                <SharedMark
+                                    title={
+                                        group.sharedWith.length > 0
+                                            ? `This spelling is shared with another word (${group.sharedWith.join(", ")}): the occurrence may not be this one`
+                                            : undefined
+                                    }
+                                />
+                            ) : undefined
+                        }
+                        play={
+                            audio || line.subStart != null
+                                ? {
+                                      at: line.subStart ?? null,
+                                      open: () => onPlay(line.csvLineNumber),
+                                  }
+                                : undefined
+                        }
+                    />
+                ))}
+                {group.count > group.lines.length && (
+                    <p className="attest-more">
+                        <Link
+                            to={`/docs/${ident}?q=${encodeURIComponent(group.lemma)}`}
+                        >
+                            {`All ${plural(group.count, "use", "uses")} in this text ›`}
+                        </Link>
+                    </p>
+                )}
+            </div>
         </div>
-    </div>
-)
+    )
+}
 
 /** What the section holds, readable while it is shut — and only what is
  * settled may say so. With sure counts in hand, the count and the range are
@@ -395,15 +397,20 @@ export const AttestationWalker = ({
     const audioTab = params.get("audio") != null && audioDocs.length > 0
 
     // the walk in two: texts holding a settled use are known matches, and
-    // texts holding the word only as spellings another lexeme also writes are
-    // potential matches, stepped apart so they cannot head the word's history
-    // (cronk 'hill' must not open crank's walk). The split engages only where
-    // the walk knows the difference and each side has something to step; a
-    // spelling walk sends no sure counts and keeps its single walk.
+    // every unsettled occurrence — a spelling another lexeme also writes — is
+    // a potential match, stepped apart so it cannot head the word's history
+    // (cronk 'hill' must not open crank's walk). A text holding both kinds
+    // walks in both: the Bible's cronkal is known, its cronk hills potential.
+    // The split engages only where the walk knows the difference and each
+    // side has something to step; a spelling walk sends no sure counts and
+    // keeps its single walk.
     const knownDocs =
         walk?.documents.filter((d) => d.sureUses != null && d.sureUses > 0) ??
         []
-    const potentialDocs = walk?.documents.filter((d) => d.sureUses === 0) ?? []
+    const potentialDocs =
+        walk?.documents.filter(
+            (d) => d.sureUses != null && d.uses != null && d.uses > d.sureUses,
+        ) ?? []
     const splitWalk = knownDocs.length > 0 && potentialDocs.length > 0
     // the potential tab is open: the walk steps the offered texts alone
     const potentialTab =
@@ -713,13 +720,13 @@ export const AttestationWalker = ({
                                     : null
                             }
                         >
-                            {/* a step held only as shared spellings is
-                                offered, not asserted: muted, and the mark
-                                carries the doubt. Null sure counts are a
-                                spelling walk's, and hedge nothing. */}
+                            {/* a step of offered occurrences is not asserted:
+                                muted, and the mark carries the doubt. Null
+                                sure counts are a spelling walk's, and hedge
+                                nothing. */}
                             <span
                                 className={
-                                    current.sureUses === 0
+                                    potentialTab || current.sureUses === 0
                                         ? "attest-step-uncertain"
                                         : undefined
                                 }
@@ -735,10 +742,23 @@ export const AttestationWalker = ({
                                 </Link>
                                 {/* the walk's own count where it has one, so it
                                     is there as you arrive; otherwise the document's
-                                    own, once counted from the offsets */}
+                                    own, once counted from the offsets. On a split
+                                    walk the step counts its own tab's kind: the
+                                    Bible is 4 known uses, or its 168 offered */}
                                 {current.uses != null ? (
                                     <span className="attest-count">
-                                        {` · ${plural(current.uses, "use", "uses")}`}
+                                        {` · ${plural(
+                                            splitWalk &&
+                                                !audioTab &&
+                                                current.sureUses != null
+                                                ? potentialTab
+                                                    ? current.uses -
+                                                      current.sureUses
+                                                    : current.sureUses
+                                                : current.uses,
+                                            "use",
+                                            "uses",
+                                        )}`}
                                     </span>
                                 ) : (
                                     fresh && (
@@ -747,7 +767,7 @@ export const AttestationWalker = ({
                                         </span>
                                     )
                                 )}
-                                {current.sureUses === 0 && (
+                                {(potentialTab || current.sureUses === 0) && (
                                     <SharedMark title={OFFERED_TITLE} />
                                 )}
                             </span>
@@ -759,33 +779,47 @@ export const AttestationWalker = ({
                             // dimmed while they are the step before's: the shape
                             // of the section holds, so the arrows stay put
                             <div className={fresh ? undefined : "attest-stale"}>
-                                {lines.groups.map((group) => (
-                                    <LemmaGroup
-                                        // a row with no readings is a spelling,
-                                        // and there is only ever one of those
-                                        key={
-                                            group.lemmaIds.join(" ") ||
-                                            group.lemma
-                                        }
-                                        group={group}
-                                        classes={classLabelFor(
-                                            group,
-                                            lines.groups,
-                                        )}
-                                        ident={lines.ident}
-                                        audio={lines.title.startsWith("🎥")}
-                                        onPlay={(csvLineNumber) =>
-                                            setHeard({
-                                                doc: {
-                                                    ident: lines.ident,
-                                                    title: lines.title,
-                                                    year: lines.year,
-                                                },
-                                                at: csvLineNumber,
-                                            })
-                                        }
-                                    />
-                                ))}
+                                {/* each tab shows its own kind: the known walk
+                                    the settled rows, the potential tab the rows
+                                    with nothing settled — the Bible's cronk
+                                    hills belong under potential, never under
+                                    crank's known step */}
+                                {lines.groups
+                                    .filter((group) =>
+                                        !splitWalk || audioTab
+                                            ? true
+                                            : potentialTab
+                                              ? group.sureCount === 0
+                                              : group.sureCount > 0,
+                                    )
+                                    .map((group) => (
+                                        <LemmaGroup
+                                            // a row with no readings is a spelling,
+                                            // and there is only ever one of those;
+                                            // the step's ident keys a fresh mount
+                                            key={`${lines.ident} ${
+                                                group.lemmaIds.join(" ") ||
+                                                group.lemma
+                                            }`}
+                                            group={group}
+                                            classes={classLabelFor(
+                                                group,
+                                                lines.groups,
+                                            )}
+                                            ident={lines.ident}
+                                            audio={lines.title.startsWith("🎥")}
+                                            onPlay={(csvLineNumber) =>
+                                                setHeard({
+                                                    doc: {
+                                                        ident: lines.ident,
+                                                        title: lines.title,
+                                                        year: lines.year,
+                                                    },
+                                                    at: csvLineNumber,
+                                                })
+                                            }
+                                        />
+                                    ))}
                             </div>
                         )}
 

--- a/CorpusSearch/ClientApp/src/components/AttestationWalker.tsx
+++ b/CorpusSearch/ClientApp/src/components/AttestationWalker.tsx
@@ -393,7 +393,28 @@ export const AttestationWalker = ({
     // ?audio= on a word no recording says falls back to the whole walk, the
     // way a garbage ?reading= does.
     const audioTab = params.get("audio") != null && audioDocs.length > 0
-    const documents = audioTab ? audioDocs : (walk?.documents ?? [])
+
+    // the walk in two: texts holding a settled use are known matches, and
+    // texts holding the word only as spellings another lexeme also writes are
+    // potential matches, stepped apart so they cannot head the word's history
+    // (cronk 'hill' must not open crank's walk). The split engages only where
+    // the walk knows the difference and each side has something to step; a
+    // spelling walk sends no sure counts and keeps its single walk.
+    const knownDocs =
+        walk?.documents.filter((d) => d.sureUses != null && d.sureUses > 0) ??
+        []
+    const potentialDocs = walk?.documents.filter((d) => d.sureUses === 0) ?? []
+    const splitWalk = knownDocs.length > 0 && potentialDocs.length > 0
+    // the potential tab is open: the walk steps the offered texts alone
+    const potentialTab =
+        params.get("potential") != null && splitWalk && !audioTab
+    const documents = audioTab
+        ? audioDocs
+        : potentialTab
+          ? potentialDocs
+          : splitWalk
+            ? knownDocs
+            : (walk?.documents ?? [])
 
     // no step named: the walk starts at the word's first attestation
     const index = Math.max(
@@ -486,6 +507,9 @@ export const AttestationWalker = ({
         if (audioTab) {
             query.set("audio", "1")
         }
+        if (potentialTab) {
+            query.set("potential", "1")
+        }
         query.set("at", ident)
         return `${pathname}?${query.toString()}`
     }
@@ -497,6 +521,16 @@ export const AttestationWalker = ({
             query.set("reading", reading)
         }
         query.set("audio", "1")
+        return `${pathname}?${query.toString()}`
+    }
+    /** the potential tab's own address: same reading, no step — the offered
+     * texts are walked from the earliest, like a walk newly opened */
+    const potentialTabTo = () => {
+        const query = new URLSearchParams()
+        if (reading != null) {
+            query.set("reading", reading)
+        }
+        query.set("potential", "1")
         return `${pathname}?${query.toString()}`
     }
     const previous = documents[index - 1]
@@ -585,6 +619,26 @@ export const AttestationWalker = ({
                                 {`🔊 audio${audioDocs.length > 1 ? ` ×${audioDocs.length.toLocaleString()}` : ""}`}
                             </Link>
                         ))}
+                    {/* the texts holding the word only as shared spellings,
+                        stepped apart: offered, never asserted */}
+                    {splitWalk &&
+                        (potentialTab ? (
+                            <span
+                                className="attest-tab attest-tab-active"
+                                aria-current="true"
+                            >
+                                {`potential ×${potentialDocs.length.toLocaleString()}`}
+                            </span>
+                        ) : (
+                            <Link
+                                className="attest-tab"
+                                to={potentialTabTo()}
+                                title={OFFERED_TITLE}
+                                replace
+                            >
+                                {`potential ×${potentialDocs.length.toLocaleString()}`}
+                            </Link>
+                        ))}
                     {/* the reading's whole family, drawn on the lemma page:
                         the tab names the lexeme, this is the way to its tree.
                         Not offered for a spelling walk — there is no lemma to
@@ -606,7 +660,19 @@ export const AttestationWalker = ({
 
             {!hasWalk ? null : (
                 <>
-                    <WalkSummary documents={documents} audioTab={audioTab} />
+                    {/* the summary reads the whole walk, not the open tab's
+                        half: the headline keeps its "possibly from" offer
+                        while the known matches are what is stepped */}
+                    <WalkSummary
+                        documents={
+                            audioTab
+                                ? audioDocs
+                                : potentialTab
+                                  ? potentialDocs
+                                  : walk.documents
+                        }
+                        audioTab={audioTab}
+                    />
 
                     <div
                         id="attest-body"
@@ -624,7 +690,9 @@ export const AttestationWalker = ({
                             ariaLabel={
                                 audioTab
                                     ? "Recordings using this word, in date order"
-                                    : "Texts using this word, in date order"
+                                    : potentialTab
+                                      ? "Texts possibly using this word, in date order"
+                                      : "Texts using this word, in date order"
                             }
                             previous={
                                 previous

--- a/CorpusSearch/Service/DictionaryAttestationService.cs
+++ b/CorpusSearch/Service/DictionaryAttestationService.cs
@@ -326,8 +326,13 @@ public class DictionaryAttestationService(
                 {
                     var sure = row.Aggregate(new HashSet<(int Line, int Start)>(),
                         (set, x) => { set.UnionWith(x.Sure); return set; });
+                    // the settled lines lead the sample: a step in the known
+                    // walk must not open on the shared-spelling occurrences
+                    // its potential twin holds (the Bible's "cronk Seir"
+                    // hills come long before its cronkal knocking)
                     var lines = row.First().Result.Lines
-                        .OrderBy(line => line.CsvLineNumber)
+                        .OrderBy(line => Occurrences(line).Any(o => !sure.Contains(o)) ? 1 : 0)
+                        .ThenBy(line => line.CsvLineNumber)
                         .Take(MaxLinesPerLemma)
                         .ToList();
                     var uncertain = lines


### PR DESCRIPTION
* An updated `cregeen.json` (`0.2.0`) splits out `crank v.` and `crank n. m.`
* `cronk` (hill) was shown under `crank`
  * A new 'potential' tab walks potential usages, rather than showing both potential and attested usages

