### PR TITLE
fix(Cregeen): restore alphabetic listing in legacy dictionary

### DIFF
--- a/CorpusSearch.Test/CregeenDictionaryServiceTest.cs
+++ b/CorpusSearch.Test/CregeenDictionaryServiceTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using CorpusSearch.Model.Dictionary;
 using CorpusSearch.Service.Dictionaries;
 using NUnit.Framework;
 
@@ -43,6 +44,49 @@ public class CregeenDictionaryServiceTest
     public void OtherNotesAreNotGenderWarnings(string? notes)
     {
         Assert.That(CregeenDictionaryService.GenderNoteOf(notes), Is.Null);
+    }
+
+    /// <summary>A letter page is filed by each entry's own letter, not sliced
+    /// between the letters' first printed entries: when the data respelled F's
+    /// opening 'fa.' as 'fa', the slice emptied F and poured the rest of the
+    /// book into E</summary>
+    [Test]
+    public void ALetterPageIsFiledByItsEntriesOwnLetters()
+    {
+        var entries = new[] { "e", "eairk", "fa", "fablagh", "gaal" }
+            .Select(word => new CregeenEntry { Words = [word], EntryHtml = "", HeadingHtml = "" })
+            .ToList();
+
+        string[] PageOf(char letter) => CregeenDictionaryService.EntriesUnder(letter, entries)
+            .Select(x => x.Words[0]).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(PageOf('E'), Is.EqualTo(new[] { "e", "eairk" }));
+            Assert.That(PageOf('F'), Is.EqualTo(new[] { "fa", "fablagh" }));
+            Assert.That(PageOf('g'), Is.EqualTo(new[] { "gaal" }), "lowercase URLs file alike");
+        });
+    }
+
+    /// <summary>Every letter of the bar answers with entries. The old slicing
+    /// failed silently: a letter whose landmark entry the data no longer
+    /// printed was simply empty, and nothing said so</summary>
+    [Test]
+    public void EveryLetterOfTheBarHasAPage()
+    {
+        var entries = CregeenDictionaryService.GetEntries();
+        // cregeen.json is downloaded on deployment (tools/init.sh): without it
+        // the dictionary is deliberately empty, and there is nothing to assert
+        Assume.That(entries, Is.Not.Empty, "cregeen.json not present");
+
+        Assert.Multiple(() =>
+        {
+            foreach (var letter in CregeenDictionaryService.Letters)
+            {
+                Assert.That(CregeenDictionaryService.EntriesUnder(letter, entries),
+                    Is.Not.Empty, $"the {letter} page has no entries");
+            }
+        });
     }
 
     /// <summary>The 702 entries without a plain Definition fall back to the

--- a/CorpusSearch.Test/DictionaryBrowseTest.cs
+++ b/CorpusSearch.Test/DictionaryBrowseTest.cs
@@ -41,7 +41,7 @@ public class DictionaryBrowseTest
     }
 
     /// <summary>The letter bar is derived, so a letter the data has is a letter
-    /// the bar shows: LetterLookup has no ç, and 39 Cregeen headwords start with
+    /// the bar shows: the hardcoded Letters has no ç, and 39 Cregeen headwords start with
     /// one</summary>
     [Test]
     public void TheLettersComeFromTheHeadwordsThemselves()

--- a/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
+++ b/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
@@ -14,34 +14,15 @@ namespace CorpusSearch.Service.Dictionaries;
 public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry> entries)
     : ISearchDictionary, IQuotingDictionary
 {
-    public static readonly Dictionary<char, string> LetterLookup = new(new CaseInsensitiveCharComparer())
-    {
-        [' '] = "  ",
-        ['A'] = "aa-",
-        ['B'] = "baa",
-        ['C'] = "caa",
-        ['D'] = "da",
-        ['E'] = "e",
-        ['F'] = "fa.",
-        ['G'] = "ga",
-        ['H'] = "ha",
-        ['I'] = "ick",
-        ['J'] = "jaagh",
-        ['K'] = "kaart",
-        ['L'] = "laa",
-        ['M'] = "maaig",
-        ['N'] = "na",
-        ['O'] = "O",
-        ['P'] = "paa",
-        ['Q'] = "quaagh",
-        ['R'] = "raa",
-        ['S'] = "saagh",
-        ['T'] = "taagh",
-        ['U'] = "udlan",
-        ['V'] = "vaidjin",
-        ['W'] = "wagaan",
-        ['Y'] = "y",
-    };
+    /// <summary>The letters of Cregeen's printed index: no X or Z, which head no
+    /// words of the book's, and no ç, which files under c (see
+    /// <see cref="DictionaryBrowse.CollationKey"/>). The legacy page's letter
+    /// bar, and what makes a one-character query a letter page, not a search.</summary>
+    public static readonly IReadOnlyList<char> Letters =
+    [
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'Y',
+    ];
 
     public string Identifier => "Cregeen";
     public string Slug => "cregeen";
@@ -104,7 +85,7 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
     {
         return !string.IsNullOrWhiteSpace(query) // invalid if whitespace
                && (query.Length > 1 // valid if longer than 1 char
-                   || LetterLookup.ContainsKey(query[0]) // valid if 1 char and in the lookup
+                   || Letters.Contains(char.ToUpperInvariant(query[0])) // valid if 1 char and a letter of the index
                );
     }
 
@@ -136,6 +117,15 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
         }
     }
 
+    /// <summary>One letter of the legacy browse page: the top-level entries
+    /// whose headword files under it (<see cref="DictionaryBrowse.LetterOf"/>),
+    /// in the book's order. Filed by each word's own letter rather than sliced
+    /// between landmark entries, so a letter keeps its page when the data
+    /// respells the entry that used to open it.</summary>
+    public static IEnumerable<CregeenEntry> EntriesUnder(char letter, IEnumerable<CregeenEntry> entries) =>
+        entries.Where(x =>
+            DictionaryBrowse.LetterOf(x.Words.FirstOrDefault() ?? "") == char.ToLowerInvariant(letter));
+
     /// <summary>Whether the dictionary contains the provided word (no fuzziness)</summary>
     public bool ContainsWordExact(string s)
     {
@@ -150,9 +140,10 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
     public IEnumerable<string> AllWords => allWords;
 
     /// <summary>The printed headwords, top-level entries only and in the file's
-    /// order, which is Cregeen's own: <see cref="LetterLookup"/>'s sentinels only
-    /// work because of it. Built once: GetSummaries re-flattens the tree per call
-    /// (see the PERF note below), and the index must not pay that.</summary>
+    /// order, which is Cregeen's own: the browse keeps the book's order (see
+    /// <see cref="DictionaryBrowse.Chapters"/>). Built once: GetSummaries
+    /// re-flattens the tree per call (see the PERF note below), and the index
+    /// must not pay that.</summary>
     public IReadOnlyList<string> Headwords { get; } =
         entries.Select(x => x.Words.FirstOrDefault()).OfType<string>().ToList();
 
@@ -243,11 +234,5 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
         var match = System.Text.RegularExpressions.Regex.Match(
             entryHtml ?? "", @"^\s*<i>\s*([^<]{1,30}?)\s*</i>");
         return match.Success ? match.Groups[1].Value : null;
-    }
-
-    private class CaseInsensitiveCharComparer : IEqualityComparer<char>
-    {
-        public bool Equals(char x, char y) => char.ToUpperInvariant(x) == char.ToUpperInvariant(y);
-        public int GetHashCode(char c) => char.ToUpperInvariant(c).GetHashCode();
     }
 }

--- a/CorpusSearch/Service/DictionaryBrowse.cs
+++ b/CorpusSearch/Service/DictionaryBrowse.cs
@@ -57,7 +57,7 @@ public static class DictionaryBrowse
     /// The letters a dictionary has headwords for, in order.
     /// </summary>
     /// <remarks>Derived rather than declared: the hardcoded
-    /// <see cref="Dictionaries.CregeenDictionaryService.LetterLookup"/> is Cregeen's
+    /// <see cref="Dictionaries.CregeenDictionaryService.Letters"/> is Cregeen's
     /// alone and has no ç, which 39 of its own headwords and 129 of Kelly's start
     /// with. A letter the data has is a letter the bar shows.</remarks>
     public static IReadOnlyList<char> LettersOf(IEnumerable<string> headwords) =>

--- a/CorpusSearch/Views/Cregeen/Index.cshtml
+++ b/CorpusSearch/Views/Cregeen/Index.cshtml
@@ -54,7 +54,7 @@
     </script>
 
     <div class="dict-letters">
-        @foreach (var k in CregeenDictionaryService.LetterLookup.Keys.Where(x => x != ' '))
+        @foreach (var k in CregeenDictionaryService.Letters)
         {
             <a href="/Dictionary/Cregeen/@k" class="@(k == activeLetter ? "active" : null)">@k</a>
         }
@@ -79,19 +79,12 @@
         }
 
         var entries = CregeenDictionaryService.GetEntries();
-        var dict = CregeenDictionaryService.LetterLookup;
 
         IEnumerable<CregeenEntry> search;
         int entryCount = 0;
         if (isLetterBrowse)
         {
-            var start = activeLetter;
-            var end = (char)(start + 1);
-
-            if (end == 'X') { end = 'Y'; }
-            if (!dict.ContainsKey(end)) { end = ' '; }
-
-            search = entries.SkipWhile(x => x.Words.First() != dict[start]).TakeWhile(x => x.Words.First() != dict[end]);
+            search = CregeenDictionaryService.EntriesUnder(activeLetter, entries);
         }
         else
         {


### PR DESCRIPTION
`fa.` was modified in the last update.

We relied on exact mappings of the first word per alphabet letter to produce the legacy dictionary.

This bug resulted in a significant number of entries under 'E'