### PR TITLE
feat(dictionary): browse lists every entry the book prints

### DIFF
--- a/CorpusSearch/Model/Dictionary/CregeenEntry.cs
+++ b/CorpusSearch/Model/Dictionary/CregeenEntry.cs
@@ -21,6 +21,21 @@ public class CregeenEntry
     public required string HeadingHtml { get; set; }
     public List<CregeenEntry>? Children { get; set; }
 
+    /// <summary>The printed headword this node stands for, particle and all:
+    /// the entry's identity, where <see cref="Words"/> is its search bag.
+    /// Null on data files older than the field</summary>
+    public string? Headword { get; set; }
+    /// <summary>The grammar words the book sets in italic before the bold
+    /// headword ("e hardjyn": "e")</summary>
+    public string? Particle { get; set; }
+    /// <summary>The letter section the book files the entry under, which for
+    /// a mutated head is not its spelling's ("e hardjyn" files under A,
+    /// beside ardjyn)</summary>
+    public string? Letter { get; set; }
+    /// <summary>The radical's initial, on entries whose own spelling files
+    /// away from it</summary>
+    public string? RadicalInitial { get; set; }
+
     public List<CregeenEntry> SafeChildren => Children ?? [];
 
     public List<CregeenEntry> ChildrenRecursive => new[] { this }.Concat(SafeChildren.SelectMany(x => x.ChildrenRecursive)).ToList();

--- a/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
+++ b/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 namespace CorpusSearch.Service.Dictionaries;
 
 public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry> entries)
-    : ISearchDictionary, IQuotingDictionary
+    : ISearchDictionary, IQuotingDictionary, IPrintedIndexDictionary
 {
     /// <summary>The letters of Cregeen's printed index: no X or Z, which head no
     /// words of the book's, and no ç, which files under c (see
@@ -139,13 +139,41 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
 
     public IEnumerable<string> AllWords => allWords;
 
-    /// <summary>The printed headwords, top-level entries only and in the file's
-    /// order, which is Cregeen's own: the browse keeps the book's order (see
-    /// <see cref="DictionaryBrowse.Chapters"/>). Built once: GetSummaries
-    /// re-flattens the tree per call (see the PERF note below), and the index
-    /// must not pay that.</summary>
-    public IReadOnlyList<string> Headwords { get; } =
-        entries.Select(x => x.Words.FirstOrDefault()).OfType<string>().ToList();
+    /// <summary>The book's index, built once: every node carrying its printed
+    /// identity (<see cref="CregeenEntry.Headword"/>), depth-first, which is
+    /// the print's own sequence; each filed under the letter the data names,
+    /// or its spelling's where the data is silent. Older data files carry no
+    /// identity fields, and the index falls back to the family heads the
+    /// top level holds — the pre-2026 browse.</summary>
+    private readonly (IReadOnlyList<PrintedHeadword> Printed, IReadOnlyList<string> Words) index =
+        BuildIndex(entries);
+
+    private static (IReadOnlyList<PrintedHeadword>, IReadOnlyList<string>) BuildIndex(
+        IList<CregeenEntry> entries)
+    {
+        var printed = entries.SelectMany(x => x.ChildrenRecursive)
+            .Where(x => x.Headword != null)
+            .Select(x => new PrintedHeadword(
+                x.Headword!,
+                x.Letter is { Length: > 0 } letter
+                    ? char.ToLowerInvariant(letter[0])
+                    : DictionaryBrowse.LetterOf(x.Headword!)))
+            .ToList();
+        var words = printed.Count > 0
+            ? printed.Select(x => x.Word).ToList()
+            : entries.Select(x => x.Words.FirstOrDefault()).OfType<string>().ToList();
+        return (printed, words);
+    }
+
+    /// <summary>Every printed entry in the book's order, with the letter the
+    /// book files it under: 'e hardjyn' in A beside ardjyn, as printed</summary>
+    public IReadOnlyList<PrintedHeadword> PrintedHeadwords => index.Printed;
+
+    /// <summary>The printed headwords, in the book's order (see
+    /// <see cref="DictionaryBrowse.Chapters"/>): what the browse lists and
+    /// the walk steps through. Built once: GetSummaries re-flattens the tree
+    /// per call (see the PERF note below), and the index must not pay that.</summary>
+    public IReadOnlyList<string> Headwords => index.Words;
 
     /// <summary>Every entry's decoded text (never the basic gloss, which drops
     /// the quotations): the reverse verse lookup's input</summary>

--- a/CorpusSearch/Service/DictionaryBrowseService.cs
+++ b/CorpusSearch/Service/DictionaryBrowseService.cs
@@ -53,7 +53,13 @@ public class DictionaryBrowseService(
         }
 
         var headwords = dictionary.Headwords;
-        var letters = DictionaryBrowse.LettersOf(headwords);
+        // a book whose data names each entry's filing letter files by it:
+        // 'e hardjyn' sits in A beside ardjyn, as printed, not under its
+        // spelling's E. Other dictionaries file by spelling, as before
+        var printed = (dictionary as IPrintedIndexDictionary)?.PrintedHeadwords;
+        var letters = printed is { Count: > 0 }
+            ? printed.Select(x => x.Letter).Where(c => c != '\0').Distinct().Order().ToList()
+            : DictionaryBrowse.LettersOf(headwords);
         var page = new DictionaryBrowsePage
         {
             Dictionary = dictionary.Identifier,
@@ -76,7 +82,9 @@ public class DictionaryBrowseService(
         page.Letter = char.ToUpperInvariant(letter).ToString();
         page.Chapters = DictionaryBrowse
             .Chapters(
-                headwords.Where(x => DictionaryBrowse.LetterOf(x) == letter),
+                printed is { Count: > 0 }
+                    ? printed.Where(x => x.Letter == letter).Select(x => x.Word)
+                    : headwords.Where(x => DictionaryBrowse.LetterOf(x) == letter),
                 vocabulary.IsAttested)
             .ToList();
         return page;

--- a/CorpusSearch/Service/ISearchDictionary.cs
+++ b/CorpusSearch/Service/ISearchDictionary.cs
@@ -49,6 +49,23 @@ public interface ISearchDictionary
     IReadOnlyList<string> Headwords { get; }
 }
 
+/// <summary>
+/// A dictionary whose data names the letter each printed entry files under:
+/// the browse takes the book's own filing instead of deriving it from
+/// spelling, so 'e hardjyn' sits in A beside ardjyn, as the book prints it.
+/// </summary>
+public interface IPrintedIndexDictionary
+{
+    /// <summary>Every printed entry in the book's order with its filing
+    /// letter; empty when the data predates the printed-identity fields</summary>
+    IReadOnlyList<PrintedHeadword> PrintedHeadwords { get; }
+}
+
+/// <summary>One printed entry of a book's index</summary>
+/// <param name="Word">the headword as printed, particle and all</param>
+/// <param name="Letter">the letter it files under, lower case</param>
+public sealed record PrintedHeadword(string Word, char Letter);
+
 /// <summary>When a query is made, provide a short summary of the result</summary>
 public class DictionarySummary
 {


### PR DESCRIPTION
Cregeen's browse showed 3,407 family heads of ~18,000 printed entries: the JSON nests each family under its head, and Headwords read only the top level, so the A page jumped from aa- to aadjin over every aa- compound the book prints between them.

The data now says what each node stands for - cregeen-nvh's classic export carries Headword, Particle, Letter and RadicalInitial, additive fields older files simply lack - and the index reads it: a depth-first walk of nodes carrying their printed identity, which is the print's own sequence, each filed under the letter the book files it (Letter), not the letter its spelling starts with. So A runs aa-, yn nah, aa-aase, aa-chionnagh...; ard, ardjyn, e hardjyn, sy n'ard sit in the order the page sets them; and daase files beside aase, where this edition gathers it. On data older than the fields, everything falls back to the family heads as before.

IPrintedIndexDictionary carries the (word, letter) pairs to the browse service; only Cregeen offers it. The neighbours walk and the union index take the fuller Headwords as they stand.