### PR TITLE
fix(dictionary): remove particles from listing

### DIFF
--- a/CorpusSearch.Test/DictionaryBrowseTest.cs
+++ b/CorpusSearch.Test/DictionaryBrowseTest.cs
@@ -161,6 +161,6 @@ public class DictionaryBrowseTest
     [Test]
     public void ALetterWithNoHeadwordsHasNoChapters()
     {
-        Assert.That(DictionaryBrowse.Chapters([]), Is.Empty);
+        Assert.That(DictionaryBrowse.Chapters((string[]) []), Is.Empty);
     }
 }

--- a/CorpusSearch/ClientApp/e2e/dictionary.spec.ts
+++ b/CorpusSearch/ClientApp/e2e/dictionary.spec.ts
@@ -30,7 +30,7 @@ test("the browse opens a letter in chapters, and can hide the never-said", async
     const greyed = page.locator(".dict-browse-words a.dict-unattested")
     const before = await greyed.count()
     expect(before).toBeGreaterThan(0)
-    await page.locator(".dict-browse-filter input").check()
+    await page.getByRole("checkbox", { name: "Hide unattested words" }).check()
     await expect(greyed).toHaveCount(0)
 })
 

--- a/CorpusSearch/ClientApp/src/api/DictionaryApi.ts
+++ b/CorpusSearch/ClientApp/src/api/DictionaryApi.ts
@@ -517,6 +517,11 @@ export type BrowseWord = {
      * the lemma index's voucher for its greyed rows. Absent where the corpus
      * speaks for the word, and on the book indexes. */
     source?: string | null
+    /** the family's own entries, where the book prints one as a family:
+     * 'anchasherick' rides here under 'casherick', not as a word of C's.
+     * In printed order; absent on dictionaries that print no families and
+     * on heads that stand alone */
+    members?: BrowseWord[] | null
 }
 
 /** @param at a letter ("a"), or a prefix ("aal") from a link made when a prefix

--- a/CorpusSearch/ClientApp/src/components/UnattestedFilter.tsx
+++ b/CorpusSearch/ClientApp/src/components/UnattestedFilter.tsx
@@ -10,8 +10,13 @@ export const useHideUnattested = () =>
     )
 
 /** The words a listing shows under the filter: every chapter's words, or the
- * attested alone, empty chapters gone with their words */
-export const visibleChapters = <T extends { words: { attested: boolean }[] }>(
+ * attested alone, empty chapters gone with their words. A family head whose
+ * own spelling no text says still stands when the corpus speaks for a member
+ * riding under it — hiding casherick would hide anchasherick with it. */
+export const visibleChapters = <
+    W extends { attested: boolean; members?: W[] | null },
+    T extends { words: W[] },
+>(
     chapters: T[],
     hideUnattested: boolean,
 ): T[] =>
@@ -19,7 +24,17 @@ export const visibleChapters = <T extends { words: { attested: boolean }[] }>(
         ? chapters
               .map((chapter) => ({
                   ...chapter,
-                  words: chapter.words.filter((word) => word.attested),
+                  words: chapter.words
+                      .map((word) => ({
+                          ...word,
+                          members: word.members?.filter(
+                              (member) => member.attested,
+                          ),
+                      }))
+                      .filter(
+                          (word) =>
+                              word.attested || (word.members?.length ?? 0) > 0,
+                      ),
               }))
               .filter((chapter) => chapter.words.length > 0)
         : chapters

--- a/CorpusSearch/ClientApp/src/routes/DictionaryBrowse.css
+++ b/CorpusSearch/ClientApp/src/routes/DictionaryBrowse.css
@@ -103,6 +103,31 @@
     padding: 0 2px;
 }
 
+/* sub-entries shown: one family a line, the head at the margin and its own
+   words running on after it, quieter — the book's paragraph, condensed */
+.dict-browse-family-line {
+    display: block;
+}
+
+.dict-browse-family {
+    font-size: 0.85em;
+    color: var(--c-muted);
+    margin-left: 12px;
+}
+
+.dict-browse-family a {
+    color: inherit;
+}
+
+/* the toggles sit together, asides on the listing */
+.dict-browse-filters {
+    margin: 0 0 12px;
+}
+
+.dict-browse-filters .dict-browse-filter {
+    margin: 0 0 2px;
+}
+
 .dict-browse-empty {
     color: var(--c-accent);
     font-style: italic;

--- a/CorpusSearch/ClientApp/src/routes/DictionaryBrowse.css
+++ b/CorpusSearch/ClientApp/src/routes/DictionaryBrowse.css
@@ -104,19 +104,19 @@
 }
 
 /* sub-entries shown: one family a line, the head at the margin and its own
-   words running on after it, quieter — the book's paragraph, condensed */
+   words running on after it — the head bold, as the book sets it, so the
+   hierarchy reads from weight and grey stays the mark of the unattested */
 .dict-browse-family-line {
     display: block;
 }
 
-.dict-browse-family {
-    font-size: 0.85em;
-    color: var(--c-muted);
-    margin-left: 12px;
+.dict-browse-family-line > a {
+    font-weight: bold;
 }
 
-.dict-browse-family a {
-    color: inherit;
+.dict-browse-family {
+    font-size: 0.85em;
+    margin-left: 12px;
 }
 
 /* the toggles sit together, asides on the listing */

--- a/CorpusSearch/ClientApp/src/routes/DictionaryBrowse.tsx
+++ b/CorpusSearch/ClientApp/src/routes/DictionaryBrowse.tsx
@@ -15,6 +15,7 @@ import {
 import { WordSearch } from "../components/WordSearch"
 import { useActiveInRow } from "../hooks/useActiveInRow"
 import { useDictionaryHead } from "../hooks/useDictionaryHead"
+import { usePersistedState } from "../hooks/usePersistedState"
 import "./DictionaryBrowse.css"
 
 const browseUrl = (dict: string, at?: string) =>
@@ -66,6 +67,14 @@ export const DictionaryBrowse = () => {
     const [page, setPage] = useState<DictionaryBrowseResponse | null>(null)
     const [failed, setFailed] = useState(false)
     const [hideUnattested, setHideUnattested] = useHideUnattested()
+    // whether a family's own entries ride visibly under their head
+    // (anchasherick under casherick), or the heads stand alone. Remembered,
+    // as the unattested filter is
+    const [showSubEntries, setShowSubEntries] = usePersistedState(
+        "dictionary.showSubEntries",
+        (stored) => stored === "true",
+        String,
+    )
 
     // a letter opens at its top: the bar that turned to it repeats at the
     // foot of a long letter, and the next should not open at its own foot
@@ -132,10 +141,36 @@ export const DictionaryBrowse = () => {
                     )}
 
                     {page.letters.length > 0 && (
-                        <UnattestedFilter
-                            hidden={hideUnattested}
-                            onChange={setHideUnattested}
-                        />
+                        <div className="dict-browse-filters">
+                            {/* only a book printed as families has sub-entries
+                                to offer (Cregeen); the toggle would be noise
+                                on the others */}
+                            {page.chapters.some((chapter) =>
+                                chapter.words.some(
+                                    (word) => (word.members?.length ?? 0) > 0,
+                                ),
+                            ) && (
+                                <label
+                                    className="dict-browse-filter"
+                                    title="Sub-entries: the words the book prints inside another word's entry"
+                                >
+                                    <input
+                                        type="checkbox"
+                                        checked={showSubEntries}
+                                        onChange={(event) =>
+                                            setShowSubEntries(
+                                                event.target.checked,
+                                            )
+                                        }
+                                    />
+                                    {" Show sub-entries"}
+                                </label>
+                            )}
+                            <UnattestedFilter
+                                hidden={hideUnattested}
+                                onChange={setHideUnattested}
+                            />
+                        </div>
                     )}
 
                     {/* no sampler here: the browse always has a letter open
@@ -163,15 +198,21 @@ export const DictionaryBrowse = () => {
                                             (entry, position) => (
                                                 <span
                                                     key={`${entry.word}-${position}`}
+                                                    className={
+                                                        showSubEntries
+                                                            ? "dict-browse-family-line"
+                                                            : undefined
+                                                    }
                                                 >
-                                                    {position > 0 && (
-                                                        <span
-                                                            className="dict-browse-sep"
-                                                            aria-hidden="true"
-                                                        >
-                                                            {" · "}
-                                                        </span>
-                                                    )}
+                                                    {!showSubEntries &&
+                                                        position > 0 && (
+                                                            <span
+                                                                className="dict-browse-sep"
+                                                                aria-hidden="true"
+                                                            >
+                                                                {" · "}
+                                                            </span>
+                                                        )}
                                                     <Link
                                                         className={
                                                             entry.attested
@@ -190,6 +231,60 @@ export const DictionaryBrowse = () => {
                                                     >
                                                         {entry.word}
                                                     </Link>
+                                                    {/* the family's own words,
+                                                        along for the ride under
+                                                        their head: anchasherick
+                                                        under casherick, never
+                                                        a word of C's */}
+                                                    {showSubEntries &&
+                                                        entry.members != null &&
+                                                        entry.members.length >
+                                                            0 && (
+                                                            <span className="dict-browse-family">
+                                                                {entry.members.map(
+                                                                    (
+                                                                        member,
+                                                                        place,
+                                                                    ) => (
+                                                                        <span
+                                                                            key={`${member.word}-${place}`}
+                                                                        >
+                                                                            {place >
+                                                                                0 && (
+                                                                                <span
+                                                                                    className="dict-browse-sep"
+                                                                                    aria-hidden="true"
+                                                                                >
+                                                                                    {
+                                                                                        " · "
+                                                                                    }
+                                                                                </span>
+                                                                            )}
+                                                                            <Link
+                                                                                className={
+                                                                                    member.attested
+                                                                                        ? undefined
+                                                                                        : "dict-unattested"
+                                                                                }
+                                                                                title={
+                                                                                    member.attested
+                                                                                        ? undefined
+                                                                                        : `${member.word}: in no text in the corpus`
+                                                                                }
+                                                                                to={dictionaryWordUrl(
+                                                                                    member.word,
+                                                                                    page.slug,
+                                                                                )}
+                                                                            >
+                                                                                {
+                                                                                    member.word
+                                                                                }
+                                                                            </Link>
+                                                                        </span>
+                                                                    ),
+                                                                )}
+                                                            </span>
+                                                        )}
                                                 </span>
                                             ),
                                         )}

--- a/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
+++ b/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
@@ -144,7 +144,14 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
     /// the print's own sequence; each filed under the letter the data names,
     /// or its spelling's where the data is silent. Older data files carry no
     /// identity fields, and the index falls back to the family heads the
-    /// top level holds — the pre-2026 browse.</summary>
+    /// top level holds — the pre-2026 browse.
+    ///
+    /// Lexical entries only: the book also prints each word's grammar demos
+    /// ('e chah', 'nyn gaa' after 'caa'; 'daase', "s'aalin"), marked in the
+    /// data by Particle and RadicalInitial. Nearly every consonant noun has
+    /// two or three, so an index listing them drowns the words in their own
+    /// mutations and breaks the prefix bar, which chunks on runs. They stay
+    /// searchable, and their word pages stand.</summary>
     private readonly (IReadOnlyList<PrintedHeadword> Printed, IReadOnlyList<string> Words) index =
         BuildIndex(entries);
 
@@ -152,7 +159,7 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
         IList<CregeenEntry> entries)
     {
         var printed = entries.SelectMany(x => x.ChildrenRecursive)
-            .Where(x => x.Headword != null)
+            .Where(x => x.Headword != null && x.Particle == null && x.RadicalInitial == null)
             .Select(x => new PrintedHeadword(
                 x.Headword!,
                 x.Letter is { Length: > 0 } letter
@@ -165,8 +172,9 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
         return (printed, words);
     }
 
-    /// <summary>Every printed entry in the book's order, with the letter the
-    /// book files it under: 'e hardjyn' in A beside ardjyn, as printed</summary>
+    /// <summary>The book's lexical entries in the book's order, with the
+    /// letter each files under: 'aa-aase' in A beside 'aa-', where the
+    /// book prints it</summary>
     public IReadOnlyList<PrintedHeadword> PrintedHeadwords => index.Printed;
 
     /// <summary>The printed headwords, in the book's order (see

--- a/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
+++ b/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
@@ -139,46 +139,59 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
 
     public IEnumerable<string> AllWords => allWords;
 
-    /// <summary>The book's index, built once: every node carrying its printed
-    /// identity (<see cref="CregeenEntry.Headword"/>), depth-first, which is
-    /// the print's own sequence; each filed under the letter the data names,
-    /// or its spelling's where the data is silent. Older data files carry no
-    /// identity fields, and the index falls back to the family heads the
-    /// top level holds — the pre-2026 browse.
+    /// <summary>The book's index, built once from the nodes carrying their
+    /// printed identity (<see cref="CregeenEntry.Headword"/>): one family per
+    /// top-level entry, filed under the letter the data names (or its
+    /// spelling's where the data is silent), its members in printed order
+    /// beneath it. 'anchasherick' rides under 'casherick'; only casherick is
+    /// C's own word. Older data files carry no identity fields, and the
+    /// index falls back to bare family heads — the pre-2026 browse.
     ///
-    /// Lexical entries only: the book also prints each word's grammar demos
-    /// ('e chah', 'nyn gaa' after 'caa'; 'daase', "s'aalin"), marked in the
-    /// data by Particle and RadicalInitial. Nearly every consonant noun has
-    /// two or three, so an index listing them drowns the words in their own
-    /// mutations and breaks the prefix bar, which chunks on runs. They stay
-    /// searchable, and their word pages stand.</summary>
-    private readonly (IReadOnlyList<PrintedHeadword> Printed, IReadOnlyList<string> Words) index =
+    /// Members are the family's lexical entries only: the book also prints
+    /// each word's grammar demos ('e chah', 'nyn gaa' after 'caa'; 'daase',
+    /// "s'aalin"), marked in the data by Particle and RadicalInitial. They
+    /// stay searchable, and their word pages stand; the index is not the
+    /// place a reader meets a paradigm.</summary>
+    private readonly (IReadOnlyList<PrintedFamily> Families, IReadOnlyList<string> Words) index =
         BuildIndex(entries);
 
-    private static (IReadOnlyList<PrintedHeadword>, IReadOnlyList<string>) BuildIndex(
+    private static (IReadOnlyList<PrintedFamily>, IReadOnlyList<string>) BuildIndex(
         IList<CregeenEntry> entries)
     {
-        var printed = entries.SelectMany(x => x.ChildrenRecursive)
-            .Where(x => x.Headword != null && x.Particle == null && x.RadicalInitial == null)
-            .Select(x => new PrintedHeadword(
+        var families = entries
+            .Where(x => x.Headword != null)
+            .Select(x => new PrintedFamily(
                 x.Headword!,
                 x.Letter is { Length: > 0 } letter
                     ? char.ToLowerInvariant(letter[0])
-                    : DictionaryBrowse.LetterOf(x.Headword!)))
+                    : DictionaryBrowse.LetterOf(x.Headword!),
+                x.ChildrenRecursive.Skip(1)
+                    .Where(c => c.Headword != null && c.Particle == null && c.RadicalInitial == null)
+                    .Select(c => c.Headword!)
+                    // a class split prints the spelling again ('aa-aase, s.m.'
+                    // then 'aa-aase, v.'): one word to a reader, as the head
+                    .Where(w => !string.Equals(w, x.Headword, StringComparison.OrdinalIgnoreCase))
+                    .Aggregate(new List<string>(), (list, w) =>
+                    {
+                        if (list.Count == 0 || !string.Equals(list[^1], w, StringComparison.OrdinalIgnoreCase))
+                        {
+                            list.Add(w);
+                        }
+                        return list;
+                    })))
             .ToList();
-        var words = printed.Count > 0
-            ? printed.Select(x => x.Word).ToList()
+        var words = families.Count > 0
+            ? families.SelectMany(f => (string[]) [f.Word, .. f.Members]).ToList()
             : entries.Select(x => x.Words.FirstOrDefault()).OfType<string>().ToList();
-        return (printed, words);
+        return (families, words);
     }
 
-    /// <summary>The book's lexical entries in the book's order, with the
-    /// letter each files under: 'aa-aase' in A beside 'aa-', where the
-    /// book prints it</summary>
-    public IReadOnlyList<PrintedHeadword> PrintedHeadwords => index.Printed;
+    /// <summary>The book's families in the book's order: heads under their
+    /// letters, members under their heads</summary>
+    public IReadOnlyList<PrintedFamily> PrintedFamilies => index.Families;
 
     /// <summary>The printed headwords, in the book's order (see
-    /// <see cref="DictionaryBrowse.Chapters"/>): what the browse lists and
+    /// <see cref="DictionaryBrowse"/>.Chapters): what the browse lists and
     /// the walk steps through. Built once: GetSummaries re-flattens the tree
     /// per call (see the PERF note below), and the index must not pay that.</summary>
     public IReadOnlyList<string> Headwords => index.Words;

--- a/CorpusSearch/Service/DictionaryBrowse.cs
+++ b/CorpusSearch/Service/DictionaryBrowse.cs
@@ -94,15 +94,21 @@ public static class DictionaryBrowse
     /// <param name="sourceOf">names the file whose print attests a word the
     /// corpus never says ("cregeen"): the lemma index's voucher for its greyed
     /// rows. Only asked about the greyed — an attested word needs none.</param>
+    /// <param name="letter">the page's letter, when the book's filing rather
+    /// than spelling chose the words: a word filed away from its own initial
+    /// ('myr-chaagh', printed among the caagh words) rides in the chapter of
+    /// the words around it, instead of opening a one-word chapter named for a
+    /// letter this page does not own</param>
     public static IReadOnlyList<BrowseChapter> Chapters(
         IEnumerable<string> headwords, Func<string, bool>? attested = null,
-        Func<string, string?>? sourceOf = null)
+        Func<string, string?>? sourceOf = null, char? letter = null)
     {
         var chapters = new List<BrowseChapter>();
         foreach (var headword in headwords)
         {
             var key = PrefixOf(headword, ChapterDepth).ToUpperInvariant();
-            if (chapters.Count == 0 || chapters[^1].Key != key)
+            var interloper = letter != null && LetterOf(headword) != letter && chapters.Count > 0;
+            if (!interloper && (chapters.Count == 0 || chapters[^1].Key != key))
             {
                 chapters.Add(new BrowseChapter { Key = key, Words = [] });
             }

--- a/CorpusSearch/Service/DictionaryBrowse.cs
+++ b/CorpusSearch/Service/DictionaryBrowse.cs
@@ -95,16 +95,28 @@ public static class DictionaryBrowse
     /// corpus never says ("cregeen"): the lemma index's voucher for its greyed
     /// rows. Only asked about the greyed — an attested word needs none.</param>
     /// <param name="letter">the page's letter, when the book's filing rather
-    /// than spelling chose the words: a word filed away from its own initial
+    /// than spelling chose the words: a head filed away from its own initial
     /// ('myr-chaagh', printed among the caagh words) rides in the chapter of
     /// the words around it, instead of opening a one-word chapter named for a
     /// letter this page does not own</param>
     public static IReadOnlyList<BrowseChapter> Chapters(
         IEnumerable<string> headwords, Func<string, bool>? attested = null,
+        Func<string, string?>? sourceOf = null, char? letter = null) =>
+        Chapters(
+            headwords.Select(x => (x, (IReadOnlyList<string>?)null)),
+            attested, sourceOf, letter);
+
+    /// <summary>As <see cref="Chapters(IEnumerable{string},Func{string,bool},Func{string,string},char?)"/>,
+    /// for a book printed as families: each head brings its members, carried
+    /// under it — 'anchasherick' under 'casherick' — never as the letter's
+    /// own words. Chapters and their keys follow the heads alone.</summary>
+    public static IReadOnlyList<BrowseChapter> Chapters(
+        IEnumerable<(string Word, IReadOnlyList<string>? Members)> families,
+        Func<string, bool>? attested = null,
         Func<string, string?>? sourceOf = null, char? letter = null)
     {
         var chapters = new List<BrowseChapter>();
-        foreach (var headword in headwords)
+        foreach (var (headword, members) in families)
         {
             var key = PrefixOf(headword, ChapterDepth).ToUpperInvariant();
             var interloper = letter != null && LetterOf(headword) != letter && chapters.Count > 0;
@@ -113,9 +125,30 @@ public static class DictionaryBrowse
                 chapters.Add(new BrowseChapter { Key = key, Words = [] });
             }
             var words = chapters[^1].Words;
-            // the same spelling twice over is one link twice over: fold it
+            var memberRows = members is { Count: > 0 }
+                ? members.Select(m =>
+                {
+                    var said = attested?.Invoke(m) ?? true;
+                    return new BrowseWord
+                    {
+                        Word = m,
+                        Attested = said,
+                        Source = said ? null : sourceOf?.Invoke(m),
+                    };
+                }).ToList()
+                : null;
+            // the same spelling twice over is one link twice over: fold it —
+            // and two same-headed families are one family to a reader, so the
+            // second's members join the row the first put up
             if (words.Count > 0 && words[^1].Word == headword)
             {
+                if (memberRows != null)
+                {
+                    var row = words[^1];
+                    row.Members ??= [];
+                    row.Members.AddRange(memberRows.Where(m =>
+                        row.Members.All(x => x.Word != m.Word)));
+                }
                 continue;
             }
             var isAttested = attested?.Invoke(headword) ?? true;
@@ -124,6 +157,7 @@ public static class DictionaryBrowse
                 Word = headword,
                 Attested = isAttested,
                 Source = isAttested ? null : sourceOf?.Invoke(headword),
+                Members = memberRows,
             });
         }
         return chapters;
@@ -154,7 +188,7 @@ public class BrowseChapter
     public required string Key { get; set; }
     /// <summary>The chapter's headwords, each spelling once: the book prints five
     /// entries 'A', but they are one link and the index shows one (see
-    /// <see cref="DictionaryBrowse.Chapters"/>)</summary>
+    /// <see cref="DictionaryBrowse"/>.Chapters)</summary>
     public required List<BrowseWord> Words { get; set; }
 }
 
@@ -173,6 +207,12 @@ public class BrowseWord
     /// where the corpus speaks for the word, and on the book indexes, whose
     /// every word is the book's own.</summary>
     public string? Source { get; set; }
+
+    /// <summary>The family's own entries, where the book prints one as a
+    /// family: 'anchasherick' rides here under 'casherick', not as a word of
+    /// C's. In printed order. Null on dictionaries that print no families,
+    /// and on heads that stand alone.</summary>
+    public List<BrowseWord>? Members { get; set; }
 }
 
 /// <summary>One entry of the browse sampler: a way into the book that is not

--- a/CorpusSearch/Service/DictionaryBrowseService.cs
+++ b/CorpusSearch/Service/DictionaryBrowseService.cs
@@ -85,7 +85,10 @@ public class DictionaryBrowseService(
                 printed is { Count: > 0 }
                     ? printed.Where(x => x.Letter == letter).Select(x => x.Word)
                     : headwords.Where(x => DictionaryBrowse.LetterOf(x) == letter),
-                vocabulary.IsAttested)
+                vocabulary.IsAttested,
+                // filing chose these words, so spelling may disagree with the
+                // page ('myr-chaagh' among the caagh words): chapter by the run
+                letter: printed is { Count: > 0 } ? letter : null)
             .ToList();
         return page;
     }

--- a/CorpusSearch/Service/DictionaryBrowseService.cs
+++ b/CorpusSearch/Service/DictionaryBrowseService.cs
@@ -53,10 +53,11 @@ public class DictionaryBrowseService(
         }
 
         var headwords = dictionary.Headwords;
-        // a book whose data names each entry's filing letter files by it:
-        // 'aa-aase' sits in A where the book prints it, and a family's words
-        // keep their printed run. Other dictionaries file by spelling, as before
-        var printed = (dictionary as IPrintedIndexDictionary)?.PrintedHeadwords;
+        // a book printed as families shows the book's shape: heads under the
+        // letter the book files them, members under their heads —
+        // 'anchasherick' under 'casherick', and only casherick a word of C's.
+        // Other dictionaries file every word by spelling, as before
+        var printed = (dictionary as IPrintedIndexDictionary)?.PrintedFamilies;
         var letters = printed is { Count: > 0 }
             ? printed.Select(x => x.Letter).Where(c => c != '\0').Distinct().Order().ToList()
             : DictionaryBrowse.LettersOf(headwords);
@@ -80,15 +81,17 @@ public class DictionaryBrowseService(
         var letter = asked.Length > 0 && letters.Contains(asked[0]) ? asked[0] : letters[0];
 
         page.Letter = char.ToUpperInvariant(letter).ToString();
-        page.Chapters = DictionaryBrowse
-            .Chapters(
-                printed is { Count: > 0 }
-                    ? printed.Where(x => x.Letter == letter).Select(x => x.Word)
-                    : headwords.Where(x => DictionaryBrowse.LetterOf(x) == letter),
-                vocabulary.IsAttested,
-                // filing chose these words, so spelling may disagree with the
-                // page ('myr-chaagh' among the caagh words): chapter by the run
-                letter: printed is { Count: > 0 } ? letter : null)
+        page.Chapters = (printed is { Count: > 0 }
+                ? DictionaryBrowse.Chapters(
+                    printed.Where(x => x.Letter == letter)
+                        .Select(x => (x.Word, (IReadOnlyList<string>?)x.Members)),
+                    vocabulary.IsAttested,
+                    // filing chose the heads, so a spelling may disagree with
+                    // the page: such a head chapters with the run it sits in
+                    letter: letter)
+                : DictionaryBrowse.Chapters(
+                    headwords.Where(x => DictionaryBrowse.LetterOf(x) == letter),
+                    vocabulary.IsAttested))
             .ToList();
         return page;
     }

--- a/CorpusSearch/Service/DictionaryBrowseService.cs
+++ b/CorpusSearch/Service/DictionaryBrowseService.cs
@@ -54,8 +54,8 @@ public class DictionaryBrowseService(
 
         var headwords = dictionary.Headwords;
         // a book whose data names each entry's filing letter files by it:
-        // 'e hardjyn' sits in A beside ardjyn, as printed, not under its
-        // spelling's E. Other dictionaries file by spelling, as before
+        // 'aa-aase' sits in A where the book prints it, and a family's words
+        // keep their printed run. Other dictionaries file by spelling, as before
         var printed = (dictionary as IPrintedIndexDictionary)?.PrintedHeadwords;
         var letters = printed is { Count: > 0 }
             ? printed.Select(x => x.Letter).Where(c => c != '\0').Distinct().Order().ToList()

--- a/CorpusSearch/Service/ISearchDictionary.cs
+++ b/CorpusSearch/Service/ISearchDictionary.cs
@@ -50,21 +50,25 @@ public interface ISearchDictionary
 }
 
 /// <summary>
-/// A dictionary whose data names the letter each printed entry files under:
-/// the browse takes the book's own filing instead of deriving it from
-/// spelling, so 'e hardjyn' sits in A beside ardjyn, as the book prints it.
+/// A dictionary printed as families: a head entry files under a letter, and
+/// its derivatives ride with it wherever their own spelling would sort —
+/// 'anchasherick' is under 'casherick', and casherick is under C. The browse
+/// shows the book's shape: heads under their letters, members under their
+/// heads, never a member as a letter's own word.
 /// </summary>
 public interface IPrintedIndexDictionary
 {
-    /// <summary>Every printed entry in the book's order with its filing
-    /// letter; empty when the data predates the printed-identity fields</summary>
-    IReadOnlyList<PrintedHeadword> PrintedHeadwords { get; }
+    /// <summary>Every printed family in the book's order; empty when the
+    /// data predates the printed-identity fields</summary>
+    IReadOnlyList<PrintedFamily> PrintedFamilies { get; }
 }
 
-/// <summary>One printed entry of a book's index</summary>
-/// <param name="Word">the headword as printed, particle and all</param>
-/// <param name="Letter">the letter it files under, lower case</param>
-public sealed record PrintedHeadword(string Word, char Letter);
+/// <summary>One family of a book's index</summary>
+/// <param name="Word">the head entry's headword, as printed</param>
+/// <param name="Letter">the letter the family files under, lower case</param>
+/// <param name="Members">the family's own entries in printed order, the head
+/// aside: the words that ride under it, however they are spelled</param>
+public sealed record PrintedFamily(string Word, char Letter, IReadOnlyList<string> Members);
 
 /// <summary>When a query is made, provide a short summary of the result</summary>
 public class DictionarySummary


### PR DESCRIPTION
The full printed sequence made C unreadable: nearly every consonant noun prints an 'e ch-' and a 'nyn g-' line ('caa, e chah, nyn gaa, caays, e chaays...'), so the words drowned in their own mutations and the prefix bar - which chunks on runs - split into a chapter per word or two (2,187 for 2,631 words).

The index now keeps lexical entries only: rows the data marks as grammar demos (Particle) or mutated repeats filed by their radical (RadicalInitial) stay out of it. C comes back to 1,397 words in 504 chapters of real prefix runs; A keeps the whole aa- family that motivated the fuller index. The demo rows remain searchable and keep their word pages - only the letter index stops listing them.

Decided against listing 'e hardjyn' and kin after leaning the other way: the deployed C page was the argument. The policy is one Where over data fields, so revisiting it stays cheap.