### PR TITLE
feat(dictionary): word pages file entries under Cregeen's numbered readings

### DIFF
--- a/CorpusSearch.Test/CregeenDictionaryServiceTest.cs
+++ b/CorpusSearch.Test/CregeenDictionaryServiceTest.cs
@@ -17,6 +17,17 @@ public class CregeenDictionaryServiceTest
         Assert.That(CregeenDictionaryService.GrammarLabelOf(html), Is.EqualTo(expected));
     }
 
+    /// <summary>The transcription corrects the print inside the label - angle
+    /// brackets around the print's reading, square around the correction - and
+    /// the marks reach the reader as brackets, not as "&amp;lt;" entities</summary>
+    [TestCase("<i>&lt;v&gt;[a]. </i>not long, not far F", "<v>[a].")]
+    [TestCase("<i>s. &lt;f.&gt; </i>a hand barrow", "s. <f.>")]
+    [TestCase("<i>&lt;a. d.&gt;[a. pl.] </i>brave men B", "<a. d.>[a. pl.]")]
+    public void TheEditorialMarksInALabelStayAndDecode(string html, string expected)
+    {
+        Assert.That(CregeenDictionaryService.GrammarLabelOf(html), Is.EqualTo(expected));
+    }
+
     [TestCase("plain text, no label")]
     [TestCase("starts plainly <i>with italics later</i>")]
     [TestCase("<i>this italic run is far too long to be a grammar label at all</i> text")]

--- a/CorpusSearch.Test/DictionaryLookupServiceTest.cs
+++ b/CorpusSearch.Test/DictionaryLookupServiceTest.cs
@@ -23,6 +23,34 @@ public class DictionaryLookupServiceTest
         return service.Lookup("gv", selection, context).Select(x => x.PrimaryWord).ToList();
     }
 
+    /// <summary>The page names the readings the inventory has: the popup picks
+    /// among them in context, and here the reader sees the fork itself</summary>
+    [Test]
+    public void ThePageNamesTheWordsReadings()
+    {
+        var table = LemmaTable.Load(new StringReader(
+            "form\tlemmaId\tlemma\nooh\tooh.n\tooh\n"));
+        var inventory = SenseInventory.Load(new StringReader(
+            "senseId\tlemmaId\tdict\tentryPath\tgloss\n"
+            + "ooh.n#1\tooh.n\tcregeen\tcregeen:ooh\tan egg\n"
+            + "ooh.n#2\tooh.n\tcregeen\tcregeen:ooh\tan udder\n"));
+        var service = new DictionaryLookupService(
+            [new FakeDictionary(["ooh"])], table, LemmaResolver.Empty, inventory);
+
+        var page = service.Page("gv", "ooh");
+        Assert.Multiple(() =>
+        {
+            Assert.That(page.Senses, Has.Count.EqualTo(1));
+            Assert.That(page.Senses[0].Lemma, Is.EqualTo("ooh"));
+            Assert.That(page.Senses[0].Readings.Select(x => x.Gloss),
+                Is.EqualTo(new[] { "an egg", "an udder" }));
+            Assert.That(page.Senses[0].Readings[0].Headword, Is.EqualTo("ooh"));
+        });
+
+        // one implicit sense: no block, nothing for the page to say
+        Assert.That(Service("ooh").Page("gv", "ooh").Senses, Is.Empty);
+    }
+
     [Test]
     public void MatchesASingleWord()
     {

--- a/CorpusSearch.Test/LemmaAdjudication/AdjudicationCommon.cs
+++ b/CorpusSearch.Test/LemmaAdjudication/AdjudicationCommon.cs
@@ -125,6 +125,50 @@ public static class AdjudicationCommon
         return result;
     }
 
+    /// <summary>(normalized headword core, pos class n/v/a/x) -> the definitions
+    /// of Cregeen's own entries of that spelling AND class. Display-keyed glosses
+    /// merge homographs (cramp the adjective showed the noun's "plague") and miss
+    /// lenited-headword entries entirely ("yn chooney" never surfaced for
+    /// chooney.n) - the Phase 3 pilot's dominant split cause. Classing mirrors
+    /// the table generator's identity rule: v before s before a, else x.</summary>
+    public static Dictionary<(string Core, string Class), string> LoadCregeenClassGlosses()
+    {
+        var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Resources", "cregeen.json");
+        var roots = JsonConvert.DeserializeObject<List<Model.Dictionary.CregeenEntry>>(File.ReadAllText(path)) ?? [];
+        var texts = new Dictionary<(string, string), List<string>>();
+        foreach (var entry in roots.SelectMany(x => x.ChildrenRecursive))
+        {
+            // pre-identity data files carry no Headword; the display-keyed
+            // fallback still serves them
+            if (entry.Headword is not { } head || string.IsNullOrWhiteSpace(entry.Definition))
+            {
+                continue;
+            }
+            var core = !string.IsNullOrEmpty(entry.Particle)
+                       && head.StartsWith(entry.Particle + " ", StringComparison.OrdinalIgnoreCase)
+                ? head[(entry.Particle.Length + 1)..]
+                : head;
+            // the JSON expands the printed labels (s. -> Noun); the class
+            // precedence mirrors the table generator's: v before n before a
+            var parts = entry.PartsOfSpeech ?? [];
+            var cls = parts.Contains("Verb") ? "v"
+                : parts.Contains("Noun") ? "n"
+                : parts.Contains("Adjective") ? "a"
+                : "x";
+            var key = (LemmaTable.NormalizeForm(core), cls);
+            if (!texts.TryGetValue(key, out var list))
+            {
+                texts[key] = list = [];
+            }
+            var definition = entry.Definition.Trim();
+            if (list.Count < 3 && !list.Contains(definition))
+            {
+                list.Add(definition);
+            }
+        }
+        return texts.ToDictionary(kv => kv.Key, kv => string.Join("; ", kv.Value));
+    }
+
     public static IEnumerable<string> EnglishWords(string text)
     {
         var word = new StringBuilder();

--- a/CorpusSearch.Test/LemmaAdjudication/AdjudicationExporter.cs
+++ b/CorpusSearch.Test/LemmaAdjudication/AdjudicationExporter.cs
@@ -66,6 +66,7 @@ public class AdjudicationExporter
         var table = LemmaTable.Instance;
         var displayById = AdjudicationCommon.DisplayLemmaById();
         var glossTexts = AdjudicationCommon.LoadGlossTexts();
+        var classGlosses = AdjudicationCommon.LoadCregeenClassGlosses();
         var linkTypes = AdjudicationCommon.LinkTypesByFormId();
         Dictionary<string, string[]> overrides = string.IsNullOrEmpty(overridesPath)
             ? []
@@ -112,9 +113,14 @@ public class AdjudicationExporter
                     labels.Add(label);
                 }
                 var glossKey = LemmaTable.NormalizeForm(lemma);
-                var gloss = glossTexts.TryGetValue(glossKey, out var texts)
-                    ? string.Join("; ", texts.Take(3))
-                    : "";
+                // the entry the id names, not everything spelled like it;
+                // display-keyed glosses only where no classed entry matches
+                var idClass = id[(id.LastIndexOf('.') + 1)..];
+                var gloss = classGlosses.TryGetValue((glossKey, idClass), out var own)
+                    ? own
+                    : glossTexts.TryGetValue(glossKey, out var texts)
+                        ? string.Join("; ", texts.Take(3))
+                        : "";
                 return (object)new
                 {
                     id,

--- a/CorpusSearch.Test/LemmaAdjudication/SenseInventoryGenerator.cs
+++ b/CorpusSearch.Test/LemmaAdjudication/SenseInventoryGenerator.cs
@@ -1,0 +1,502 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using CorpusSearch.Service.Dictionaries;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test.LemmaAdjudication;
+
+/// <summary>
+/// Mints the Cregeen sense inventory (DESIGN-disambiguation.md Phase 4):
+/// one row per discriminable printed sense, senseId = lemmaId#n with n in
+/// book order, entryPath = the printed headword the sense belongs to.
+///
+/// Rows are minted only where a lemma id has two or more printed entries to
+/// tell apart - a single-entry id keeps its implicit whole-entry sense, and
+/// the id split (aase.n / aase.v) already carries the word-class distinction.
+/// Cregeen's double-printed prefix compounds (aa-aase under aa- and at its
+/// own place) fold to one sense, as the word page folds them to one link.
+///
+/// Ids that already have senses.tsv rows are skipped, not regenerated: the
+/// existing rows are curated and can be finer than the print (foddey.a#2
+/// "long, of time" splits a single printed entry). They go to the skim
+/// report for manual reconcile instead.
+///
+/// Writes senses.generated.tsv (rows to review, then fold into senses.tsv)
+/// and senses.generated.skim.tsv (what needs a human) beside the inputs.
+///
+/// Run: LEMMA_DATA_DIR=&lt;manx-lemma-data&gt;
+///   dotnet test CorpusSearch.Test --filter FullyQualifiedName~SenseInventoryGenerator
+/// </summary>
+[TestFixture]
+[Explicit("artifact generator over cregeen.json and the lemma table, not a regression test")]
+public class SenseInventoryGenerator
+{
+    /// <summary>One printed entry, deduplicated: headword, its printed word
+    /// classes, and the gloss snippet that discriminates it</summary>
+    internal sealed record PrintedSense(string Headword, IReadOnlyList<string> Pos, string Gloss);
+
+    /// <summary>Gloss carries the whole definition; the vendored TSV snips it
+    /// to the pilot's snippet length, the review file shows it entire. Flag
+    /// is the review's margin note ("single-id-attach", "near-identical"),
+    /// empty on rows nothing doubts.</summary>
+    internal sealed record MintedSense(string SenseId, string LemmaId, string EntryPath, string Gloss)
+    {
+        public string Flag { get; set; } = "";
+    }
+
+    /// <summary>A sense the generator could not place, and why: the human
+    /// queue, not an error list</summary>
+    internal sealed record SkimRow(string Headword, string Reason, string Detail);
+
+    [Test]
+    public void Generate()
+    {
+        var dataDir = Environment.GetEnvironmentVariable("LEMMA_DATA_DIR");
+        Assert.That(dataDir, Is.Not.Null.And.Not.Empty, "set LEMMA_DATA_DIR to the manx-lemma-data checkout");
+
+        var entries = CregeenDictionaryService.GetEntries();
+        Assume.That(entries, Is.Not.Empty, "cregeen.json not present");
+
+        var idsByWord = ReadSelfIds(Path.Combine(dataDir!, "cregeen.tsv"));
+        var existing = ReadExistingSenseIds(Path.Combine(dataDir!, "senses.tsv"));
+
+        var senses = PrintedSensesOf(entries);
+        var (minted, skim) = Mint(senses, idsByWord, existing);
+
+        // ids the table minted from an apparatus label, taking the printed
+        // reading over its correction (foddey.v from "<v>[a]."): nonsense at
+        // the lexeme layer. The fix is the cregeen-nvh table generator using
+        // the corrected reading (cregeen.json's PartsOfSpeech already does),
+        // then a rekey; enumerated here so the senses over them are read
+        // with suspicion until then
+        foreach (var (id, pos) in ReadApparatusIds(Path.Combine(dataDir!, "cregeen.tsv")))
+        {
+            skim.Add(new SkimRow(id, "apparatus-pos-id",
+                $"table pos is the raw apparatus \"{pos}\"; the correction names the class"));
+        }
+
+        var output = new StringBuilder("senseId\tlemmaId\tdict\tentryPath\tgloss\n");
+        foreach (var row in minted)
+        {
+            output.Append($"{row.SenseId}\t{row.LemmaId}\tcregeen\t{row.EntryPath}\t{Snip(row.Gloss)}\n");
+        }
+        File.WriteAllText(Path.Combine(dataDir!, "senses.generated.tsv"), output.ToString());
+
+        // the review file is for a human's eye alone: an id's readings stay
+        // together (judging "two senses or one?" needs them side by side),
+        // groups anything doubts float to the top whole, definitions are
+        // uncut, and a blank line breathes between ids
+        var review = new StringBuilder("flag\tsenseId\tentryPath\tgloss\n");
+        var groups = minted.GroupBy(x => x.LemmaId)
+            .OrderBy(g => g.All(x => x.Flag.Length == 0))
+            .ThenBy(g => g.Key, StringComparer.Ordinal);
+        foreach (var group in groups)
+        {
+            foreach (var row in group)
+            {
+                review.Append($"{row.Flag}\t{row.SenseId}\t{row.EntryPath}\t{row.Gloss}\n");
+            }
+            review.Append('\n');
+        }
+        File.WriteAllText(Path.Combine(dataDir!, "senses.review.tsv"), review.ToString());
+
+        var skimOut = new StringBuilder("headword\treason\tdetail\n");
+        foreach (var row in skim.OrderBy(x => x.Reason, StringComparer.Ordinal))
+        {
+            skimOut.Append($"{row.Headword}\t{row.Reason}\t{row.Detail}\n");
+        }
+        File.WriteAllText(Path.Combine(dataDir!, "senses.generated.skim.tsv"), skimOut.ToString());
+
+        Console.WriteLine($"printed senses (deduped): {senses.Count}");
+        Console.WriteLine($"minted rows: {minted.Count} across {minted.Select(x => x.LemmaId).Distinct().Count()} lemma ids");
+        foreach (var reason in skim.GroupBy(x => x.Reason).OrderByDescending(x => x.Count()))
+        {
+            Console.WriteLine($"skim/{reason.Key}: {reason.Count()}");
+        }
+    }
+
+    /// <summary>The printed entries in book order, children included, one
+    /// sense each, with Cregeen's double-printings folded to their first
+    /// appearance. Children walk because the table files phrase readings
+    /// under the parent's id ('dy cheilley' → cheilley.x): a reading with no
+    /// senseId is one the sidecar can never assign to a token in context.
+    /// The grammatical children ('e edjag' his feather) fold away by
+    /// <see cref="SenseKey"/> instead, in <see cref="Mint"/>.</summary>
+    internal static List<PrintedSense> PrintedSensesOf(IEnumerable<Model.Dictionary.CregeenEntry> entries)
+    {
+        var senses = new List<PrintedSense>();
+        var seen = new HashSet<string>();
+        void Walk(IEnumerable<Model.Dictionary.CregeenEntry> level)
+        {
+            foreach (var entry in level)
+            {
+                var headword = entry.Words.FirstOrDefault();
+                if (headword != null)
+                {
+                    var pos = entry.PartsOfSpeech ?? [];
+                    var gloss = CollapseGloss(entry.Definition);
+                    var key = $"{headword.ToLowerInvariant()}\t{string.Join(",", pos)}\t{NormalizeGloss(gloss)}";
+                    if (seen.Add(key))
+                    {
+                        senses.Add(new PrintedSense(headword, pos, gloss));
+                    }
+                }
+                Walk(entry.SafeChildren);
+            }
+        }
+        Walk(entries);
+        return senses;
+    }
+
+    /// <summary>The entry's plain definition as one line, whole: the folds
+    /// compare it and the review shows it</summary>
+    internal static string CollapseGloss(string? definition) =>
+        string.Join(" ", (definition ?? "").Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    /// <summary>The sense's discriminating snippet: the whole gloss capped
+    /// the way the pilot rows are, for the vendored TSV alone</summary>
+    internal static string GlossOf(string? definition) => Snip(CollapseGloss(definition));
+
+    private static string Snip(string gloss) =>
+        gloss.Length <= 80 ? gloss : gloss[..79].TrimEnd() + "…";
+
+    /// <summary>What makes two glosses the same sense: the book's two
+    /// printings of a compound differ by a hyphen, a trailing semicolon or
+    /// the spacing of a compound ("a great grand child" / "a great
+    /// grandchild;"), and that is one sense, not two. Letters and digits
+    /// alone decide.</summary>
+    internal static string NormalizeGloss(string gloss) =>
+        new(gloss.ToLowerInvariant().Where(char.IsLetterOrDigit).ToArray());
+
+    /// <summary>The words of Cregeen's grammatical formulas: what a child
+    /// entry's gloss wraps around the parent's ("his feather", "your, &amp;c.
+    /// feather", "to push, &amp;c.", "hath, &amp;c. reared"). Content words
+    /// they are not, so they carry no sense of their own.</summary>
+    private static readonly HashSet<string> FormulaWords =
+    [
+        "his", "her", "your", "our", "their", "my", "thy", "the", "a", "an",
+        "of", "to", "c", "did", "didst", "doth", "dost", "hath", "hast",
+        "have", "had", "would", "wouldst", "should", "shouldst", "shall",
+        "shalt", "will", "wilt", "art", "am", "is", "are", "was", "wast",
+        "were", "wert", "be", "been", "or", "and", "too", "not",
+    ];
+
+    /// <summary>What a gloss says once the grammatical formula is stripped:
+    /// "his feather" and "a feather" both say "feather" - the same sense
+    /// through a possessive, not two senses. A gloss that is nothing but
+    /// formula ("would be") falls back to its plain letters, so the
+    /// auxiliaries' own entries stay distinguishable.</summary>
+    internal static string SenseKey(string gloss)
+    {
+        var folded = new string(gloss.ToLowerInvariant()
+            .Select(c => char.IsLetterOrDigit(c) ? c : ' ')
+            .ToArray());
+        var content = string.Concat(
+            folded.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Where(w => !FormulaWords.Contains(w)));
+        return content.Length > 0 ? content : NormalizeGloss(gloss);
+    }
+
+    /// <summary>The lemma id a printed word class files under: the table's
+    /// suffix scheme (n / v / a, x for the closed classes). Null when the
+    /// entry has no single printed class to map.</summary>
+    internal static string? SuffixOf(IReadOnlyList<string> pos)
+    {
+        if (pos.Count != 1)
+        {
+            return null;
+        }
+        return pos[0] switch
+        {
+            "Noun" => "n",
+            "Verb" => "v",
+            "Adjective" => "a",
+            _ => "x",
+        };
+    }
+
+    private static string IdSuffix(string lemmaId)
+    {
+        var dot = lemmaId.LastIndexOf('.');
+        return dot < 0 ? lemmaId : lemmaId[(dot + 1)..];
+    }
+
+    /// <summary>
+    /// Attach each sense to a lemma id, then mint rows for every id with two
+    /// or more senses to tell apart. Ordinals count in book order, per id.
+    /// </summary>
+    internal static (List<MintedSense> Minted, List<SkimRow> Skim) Mint(
+        IEnumerable<PrintedSense> sensesInBookOrder,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> idsByWord,
+        IReadOnlySet<string> idsWithExistingRows)
+    {
+        var attached = new List<(string Id, PrintedSense Sense, bool Fallback)>();
+        var skim = new List<SkimRow>();
+
+        foreach (var sense in sensesInBookOrder)
+        {
+            var ids = idsByWord.GetValueOrDefault(sense.Headword.ToLowerInvariant());
+            if (ids == null || ids.Count == 0)
+            {
+                // a printed word the table has no id for is the table's gap,
+                // not the inventory's: Phase 2's queue, only counted here
+                continue;
+            }
+
+            var suffix = SuffixOf(sense.Pos);
+            var matches = suffix == null ? [] : ids.Where(x => IdSuffix(x) == suffix).ToList();
+            if (matches.Count == 1)
+            {
+                attached.Add((matches[0], sense, Fallback: false));
+            }
+            else if (ids.Count == 1)
+            {
+                // one id is the only place the sense can live, whatever the
+                // label says - attached, and reported when it mints, so a
+                // mislabel is seen where it matters
+                attached.Add((ids[0], sense, Fallback: true));
+            }
+            else
+            {
+                skim.Add(new SkimRow(sense.Headword,
+                    matches.Count > 1 ? "ambiguous-ids" : sense.Pos.Count == 1 ? "pos-unmatched" : "no-single-pos",
+                    $"pos [{string.Join(", ", sense.Pos)}] ids [{string.Join(", ", ids)}]: {sense.Gloss}"));
+            }
+        }
+
+        var minted = new List<MintedSense>();
+        foreach (var group in attached.GroupBy(x => x.Id))
+        {
+            // discriminable = distinct readings: the double-printings that
+            // survive the entry-level fold (a hyphen, a trailing semicolon,
+            // one printing truncating the other's gloss) are one sense here
+            var discriminable = Discriminable(group.ToList());
+            if (discriminable.Count < 2)
+            {
+                continue; // the implicit whole-entry sense suffices
+            }
+            if (idsWithExistingRows.Contains(group.Key))
+            {
+                skim.Add(new SkimRow(group.First().Sense.Headword, "existing-rows",
+                    $"{group.Key} already has curated senses; reconcile by hand"));
+                continue;
+            }
+            if (discriminable.Any(x => x.Sense.Gloss.Contains('<') || x.Sense.Gloss.Contains('[')))
+            {
+                // an apparatus gloss is two readings in one string: whether
+                // its printings are one sense is the apparatus question, not
+                // a spelling one - a human's, until the upstream handling
+                skim.Add(new SkimRow(group.First().Sense.Headword, "apparatus-gloss",
+                    $"{group.Key}: {string.Join(" | ", discriminable.Select(x => x.Sense.Gloss))}"));
+                continue;
+            }
+            var ordinal = 0;
+            var rows = new List<MintedSense>();
+            foreach (var (id, sense, fallback) in discriminable)
+            {
+                ordinal++;
+                rows.Add(new MintedSense($"{id}#{ordinal}", id, $"cregeen:{sense.Headword}", sense.Gloss)
+                {
+                    Flag = fallback ? "single-id-attach" : "",
+                });
+                if (fallback)
+                {
+                    skim.Add(new SkimRow(sense.Headword, "single-id-attach",
+                        $"pos [{string.Join(", ", sense.Pos)}] onto {id}: {sense.Gloss}"));
+                }
+            }
+            FlagNearIdentical(rows);
+            minted.AddRange(rows);
+        }
+        return (minted, skim);
+    }
+
+    /// <summary>The distinct readings among one id's printed senses: two
+    /// glosses whose stemmed content words half-overlap are one reading -
+    /// the grammatical children ("his feather" says "feather"), the
+    /// truncated and label-prefixed reprintings ("discord, division;"),
+    /// and the same verb glossed across its inflections ("lifting, rearing"
+    /// / "to lift, rear"). The fuller gloss survives the fold. What is left
+    /// is a reading of its own: 'dy cheilley' "together, joined" beside
+    /// "one another".</summary>
+    private static List<(string Id, PrintedSense Sense, bool Fallback)> Discriminable(
+        List<(string Id, PrintedSense Sense, bool Fallback)> group)
+    {
+        var kept = new List<(string Id, PrintedSense Sense, bool Fallback)>();
+        foreach (var candidate in group.Where(x => x.Sense.Gloss.Length > 0)
+                     .DistinctBy(x => SenseKey(x.Sense.Gloss)))
+        {
+            var words = ContentWords(candidate.Sense.Gloss);
+            var at = kept.FindIndex(k => SameReading(words, ContentWords(k.Sense.Gloss)));
+            if (at < 0)
+            {
+                kept.Add(candidate);
+            }
+            else if (candidate.Sense.Gloss.Length > kept[at].Sense.Gloss.Length)
+            {
+                kept[at] = (kept[at].Id, candidate.Sense, kept[at].Fallback);
+            }
+        }
+        return kept;
+    }
+
+    /// <summary>Marks the pairs one letter-slip apart (crudled/curdled shapes
+    /// whose content words happen not to meet): the fold will not guess at
+    /// them, so the reviewer's eye is asked instead</summary>
+    private static void FlagNearIdentical(List<MintedSense> rows)
+    {
+        for (var i = 0; i < rows.Count; i++)
+        {
+            for (var j = i + 1; j < rows.Count; j++)
+            {
+                var a = NormalizeGloss(rows[i].Gloss);
+                var b = NormalizeGloss(rows[j].Gloss);
+                if (Similarity(a, b) < 0.85)
+                {
+                    continue;
+                }
+                foreach (var row in new[] { rows[i], rows[j] }
+                             .Where(x => !x.Flag.Contains("near-identical")))
+                {
+                    row.Flag = row.Flag.Length == 0 ? "near-identical" : row.Flag + "+near-identical";
+                }
+            }
+        }
+    }
+
+    /// <summary>1 at identical, scaled down by edit distance</summary>
+    private static double Similarity(string a, string b)
+    {
+        if (a.Length == 0 || b.Length == 0)
+        {
+            return 0;
+        }
+        var previous = Enumerable.Range(0, b.Length + 1).ToArray();
+        for (var i = 1; i <= a.Length; i++)
+        {
+            var current = new int[b.Length + 1];
+            current[0] = i;
+            for (var j = 1; j <= b.Length; j++)
+            {
+                current[j] = Math.Min(
+                    Math.Min(previous[j] + 1, current[j - 1] + 1),
+                    previous[j - 1] + (a[i - 1] == b[j - 1] ? 0 : 1));
+            }
+            previous = current;
+        }
+        return 1.0 - (double)previous[b.Length] / Math.Max(a.Length, b.Length);
+    }
+
+    /// <summary>Whether half of the smaller gloss's content already says what
+    /// the other says. All-formula glosses ("would be") never match here:
+    /// they stay apart unless spelled alike.</summary>
+    private static bool SameReading(HashSet<string> a, HashSet<string> b) =>
+        a.Count > 0 && b.Count > 0
+        && a.Intersect(b).Count() * 2 >= Math.Min(a.Count, b.Count);
+
+    /// <summary>The gloss's stemmed content words: formula words drop, and a
+    /// crude English stem folds the inflections the book glosses with
+    /// ("lifting"/"lift", "reared"/"rear")</summary>
+    internal static HashSet<string> ContentWords(string gloss)
+    {
+        var folded = new string(gloss.ToLowerInvariant()
+            .Select(c => char.IsLetterOrDigit(c) ? c : ' ')
+            .ToArray());
+        return folded.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(w => !FormulaWords.Contains(w))
+            .Select(Stem)
+            .ToHashSet();
+    }
+
+    private static string Stem(string word)
+    {
+        var stem = word;
+        if (stem.Length > 5 && stem.EndsWith("ing", StringComparison.Ordinal))
+        {
+            stem = stem[..^3];
+        }
+        else if (stem.Length > 4 && (stem.EndsWith("eth", StringComparison.Ordinal)
+                                     || stem.EndsWith("est", StringComparison.Ordinal)))
+        {
+            stem = stem[..^3];
+        }
+        else if (stem.Length > 4 && (stem.EndsWith("ed", StringComparison.Ordinal)
+                                     || stem.EndsWith("es", StringComparison.Ordinal)
+                                     || stem.EndsWith("en", StringComparison.Ordinal)))
+        {
+            stem = stem[..^2];
+        }
+        else if (stem.Length > 3 && stem.EndsWith("s", StringComparison.Ordinal))
+        {
+            stem = stem[..^1];
+        }
+        // 'shaking' stems to 'shak' and bare 'shake' must meet it there
+        return stem.Length > 3 && stem.EndsWith("e", StringComparison.Ordinal) ? stem[..^1] : stem;
+    }
+
+    /// <summary>headword (lower) → its lemma ids, from the table's self rows,
+    /// keyed by FORM: a self row is the table saying "this spelling is a
+    /// citation form of this id", and the printed headword is not always the
+    /// lemma display (Cregeen headwords the lenited 'cheilley' under keeill;
+    /// its id is keilley.a, whose display is the unlenited spelling)</summary>
+    private static Dictionary<string, IReadOnlyList<string>> ReadSelfIds(string cregeenTsv) =>
+        SelfIdsByForm(File.ReadLines(cregeenTsv));
+
+    internal static Dictionary<string, IReadOnlyList<string>> SelfIdsByForm(IEnumerable<string> lines)
+    {
+        var byForm = new Dictionary<string, List<string>>();
+        foreach (var line in lines)
+        {
+            if (line.StartsWith('#') || line.StartsWith("form\t"))
+            {
+                continue;
+            }
+            var columns = line.Split('\t');
+            if (columns.Length < 4 || columns[3] != "self")
+            {
+                continue;
+            }
+            var form = columns[0].ToLowerInvariant();
+            if (!byForm.TryGetValue(form, out var ids))
+            {
+                byForm[form] = ids = [];
+            }
+            if (!ids.Contains(columns[1]))
+            {
+                ids.Add(columns[1]);
+            }
+        }
+        return byForm.ToDictionary(x => x.Key, x => (IReadOnlyList<string>)x.Value);
+    }
+
+    /// <summary>Ids whose table pos still carries the editorial apparatus
+    /// ("&lt;v&gt;[a]."): minted from the printed reading, not its correction</summary>
+    private static List<(string Id, string Pos)> ReadApparatusIds(string cregeenTsv)
+    {
+        return File.ReadLines(cregeenTsv)
+            .Where(x => !x.StartsWith('#') && !x.StartsWith("form\t"))
+            .Select(x => x.Split('\t'))
+            .Where(x => x.Length >= 5 && (x[4].Contains('<') || x[4].Contains('[')))
+            .Select(x => (Id: x[1], Pos: x[4]))
+            .Distinct()
+            .OrderBy(x => x.Id, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static HashSet<string> ReadExistingSenseIds(string sensesTsv)
+    {
+        if (!File.Exists(sensesTsv))
+        {
+            return [];
+        }
+        return File.ReadLines(sensesTsv)
+            .Where(x => x.Length > 0 && !x.StartsWith('#') && !x.StartsWith("senseId\t"))
+            .Select(x => x.Split('\t'))
+            .Where(x => x.Length >= 2)
+            .Select(x => x[1])
+            .ToHashSet();
+    }
+}

--- a/CorpusSearch.Test/LemmaAdjudication/SenseInventoryGenerator.cs
+++ b/CorpusSearch.Test/LemmaAdjudication/SenseInventoryGenerator.cs
@@ -9,6 +9,14 @@ using NUnit.Framework;
 namespace CorpusSearch.Test.LemmaAdjudication;
 
 /// <summary>
+/// DEPRECATED - the bootstrap that minted the first inventory. The build
+/// lives in cregeen-nvh now (tools/Senses.fs, `make senses`, from c80b6f4),
+/// where the curation rides as sidecars: senses.nvh (hand rows) and
+/// sense-exclusions.nvh (content-keyed, replacing this tool's post-hoc
+/// senseId exclusion). Do not ship this tool's output; it stays only as
+/// the behavioural spec (the tests below) until one clean regeneration
+/// cycle retires it.
+///
 /// Mints the Cregeen sense inventory (DESIGN-disambiguation.md Phase 4):
 /// one row per discriminable printed sense, senseId = lemmaId#n with n in
 /// book order, entryPath = the printed headword the sense belongs to.

--- a/CorpusSearch.Test/LemmaAdjudication/SenseInventoryGeneratorTest.cs
+++ b/CorpusSearch.Test/LemmaAdjudication/SenseInventoryGeneratorTest.cs
@@ -1,0 +1,335 @@
+using System.Collections.Generic;
+using System.Linq;
+using CorpusSearch.Model.Dictionary;
+using NUnit.Framework;
+using static CorpusSearch.Test.LemmaAdjudication.SenseInventoryGenerator;
+
+namespace CorpusSearch.Test.LemmaAdjudication;
+
+public class SenseInventoryGeneratorTest
+{
+    private static CregeenEntry Entry(string word, string? pos, string gloss, params CregeenEntry[] children) =>
+        new()
+        {
+            Words = [word],
+            EntryHtml = "",
+            HeadingHtml = "",
+            Definition = gloss,
+            PartsOfSpeech = pos == null ? [] : [pos],
+            Children = children.ToList(),
+        };
+
+    private static Dictionary<string, IReadOnlyList<string>> Ids(
+        params (string Word, string[] Ids)[] entries) =>
+        entries.ToDictionary(x => x.Word, x => (IReadOnlyList<string>)x.Ids);
+
+    /// <summary>An id with two printed entries gets ordinals in book order;
+    /// an id with one keeps its implicit whole-entry sense</summary>
+    [Test]
+    public void TwoSensesMintAndOneDoesNot()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("aase", ["Noun"], "growth"),
+            new PrintedSense("aase", ["Noun"], "a second crop"),
+            new PrintedSense("aase", ["Verb"], "grow"),
+        };
+        var (minted, skim) = Mint(senses, Ids(("aase", ["aase.n", "aase.v"])), new HashSet<string>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(minted.Select(x => x.SenseId), Is.EqualTo(new[] { "aase.n#1", "aase.n#2" }));
+            Assert.That(minted[0].Gloss, Is.EqualTo("growth"));
+            Assert.That(minted[0].EntryPath, Is.EqualTo("cregeen:aase"));
+            Assert.That(skim, Is.Empty);
+        });
+    }
+
+    /// <summary>Curated rows are finer than the print (foddey.a#2 splits one
+    /// printed entry): the generator never mints over them</summary>
+    [Test]
+    public void AnIdWithCuratedRowsIsSkippedAndFlagged()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("foddey", ["Adjective"], "far, at a great distance"),
+            new PrintedSense("foddey", ["Adjective"], "remote, distant, foreign"),
+        };
+        var (minted, skim) = Mint(senses, Ids(("foddey", ["foddey.a"])),
+            new HashSet<string> { "foddey.a" });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(minted, Is.Empty);
+            Assert.That(skim.Single().Reason, Is.EqualTo("existing-rows"));
+        });
+    }
+
+    /// <summary>A sense with no printed class still attaches when the word
+    /// has only one id - and is reported, so a mislabel is seen</summary>
+    [Test]
+    public void ASingleIdTakesTheUnlabelledSense()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("er-lhieu", [], "in their opinion"),
+            new PrintedSense("er-lhieu", [], "they think"),
+        };
+        var (minted, skim) = Mint(senses, Ids(("er-lhieu", ["er-lhieu.x"])), new HashSet<string>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(minted.Select(x => x.SenseId), Is.EqualTo(new[] { "er-lhieu.x#1", "er-lhieu.x#2" }));
+            Assert.That(minted.Select(x => x.Flag), Is.All.EqualTo("single-id-attach"));
+            Assert.That(skim.Count(x => x.Reason == "single-id-attach"), Is.EqualTo(2));
+        });
+    }
+
+    /// <summary>A pair one letter-slip apart whose content words never meet:
+    /// the fold will not guess, so both rows carry the reviewer's flag</summary>
+    [Test]
+    public void ALetterSlipPairIsFlaggedNearIdentical()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("sheiltynys", ["Noun"], "imagination"),
+            new PrintedSense("sheiltynys", ["Noun"], "immagination"),
+        };
+        var (minted, _) = Mint(senses, Ids(("sheiltynys", ["sheiltynys.n"])), new HashSet<string>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(minted, Has.Count.EqualTo(2));
+            Assert.That(minted.Select(x => x.Flag), Is.All.EqualTo("near-identical"));
+        });
+    }
+
+    /// <summary>Several ids and no matching class is a human's call</summary>
+    [Test]
+    public void AnUnmatchedSenseAmongSeveralIdsGoesToTheSkim()
+    {
+        var senses = new[] { new PrintedSense("çhiu", ["Adverb"], "thickly") };
+        var (minted, skim) = Mint(senses, Ids(("çhiu", ["çhiu.a", "çhiu.n"])), new HashSet<string>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(minted, Is.Empty);
+            Assert.That(skim.Single().Reason, Is.EqualTo("pos-unmatched"));
+        });
+    }
+
+    /// <summary>A sense with no gloss cannot discriminate anything: it never
+    /// mints, and never drags a real pair below the minting bar</summary>
+    [Test]
+    public void EmptyGlossesDoNotMint()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("eabbey", ["Verb"], ""),
+            new PrintedSense("eabbey", ["Verb"], "attempting"),
+        };
+        var (minted, _) = Mint(senses, Ids(("eabbey", ["eabbey.v"])), new HashSet<string>());
+        Assert.That(minted, Is.Empty);
+    }
+
+    /// <summary>Two top-level printings of the same entry fold to one</summary>
+    [Test]
+    public void DoublePrintedEntriesFoldToOneSense()
+    {
+        var senses = PrintedSensesOf([
+            Entry("aa-aase", "Noun", "second growth"),
+            Entry("aa-aase", "Noun", "second growth"),
+        ]);
+        Assert.That(senses.Count(x => x.Headword == "aa-aase"), Is.EqualTo(1));
+    }
+
+    /// <summary>Children that conjugate and mutate the parent ('e edjag' his
+    /// feather) say the same thing through a possessive: they fold, and the
+    /// id keeps its one implicit sense</summary>
+    [Test]
+    public void MutationChildrenFoldIntoTheParentSense()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("fedjag", ["Noun"], "a feather"),
+            new PrintedSense("e edjag", ["Noun"], "his feather"),
+            new PrintedSense("nyn vedjag", ["Noun"], "your, &c. feather"),
+        };
+        var ids = Ids(("fedjag", ["fedjag.n"]), ("e edjag", ["fedjag.n"]), ("nyn vedjag", ["fedjag.n"]));
+        var (minted, _) = Mint(senses, ids, new HashSet<string>());
+        Assert.That(minted, Is.Empty);
+    }
+
+    /// <summary>A phrase child with a reading of its own ('dy cheilley'
+    /// together) mints beside the parent: a reading with no senseId is one
+    /// the sidecar can never assign to a token in context</summary>
+    [Test]
+    public void APhraseChildKeepsItsOwnReading()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("cheilley", ["Pronoun"], "‘one another’"),
+            new PrintedSense("dy cheilley", ["Adverb"], "together, joined"),
+        };
+        var ids = Ids(("cheilley", ["cheilley.x"]), ("dy cheilley", ["cheilley.x"]));
+        var (minted, _) = Mint(senses, ids, new HashSet<string>());
+        Assert.That(minted.Select(x => (x.SenseId, x.EntryPath)), Is.EqualTo(new[]
+        {
+            ("cheilley.x#1", "cregeen:cheilley"),
+            ("cheilley.x#2", "cregeen:dy cheilley"),
+        }));
+    }
+
+    /// <summary>A self row keys by its FORM: Cregeen headwords the lenited
+    /// 'cheilley' under keeill, and its id is keilley.a - looking the ids up
+    /// by lemma display would leave only cheilley.x, and 'of the church'
+    /// would park on the reciprocal pronoun</summary>
+    [Test]
+    public void SelfRowsKeyByFormNotLemmaDisplay()
+    {
+        var ids = SelfIdsByForm(
+        [
+            "form\tlemmaId\tlemma\tlinkType\tpos\tvia\tnote",
+            "cheilley\tcheilley.x\tcheilley\tself\tpro.\tcheilley\t",
+            "cheilley\tkeilley.a\tkeilley\tself\ta. d.\tcheilley\t",
+            "cheilley\tkeilley.a\tkeilley\tdemutated\ta. d.\tcheilley\t",
+        ]);
+        Assert.That(ids["cheilley"], Is.EqualTo(new[] { "cheilley.x", "keilley.a" }));
+
+        var senses = new[]
+        {
+            new PrintedSense("cheilley", ["Pronoun"], "one another"),
+            new PrintedSense("cheilley", ["Adjective"], "of the church"),
+        };
+        var (minted, skim) = Mint(senses, ids, new HashSet<string>());
+        Assert.Multiple(() =>
+        {
+            // each sense lands on its own lexeme: nothing to discriminate
+            Assert.That(minted, Is.Empty);
+            Assert.That(skim, Is.Empty);
+        });
+    }
+
+    /// <summary>The two printings of a compound differ by a hyphen or a
+    /// trailing semicolon: one sense, not a minted pair</summary>
+    [Test]
+    public void NearDuplicateGlossesAreOneSense()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("aa-oe", ["Noun"], "a great grand child"),
+            new PrintedSense("aa-oe", ["Noun"], "a great grandchild;"),
+        };
+        var (minted, _) = Mint(senses, Ids(("aa-oe", ["aa-oe.n"])), new HashSet<string>());
+        Assert.That(minted, Is.Empty);
+    }
+
+    /// <summary>The second printing truncates the first's gloss ("discord,
+    /// division;" under the prefix entry): one sense, the fuller text</summary>
+    [Test]
+    public void ATruncatedReprintingFoldsIntoTheFullerGloss()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("anvea", ["Noun"], "discord, division, strife, perplexity"),
+            new PrintedSense("anvea", ["Noun"], "discord, division;"),
+        };
+        var (minted, _) = Mint(senses, Ids(("anvea", ["anvea.n"])), new HashSet<string>());
+        Assert.That(minted, Is.Empty);
+    }
+
+    /// <summary>The second printing prepends a label instead ("pl. principal
+    /// fathers"): the suffix fold catches what the prefix fold cannot</summary>
+    [Test]
+    public void ALabelPrefixedReprintingFoldsToo()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("ard-ayraghyn", ["Noun"], "principal fathers, chief fathers;"),
+            new PrintedSense("ard-ayraghyn", ["Noun"], "pl. principal fathers, chief fathers;"),
+        };
+        var (minted, _) = Mint(senses, Ids(("ard-ayraghyn", ["ard-ayraghyn.n"])), new HashSet<string>());
+        Assert.That(minted, Is.Empty);
+    }
+
+    /// <summary>An apparatus gloss is two readings in one string: whether its
+    /// printings are one sense is a human's call, not a spelling rule's</summary>
+    [Test]
+    public void ApparatusGlossesGoToTheSkimNotTheInventory()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("anlheil", ["Noun"], "<unable> [inability] to move about"),
+            new PrintedSense("anlheil", ["Noun"], "helplessness of the body"),
+        };
+        var (minted, skim) = Mint(senses, Ids(("anlheil", ["anlheil.n"])), new HashSet<string>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(minted, Is.Empty);
+            Assert.That(skim.Single().Reason, Is.EqualTo("apparatus-gloss"));
+        });
+    }
+
+    /// <summary>The same verb glossed across its inflections ("lifting" /
+    /// "to lift" / "hath reared") is one reading: stemmed content words
+    /// overlap, and the fuller gloss survives</summary>
+    [Test]
+    public void InflectionGlossesFoldIntoOneReading()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("troggal", ["Verb"], "lifting, rearing, training, building;"),
+            new PrintedSense("dy hroggal", ["Verb"], "to lift, rear, build, train, &c"),
+            new PrintedSense("er droggal", ["Verb"], "hath, &c. reared, lifted, trained, built, or raised"),
+        };
+        var ids = Ids(("troggal", ["troggal.v"]), ("dy hroggal", ["troggal.v"]), ("er droggal", ["troggal.v"]));
+        var (minted, _) = Mint(senses, ids, new HashSet<string>());
+        Assert.That(minted, Is.Empty);
+    }
+
+    /// <summary>A one-letter spelling slip between the printings (crudled /
+    /// curdled) folds on the surviving shared words</summary>
+    [Test]
+    public void ASpellingSlipBetweenPrintingsFolds()
+    {
+        var senses = new[]
+        {
+            new PrintedSense("bainney clabbagh", [], "crudled or sour milk"),
+            new PrintedSense("bainney clabbagh", [], "curdled or sour milk"),
+        };
+        var (minted, _) = Mint(senses, Ids(("bainney clabbagh", ["bainney-clabbagh.x"])), new HashSet<string>());
+        Assert.That(minted, Is.Empty);
+    }
+
+    [TestCase("Noun", "n")]
+    [TestCase("Verb", "v")]
+    [TestCase("Adjective", "a")]
+    [TestCase("Adverb", "x")]
+    [TestCase("Pronoun", "x")]
+    public void PrintedClassesFileUnderTheTableSuffixes(string pos, string expected)
+    {
+        Assert.That(SuffixOf([pos]), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void NoSingleClassMapsToNoSuffix()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(SuffixOf([]), Is.Null);
+            Assert.That(SuffixOf(["Noun", "Verb"]), Is.Null);
+        });
+    }
+
+    [Test]
+    public void GlossesAreOneLineAndCapped()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(GlossOf("growth,\n  second \t crop"), Is.EqualTo("growth, second crop"));
+            Assert.That(GlossOf(null), Is.EqualTo(""));
+            var longGloss = GlossOf(string.Join(" ", Enumerable.Repeat("word", 40)));
+            Assert.That(longGloss, Has.Length.LessThanOrEqualTo(80));
+            Assert.That(longGloss, Does.EndWith("…"));
+        });
+    }
+}

--- a/CorpusSearch.Test/SenseLayerTest.cs
+++ b/CorpusSearch.Test/SenseLayerTest.cs
@@ -31,6 +31,55 @@ public class SenseLayerTest
             "docId\tkey\tenglishHash\ttokenIndex\tform\tsenseIds\ttier\thumanVerified\n"
             + string.Join("", rows.Select(x => x + "\n"))), inventory);
 
+    /// <summary>Every vendored sense row must round-trip against the data it
+    /// points into: its lemmaId known to the table, its cregeen entryPath a
+    /// printed headword, its gloss non-empty. A cregeen-nvh edit or a table
+    /// rekey that strands a row fails here, not silently in the popup.</summary>
+    [Test]
+    public void TheVendoredInventoryRoundTrips()
+    {
+        var inventory = SenseInventory.Instance;
+        Assume.That(inventory.Count, Is.GreaterThan(0), "no vendored senses.tsv");
+        var entries = Service.Dictionaries.CregeenDictionaryService.GetEntries();
+        Assume.That(entries, Is.Not.Empty, "cregeen.json not present");
+
+        var headwords = new System.Collections.Generic.HashSet<string>(
+            System.StringComparer.OrdinalIgnoreCase);
+        void Walk(System.Collections.Generic.IEnumerable<Model.Dictionary.CregeenEntry> level)
+        {
+            foreach (var entry in level)
+            {
+                if (entry.Words.FirstOrDefault() is { } word)
+                {
+                    headwords.Add(word);
+                }
+                Walk(entry.SafeChildren);
+            }
+        }
+        Walk(entries);
+        var knownIds = LemmaAdjudication.AdjudicationCommon.DisplayLemmaById();
+
+        Assert.Multiple(() =>
+        {
+            foreach (var sense in inventory.All)
+            {
+                Assert.That(knownIds, Does.ContainKey(sense.LemmaId),
+                    $"{sense.SenseId}: lemma id unknown to the table");
+                Assert.That(sense.Gloss, Is.Not.Empty, $"{sense.SenseId}: empty gloss");
+                if (sense.Dictionary != "cregeen")
+                {
+                    continue;
+                }
+                var path = sense.EntryPath.Split(':');
+                Assert.That(path, Has.Length.EqualTo(2), $"{sense.SenseId}: malformed entryPath");
+                // set-side Contains: the set folds case (Erin/erin), and
+                // NUnit's Does.Contain would compare case-sensitively
+                Assert.That(headwords.Contains(path[1]), Is.True,
+                    $"{sense.SenseId}: entryPath names no printed entry ({sense.EntryPath})");
+            }
+        });
+    }
+
     [Test]
     public void TheInventoryKnowsItsSenses()
     {

--- a/CorpusSearch/ClientApp/src/api/DictionaryApi.ts
+++ b/CorpusSearch/ClientApp/src/api/DictionaryApi.ts
@@ -139,6 +139,24 @@ export type DictionaryPageResponse = {
      * Optional because a server from before word lists existed answers without
      * it, and the page has to survive the minutes of a deploy */
     wordLists?: WordListCitation[]
+    /** the word's named readings, one block per lemma the word resolves to
+     * whose sense inventory names any (ooh: an egg / an udder). Empty for the
+     * many words with one implicit sense; optional to survive a deploy from
+     * before the inventory existed */
+    senses?: {
+        lemmaId: string
+        /** the lemma as the reader knows it ("foddey") */
+        lemma: string
+        /** the dictionary slug whose senses these are ("cregeen") */
+        dictionary: string
+        readings: {
+            senseId: string
+            /** the book's own gloss for the reading */
+            gloss: string
+            /** the printed headword the gloss belongs to */
+            headword: string
+        }[]
+    }[]
 }
 
 /** What one printed word list prints against a word */

--- a/CorpusSearch/ClientApp/src/components/AttestationWalker.tsx
+++ b/CorpusSearch/ClientApp/src/components/AttestationWalker.tsx
@@ -307,10 +307,13 @@ export const AttestationWalker = ({
     word,
     history,
     classes,
+    senseGlosses,
 }: {
     word: string
     history: DictionaryHistoryResponse | null
     classes: string[]
+    /** the inventory's named readings, for the multi-sense warning */
+    senseGlosses?: string[]
 }) => {
     const { pathname } = useLocation()
     const [params] = useSearchParams()
@@ -569,6 +572,7 @@ export const AttestationWalker = ({
             <FirstAttestation
                 history={history}
                 classes={classes}
+                senseGlosses={senseGlosses}
                 // the walk's settled year rides down only once the walk on
                 // screen is this word's: the last word's evidence, still
                 // holding the section's shape, must not caption this one

--- a/CorpusSearch/ClientApp/src/components/FirstAttestation.test.tsx
+++ b/CorpusSearch/ClientApp/src/components/FirstAttestation.test.tsx
@@ -326,6 +326,23 @@ describe("FirstAttestation", () => {
         expect(warning.textContent).toMatch(/earliest of any of them/)
     })
 
+    it("prefers the inventory's glosses over the class list", () => {
+        // "an egg / an udder" says more than "noun, noun"
+        render(
+            <MemoryRouter>
+                <FirstAttestation
+                    history={{ ...billeyHistory, word: "ooh" }}
+                    classes={["Noun", "Verb"]}
+                    senseGlosses={["an egg", "an udder"]}
+                />
+            </MemoryRouter>,
+        )
+
+        const warning = screen.getByText(/covers more than one sense/)
+        expect(warning.textContent).toContain("an egg / an udder")
+        expect(warning.textContent).not.toContain("noun, verb")
+    })
+
     it("says nothing when the entries agree on one class", () => {
         renderBand(billeyHistory, ["Noun"])
 

--- a/CorpusSearch/ClientApp/src/components/FirstAttestation.tsx
+++ b/CorpusSearch/ClientApp/src/components/FirstAttestation.tsx
@@ -185,12 +185,16 @@ const EarlierShared = ({ claim }: { claim: AttestationClaim }) => (
 export const FirstAttestation = ({
     history,
     classes = [],
+    senseGlosses,
     sureClaim,
 }: {
     history: DictionaryHistoryResponse | null
     /** the word classes the entries declare: more than one and the date below
      * belongs to whichever of them came first */
     classes?: string[]
+    /** the inventory's named readings, when it has them: "an egg / an udder"
+     * says more than "noun, noun", so the warning prefers the glosses */
+    senseGlosses?: string[]
     /** the walk's oldest settled evidence (attestations.earliestSure): a year
      * the resolver stands behind. The history's own claim rests on counting
      * spellings, which cannot settle one — so when the walk's word is earlier
@@ -304,11 +308,11 @@ export const FirstAttestation = ({
                     >
                         !
                     </span>
-                    {`“${history.word}” covers more than one sense (${classes
-                        .map((x) => x.toLowerCase())
-                        .join(
-                            ", ",
-                        )}): this date is the earliest of any of them.`}
+                    {`“${history.word}” covers more than one sense (${
+                        senseGlosses && senseGlosses.length > 1
+                            ? senseGlosses.join(" / ")
+                            : classes.map((x) => x.toLowerCase()).join(", ")
+                    }): this date is the earliest of any of them.`}
                 </p>
             )}
             {history.truncatedForms > 0 && (

--- a/CorpusSearch/ClientApp/src/routes/Dictionary.css
+++ b/CorpusSearch/ClientApp/src/routes/Dictionary.css
@@ -241,6 +241,29 @@ h4.dict-page-dictionary {
     border-radius: 6px;
 }
 
+/* a named reading: the book's own gloss as a numbered heading under the
+   headword-and-class line, its entries a step further in - the
+   dictionary.com shape. The whole body, ancestry included, sits inside the
+   headword's margin: it all belongs to the line above. */
+.dict-page-reading-body {
+    margin-left: 20px;
+}
+
+.dict-page-reading {
+    margin: 8px 0 10px;
+}
+
+.dict-page-reading-heading {
+    margin: 0 0 4px;
+    font-size: 15px;
+    font-weight: 600;
+    color: #333;
+}
+
+.dict-page-reading .dict-page-entry {
+    margin-left: 18px;
+}
+
 /* near-spelling suggestions: tinted apart from real entries, as in the popup */
 .dict-page-suggestions {
     background: #fff8e1;

--- a/CorpusSearch/ClientApp/src/routes/Dictionary.test.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Dictionary.test.tsx
@@ -144,6 +144,154 @@ describe("Dictionary page", () => {
         expect(document.querySelectorAll(".dict-page-credit")).toHaveLength(2)
     })
 
+    it("splits the entries under the inventory's numbered readings", async () => {
+        respondWith({
+            word: "ooh",
+            isSuggestionTier: false,
+            attested: true,
+            groups: [
+                {
+                    dictionary: "Cregeen",
+                    entries: [
+                        {
+                            primaryWord: "ooh",
+                            summary: "an egg;",
+                            dictionaryName: "Cregeen",
+                            rootDepth: 0,
+                            partsOfSpeech: ["Noun"],
+                        },
+                        {
+                            primaryWord: "ooh",
+                            summary: "an udder",
+                            dictionaryName: "Cregeen",
+                            rootDepth: 0,
+                            partsOfSpeech: ["Noun"],
+                        },
+                    ],
+                },
+                {
+                    dictionary: "Phil Kelly Manx to English",
+                    entries: [
+                        {
+                            primaryWord: "ooh",
+                            summary: "egg; nest egg; ovum; dug; udder",
+                            dictionaryName: "Phil Kelly Manx to English",
+                            rootDepth: 0,
+                        },
+                    ],
+                },
+            ],
+            senses: [
+                {
+                    lemmaId: "ooh.n",
+                    lemma: "ooh",
+                    dictionary: "cregeen",
+                    readings: [
+                        {
+                            senseId: "ooh.n#1",
+                            gloss: "an egg;",
+                            headword: "ooh",
+                        },
+                        {
+                            senseId: "ooh.n#2",
+                            gloss: "an udder",
+                            headword: "ooh",
+                        },
+                    ],
+                },
+            ],
+        })
+        renderAt("/dictionary/ooh")
+
+        // dictionary.com-fashion: headword and class, then each reading a
+        // numbered heading with the books' entries beneath the one it defines
+        expect(await screen.findByText("1. an egg;")).toBeTruthy()
+        const block = document.querySelector(".dict-page-group")
+        expect(block?.querySelector(".dict-page-sense-word")?.textContent).toBe(
+            "ooh",
+        )
+        const headings = [
+            ...document.querySelectorAll(".dict-page-reading-heading"),
+        ]
+        expect(headings.map((h) => h.textContent)).toEqual([
+            "1. an egg;",
+            "2. an udder",
+        ])
+        // Phil Kelly's line answers both readings: under each, marked as
+        // possibly belonging to the other
+        expect(
+            document.querySelectorAll(".dict-page-entry-unplaced"),
+        ).toHaveLength(2)
+    })
+
+    it("drops unmatched entries to the class-grouped tail", async () => {
+        respondWith({
+            word: "voddey",
+            isSuggestionTier: false,
+            attested: true,
+            groups: [
+                {
+                    dictionary: "Cregeen",
+                    entries: [
+                        {
+                            primaryWord: "cha voddey",
+                            summary: "not long, not far",
+                            dictionaryName: "Cregeen",
+                            rootDepth: 0,
+                            partsOfSpeech: ["Adjective"],
+                            throughLemma: "foddey",
+                        },
+                        {
+                            primaryWord: "yn voddey",
+                            summary: "the dog.",
+                            dictionaryName: "Cregeen",
+                            rootDepth: 0,
+                            partsOfSpeech: ["Noun"],
+                            throughLemma: "moddey",
+                        },
+                    ],
+                },
+            ],
+            senses: [
+                {
+                    lemmaId: "foddey.a",
+                    lemma: "foddey",
+                    dictionary: "cregeen",
+                    readings: [
+                        {
+                            senseId: "foddey.a#1",
+                            gloss: "far, at a great distance",
+                            headword: "foddey",
+                        },
+                        {
+                            senseId: "foddey.a#2",
+                            gloss: "long, of time",
+                            headword: "foddey",
+                        },
+                    ],
+                },
+            ],
+        })
+        renderAt("/dictionary/voddey")
+
+        // "not long, not far" answers both foddey readings; the dog matches
+        // neither and keeps the page it had, after the named readings -
+        // headed by its own lexeme, not the mutated spelling
+        expect(await screen.findByText(/the dog/)).toBeTruthy()
+        expect(
+            [...document.querySelectorAll(".dict-page-sense-word")].map(
+                (x) => x.textContent,
+            ),
+        ).toEqual(["foddey", "moddey"])
+        const headings = [
+            ...document.querySelectorAll(".dict-page-reading-heading"),
+        ].map((h) => h.textContent)
+        expect(headings).toEqual([
+            "1. far, at a great distance",
+            "2. long, of time",
+        ])
+    })
+
     /** One word of one book, with the picker's answer as the caller likes it */
     const caag = (answering: string[]): PageFixture => ({
         word: "caag",

--- a/CorpusSearch/ClientApp/src/routes/Dictionary.tsx
+++ b/CorpusSearch/ClientApp/src/routes/Dictionary.tsx
@@ -14,6 +14,7 @@ import {
     dictionaryIndexUrl,
     dictionaryWordUrl,
     headingFor,
+    readingGroupsIn,
     rootsBySense,
     senseGroupsIn,
     tiersOf,
@@ -291,8 +292,17 @@ export const Dictionary = () => {
 
     const rootEntries = tiers?.roots ?? []
 
-    const senses =
-        page != null && !page.isSuggestionTier ? senseGroupsIn(page) : []
+    /* the inventory's named readings outrank the class split where they
+       exist: "ooh n. — 1. an egg / 2. an udder" is the fork itself, and each
+       book's entry files under the reading it defines. What no reading
+       claims keeps the class-grouped page it had, as the tail. */
+    const readingBlocks =
+        page != null && !page.isSuggestionTier ? readingGroupsIn(page) : null
+    const senses = readingBlocks
+        ? readingBlocks.tail
+        : page != null && !page.isSuggestionTier
+          ? senseGroupsIn(page)
+          : []
 
     /** entries for a piece of the word, where nothing answered for the whole:
      * they define the part, and are shown saying so */
@@ -309,14 +319,26 @@ export const Dictionary = () => {
         !!page.wordLists?.length
 
     /** the roots split among the senses they belong to, the unthreadable left
-     * in a page-level basket */
-    const sensedRoots = rootsBySense(senses, rootEntries)
+     * in a page-level basket. A reading block claims through its own lemma,
+     * so foddey's ancestry sits under foddey's readings. */
+    const sensedRoots = rootsBySense(
+        [
+            ...(readingBlocks?.blocks ?? []).map((block) => ({
+                key: block.lemmaId,
+                labels: [],
+                entries: [],
+                lemmas: [block.lemma],
+            })),
+            ...senses,
+        ],
+        rootEntries,
+    )
 
     /* The only sense of a word has nothing to tell apart, so it needs no heading
        of its own: its label rides on the title, and the word is not said twice
        over. Several senses each earn the word again, under a label that says
        which of them you are reading. */
-    const singleSense = senses.length === 1
+    const singleSense = readingBlocks == null && senses.length === 1
 
     /** Whether any text actually uses the word, as the history's own scan found
      * it: the evidence, rather than the browse page's guess at it */
@@ -357,7 +379,7 @@ export const Dictionary = () => {
                 {/* the class is the entries', so it waits for them: the title is
                     already this word, and "CREEAGH n." on cree's authority is a
                     claim about a word that has not arrived */}
-                {!stale && singleSense && (
+                {!stale && singleSense && senses[0].labels.length > 0 && (
                     <SenseLabel labels={senses[0].labels} />
                 )}
             </h1>
@@ -540,6 +562,78 @@ export const Dictionary = () => {
                     />
                 )}
 
+                {/* the inventory's blocks lead: the headword and its class,
+                then the numbered readings, each with every book's entries
+                for that reading beneath it - dictionary.com's shape */}
+                {page != null &&
+                    readingBlocks?.blocks.map((block) => (
+                        <section
+                            className="dict-page-group"
+                            key={block.lemmaId}
+                        >
+                            <h3 className="dict-page-sense">
+                                <span className="dict-page-sense-word">
+                                    {block.lemma}
+                                </span>
+                                {block.label && (
+                                    <SenseLabel labels={[block.label]} />
+                                )}
+                            </h3>
+                            {/* everything of the block's sits inside the
+                            headword's margin: the readings, their entries
+                            and the ancestry all belong to the line above */}
+                            <div className="dict-page-reading-body">
+                                {block.readings.map((reading) => (
+                                    <div
+                                        className="dict-page-reading"
+                                        key={reading.key}
+                                    >
+                                        <h4 className="dict-page-reading-heading">
+                                            {reading.heading}
+                                        </h4>
+                                        {reading.entries.map(
+                                            (summary, index) => (
+                                                <Entry
+                                                    word={page.word}
+                                                    summary={summary}
+                                                    credit
+                                                    unplaced={reading.unplaced.includes(
+                                                        summary,
+                                                    )}
+                                                    onCitationClick={
+                                                        setCitationKey
+                                                    }
+                                                    key={index}
+                                                />
+                                            ),
+                                        )}
+                                    </div>
+                                ))}
+                                {(sensedRoots.bySense.get(block.lemmaId) ?? [])
+                                    .length > 0 && (
+                                    <>
+                                        <h4 className="dict-page-dictionary">
+                                            Built from
+                                        </h4>
+                                        {sensedRoots.bySense
+                                            .get(block.lemmaId)!
+                                            .map((summary, index) => (
+                                                <Entry
+                                                    word={page.word}
+                                                    summary={summary}
+                                                    credit
+                                                    onCitationClick={
+                                                        setCitationKey
+                                                    }
+                                                    key={index}
+                                                />
+                                            ))}
+                                    </>
+                                )}
+                            </div>
+                        </section>
+                    ))}
+
                 {page != null &&
                     !page.isSuggestionTier &&
                     senses.map((sense) => (
@@ -551,46 +645,65 @@ export const Dictionary = () => {
                             {!singleSense && sense.labels.length > 0 && (
                                 <h3 className="dict-page-sense">
                                     <span className="dict-page-sense-word">
-                                        {page.word}
+                                        {/* the sense belongs to its lexeme:
+                                        when every entry threads through one
+                                        lemma, the heading names it (moddey
+                                        over the mutated voddey), as the
+                                        reading blocks name theirs */}
+                                        {sense.lemmas.length === 1
+                                            ? sense.lemmas[0]
+                                            : page.word}
                                     </span>
                                     <SenseLabel labels={sense.labels} />
                                 </h3>
                             )}
-                            {sense.entries.map((summary, index) => (
-                                <Entry
-                                    word={page.word}
-                                    summary={summary}
-                                    credit
-                                    unplaced={
-                                        senses.length > 1 &&
-                                        !summary.partsOfSpeech?.length
-                                    }
-                                    onCitationClick={setCitationKey}
-                                    key={index}
-                                />
-                            ))}
-                            {/* each reading owns the roots it is built from: the
-                            dog sense says moddey, "not long" says foddey, and
-                            neither answers for the other's ancestry */}
-                            {(sensedRoots.bySense.get(sense.key) ?? []).length >
-                                0 && (
-                                <>
-                                    <h4 className="dict-page-dictionary">
-                                        Built from
-                                    </h4>
-                                    {sensedRoots.bySense
-                                        .get(sense.key)!
-                                        .map((summary, index) => (
-                                            <Entry
-                                                word={page.word}
-                                                summary={summary}
-                                                credit
-                                                onCitationClick={setCitationKey}
-                                                key={index}
-                                            />
-                                        ))}
-                                </>
-                            )}
+                            {/* under a heading, the section's body sits in
+                            its margin, as the reading blocks' do */}
+                            <div
+                                className={
+                                    !singleSense && sense.labels.length > 0
+                                        ? "dict-page-reading-body"
+                                        : undefined
+                                }
+                            >
+                                {sense.entries.map((summary, index) => (
+                                    <Entry
+                                        word={page.word}
+                                        summary={summary}
+                                        credit
+                                        unplaced={
+                                            senses.length > 1 &&
+                                            !summary.partsOfSpeech?.length
+                                        }
+                                        onCitationClick={setCitationKey}
+                                        key={index}
+                                    />
+                                ))}
+                                {/* each reading owns the roots it is built from:
+                                the dog sense says moddey, "not long" says foddey,
+                                and neither answers for the other's ancestry */}
+                                {(sensedRoots.bySense.get(sense.key) ?? [])
+                                    .length > 0 && (
+                                    <>
+                                        <h4 className="dict-page-dictionary">
+                                            Built from
+                                        </h4>
+                                        {sensedRoots.bySense
+                                            .get(sense.key)!
+                                            .map((summary, index) => (
+                                                <Entry
+                                                    word={page.word}
+                                                    summary={summary}
+                                                    credit
+                                                    onCitationClick={
+                                                        setCitationKey
+                                                    }
+                                                    key={index}
+                                                />
+                                            ))}
+                                    </>
+                                )}
+                            </div>
                         </section>
                     ))}
 
@@ -649,6 +762,9 @@ export const Dictionary = () => {
                         word={word}
                         history={history}
                         classes={declaredClassesIn(page)}
+                        senseGlosses={page.senses?.flatMap((block) =>
+                            block.readings.map((reading) => reading.gloss),
+                        )}
                     />
                 )}
 

--- a/CorpusSearch/ClientApp/src/utils/DictionaryEntries.ts
+++ b/CorpusSearch/ClientApp/src/utils/DictionaryEntries.ts
@@ -210,6 +210,151 @@ export const senseGroupsIn = (page: DictionaryPageResponse): SenseGroup[] => {
     })
 }
 
+/** Words that carry no sense of their own when matching an entry's text to a
+ * reading's gloss: articles, copulas and the books' formula words */
+const MATCH_STOP = new Set([
+    "a",
+    "an",
+    "the",
+    "of",
+    "to",
+    "or",
+    "and",
+    "in",
+    "on",
+    "at",
+    "by",
+    "for",
+    "with",
+    "is",
+    "it",
+    "its",
+    "as",
+    "be",
+    "not",
+    "s",
+    "v",
+    "pl",
+    "&c",
+    "c",
+])
+
+const contentWords = (text: string): Set<string> =>
+    new Set(
+        text
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, " ")
+            .split(" ")
+            .filter((w) => w.length > 0 && !MATCH_STOP.has(w)),
+    )
+
+/** The printed class a lemma id's suffix declares: ooh.n is the noun. The
+ * closed-class x carries no label a reader is owed. */
+const LABEL_OF_ID: Record<string, string> = { n: "n.", v: "v.", a: "a." }
+
+/** One lemma id's readings, headed the dictionary.com way: the headword and
+ * its class, then the numbered senses, each gathering the entries of every
+ * book beneath the reading it defines */
+export type ReadingBlock = {
+    lemmaId: string
+    /** the headword of the block ("foddey" on voddey's page) */
+    lemma: string
+    /** the class the id declares, abbreviated ("n."); null for the closed
+     * classes, whose id suffix names no reader-facing label */
+    label: string | null
+    readings: {
+        key: string
+        /** numbered within the block ("1. an egg;") */
+        heading: string
+        entries: Summary[]
+        /** matched more than one reading equally: shown under each, marked */
+        unplaced: Summary[]
+    }[]
+}
+
+/** The word's own entries, split by the sense inventory's named readings —
+ * the dictionary.com shape: headword and class, then each reading a numbered
+ * heading with every book's entries gathered beneath the one it defines.
+ *
+ * The assignment is textual and admits it: an entry goes to the reading
+ * sharing most content words with its text; a tie (Phil Kelly's "egg; ...
+ * udder" line) puts it under each tied reading with the unplaced mark; an
+ * entry matching no reading falls to the class-grouped tail, exactly the
+ * sections the page had before the inventory. A reading no entry matched
+ * still shows: the gloss is the book's own definition, not a mere caption.
+ * Null where the inventory has nothing to say, so the caller falls back to
+ * senseGroupsIn. */
+export const readingGroupsIn = (
+    page: DictionaryPageResponse,
+): { blocks: ReadingBlock[]; tail: SenseGroup[] } | null => {
+    const senseBlocks = page.senses ?? []
+    if (senseBlocks.length === 0) {
+        return null
+    }
+    const own = tiersOf(page.groups.flatMap((g) => g.entries)).own
+    if (own.length === 0) {
+        return null
+    }
+
+    const blocks = senseBlocks.map((block) => ({
+        lemmaId: block.lemmaId,
+        lemma: block.lemma,
+        label: LABEL_OF_ID[block.lemmaId.split(".").pop() ?? ""] ?? null,
+        readings: block.readings.map((reading, index) => ({
+            key: reading.senseId,
+            heading: `${index + 1}. ${reading.gloss}`,
+            words: contentWords(reading.gloss),
+            entries: [] as Summary[],
+            unplaced: [] as Summary[],
+        })),
+    }))
+    const readings = blocks.flatMap((block) => block.readings)
+
+    const unmatched: Summary[] = []
+    for (const entry of own) {
+        const words = contentWords(entry.summary)
+        const overlaps = readings.map(
+            (reading) => [...reading.words].filter((w) => words.has(w)).length,
+        )
+        const best = Math.max(...overlaps)
+        if (best === 0) {
+            unmatched.push(entry)
+            continue
+        }
+        const winners = readings.filter((_, i) => overlaps[i] === best)
+        for (const reading of winners) {
+            reading.entries.push(entry)
+            if (winners.length > 1) {
+                reading.unplaced.push(entry)
+            }
+        }
+    }
+
+    // whatever no reading claimed keeps the page it had: the class-grouped
+    // sections, after the named readings
+    const tail =
+        unmatched.length > 0
+            ? senseGroupsIn({
+                  ...page,
+                  groups: [{ dictionary: "", entries: unmatched }],
+              })
+            : []
+    return {
+        blocks: blocks.map((block) => ({
+            ...block,
+            readings: block.readings.map(
+                ({ key, heading, entries, unplaced }) => ({
+                    key,
+                    heading,
+                    entries,
+                    unplaced,
+                }),
+            ),
+        })),
+        tail,
+    }
+}
+
 /** The roots each sense's entries derive through, threaded by `throughLemma`:
  * the moddey hop belongs under the dog sense, foddey's under "not long".
  * A root no sense claims stays page-level — where the thread is missing, the

--- a/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
+++ b/CorpusSearch/Service/Dictionaries/CregeenDictionaryService.cs
@@ -277,11 +277,14 @@ public class CregeenDictionaryService(ISet<string> allWords, IList<CregeenEntry>
     /// <summary>Cregeen's printed grammar label - the entry's leading italic
     /// run ("s. m.", "s. f.", "v."): word class and gender, absent from the
     /// basic summary text, surfaced so the client can show it beside the
-    /// headword with the expansion on hover</summary>
+    /// headword with the expansion on hover. Decoded to text as the summaries
+    /// are: the transcription's editorial marks stay - angle brackets around
+    /// the print's reading, square around the correction - and the reader
+    /// sees the brackets themselves, not "&amp;lt;" entities.</summary>
     internal static string? GrammarLabelOf(string? entryHtml)
     {
         var match = System.Text.RegularExpressions.Regex.Match(
             entryHtml ?? "", @"^\s*<i>\s*([^<]{1,30}?)\s*</i>");
-        return match.Success ? match.Groups[1].Value : null;
+        return match.Success ? HttpUtility.HtmlDecode(match.Groups[1].Value) : null;
     }
 }

--- a/CorpusSearch/Service/DictionaryLookupService.cs
+++ b/CorpusSearch/Service/DictionaryLookupService.cs
@@ -394,6 +394,23 @@ public class DictionaryLookupService(IEnumerable<ISearchDictionary> dictionarySe
                     Entries = g.ToList(),
                 })
                 .ToList(),
+            Senses = lemmaTable.CandidatesFor(word)
+                .Select(id => (Id: id, Readings: senseInventory.SensesOf(id)))
+                .Where(x => x.Readings.Count > 0)
+                .Select(x => new DictionaryPageSenses
+                {
+                    LemmaId = x.Id,
+                    Lemma = lemmaTable.DisplayLemmaOf(x.Id) ?? x.Id,
+                    Dictionary = x.Readings[0].Dictionary,
+                    Readings = x.Readings.Select(s => new DictionaryPageSense
+                    {
+                        SenseId = s.SenseId,
+                        Gloss = s.Gloss,
+                        Headword = s.EntryPath.Split(':') is { Length: 2 } path
+                            ? path[1] : s.EntryPath,
+                    }).ToList(),
+                })
+                .ToList(),
         };
     }
 

--- a/CorpusSearch/Service/DictionaryPage.cs
+++ b/CorpusSearch/Service/DictionaryPage.cs
@@ -53,6 +53,35 @@ public class DictionaryPage
     /// definition or a word class, so it is shown as a citation rather than as an
     /// entry a reader might mistake for a book's own reading.</summary>
     public List<WordListCitation> WordLists { get; set; } = [];
+
+    /// <summary>The word's named readings, one block per lemma id the word
+    /// resolves to whose sense inventory names any: what the popup picks among
+    /// in context, shown here so the reader sees the fork itself (ooh: an egg /
+    /// an udder). Empty for the many words with one implicit sense.</summary>
+    public List<DictionaryPageSenses> Senses { get; set; } = [];
+}
+
+/// <summary>One lemma id's named readings</summary>
+public class DictionaryPageSenses
+{
+    public required string LemmaId { get; set; }
+    /// <summary>The lemma as the reader knows it ("foddey")</summary>
+    public required string Lemma { get; set; }
+    /// <summary>The dictionary slug whose senses these are ("cregeen"):
+    /// the inventory is per book, and the strip credits its source the way
+    /// every entry on the page does</summary>
+    public required string Dictionary { get; set; }
+    public required List<DictionaryPageSense> Readings { get; set; }
+}
+
+/// <summary>One reading: the book's own gloss for it</summary>
+public class DictionaryPageSense
+{
+    public required string SenseId { get; set; }
+    public required string Gloss { get; set; }
+    /// <summary>The printed headword the gloss belongs to, for the reader who
+    /// wants the entry ("dy cheilley" under cheilley)</summary>
+    public required string Headword { get; set; }
 }
 
 public class DictionaryPageGroup

--- a/CorpusSearch/Service/SenseInventory.cs
+++ b/CorpusSearch/Service/SenseInventory.cs
@@ -44,6 +44,9 @@ public class SenseInventory
 
     public Sense? SenseOf(string senseId) => bySenseId.GetValueOrDefault(senseId);
 
+    /// <summary>Every vendored sense: the round-trip check walks them all</summary>
+    public IEnumerable<Sense> All => bySenseId.Values;
+
     public int Count => bySenseId.Count;
 
     /// <summary>Reads senses.tsv: senseId, lemmaId, dict, entryPath, gloss.


### PR DESCRIPTION

  ## What the reader sees

  A word page now reads like a dictionary entry rather than a pile of sources:
  one block per lemma the word resolves to, the headword and its class
  (`ooh n.`, `foddey a.`), then each of Cregeen's readings as a numbered
  heading — *1. egg · 2. udder* — with every book's entries filed under the
  reading it defines, and the block's ancestry indented within it. Where the
  inventory is silent the page is exactly what it was. The multi-sense warning
  names the readings themselves, not the word classes.

  The assignment is textual and admits it: an entry goes to the reading sharing
  most content words with its text; a tie shows under each tied reading with an
  unplaced mark. Phase 3 per-token verdicts can replace the heuristic without
  moving the furniture.

  ## The data underneath

  - The 327-reading Cregeen sense inventory (161 lemma ids), generated in
    cregeen-nvh and vendored via manx-lemma-data — a round-trip test now fails
    the build if a regeneration strands any senseId (table-known lemmaId, live
    entryPath, non-empty gloss).
  - Submodule to manx-lemma-data 84e018e: the demutation fix that offers every
    radical homograph (+475 candidate rows, zero id churn — `chooney` finally
    offers *cooney* "help" beside *cooney* "narrow"), the Phase 3 pilot's 540
    sidecar verdicts over 50 previously-uncovered forms, the audited
    equivalence layer (77 wrong cross-POS "same" verdicts flipped), and the
    particle-era table regeneration.

  ## Fixes

  - POS corrections in the editorial apparatus (`<v>[a].`) now resolve to the
    corrected reading everywhere identity is decided; the printed label stays
    display-side.

  ## Tooling (no runtime effect)

  - The adjudication exporter glosses each candidate from Cregeen's own entry,
    keyed by headword core and class, instead of a display-keyed merge that
    showed the noun's "plague" on the adjective and nothing at all for
    lenited headwords. Falls back to display-keyed on pre-v0.3.0 data.

  ## Verification

  - Backend 780/781 green (1 deliberately skipped), including the new
    round-trip guard and the two-lookup-paths equivalence test.
  - ClientApp tests cover the reading blocks, tie handling, and the unchanged
    single-sense page.

  ## Deploy notes

  - `Resources/cregeen.json` is untracked and must be ≥ release v0.3.0
    (`download_cregeen.sh`) — older files lack the printed-identity fields;
    the site falls back gracefully, the exporter tooling falls back to
    display-keyed glosses.
  - Production picks up the data-repo side on its daily restart regardless of
    this PR; the PR pins the same content for image builds and tests.
