### PR TITLE
feat(dictionary): handle senses

### DIFF
--- a/CorpusSearch.Test/LemmaAdjudication/AdjudicationCommon.cs
+++ b/CorpusSearch.Test/LemmaAdjudication/AdjudicationCommon.cs
@@ -28,13 +28,23 @@ public static class AdjudicationCommon
         return LemmaTable.NormalizeForm(lemma).Replace(" ", "");
     }
 
-    /// <summary>lemma id -> display lemma, straight from the vendored table's columns</summary>
+    /// <summary>lemma id -> display lemma. The self row's, by preference: link
+    /// rows carry the spelling that reached them (ghoan names goo.n as "goan"),
+    /// and whichever the file orders first is an accident of the book</summary>
     public static Dictionary<string, string> DisplayLemmaById()
     {
         var result = new Dictionary<string, string>();
+        var bySelf = new HashSet<string>();
         foreach (var columns in TableRows())
         {
-            result.TryAdd(columns[1], columns[2]);
+            if (columns.Length > 3 && columns[3] == "self" && bySelf.Add(columns[1]))
+            {
+                result[columns[1]] = columns[2];
+            }
+            else
+            {
+                result.TryAdd(columns[1], columns[2]);
+            }
         }
         return result;
     }

--- a/CorpusSearch.Test/LemmaAdjudication/AdjudicationExporter.cs
+++ b/CorpusSearch.Test/LemmaAdjudication/AdjudicationExporter.cs
@@ -90,22 +90,49 @@ public class AdjudicationExporter
             }
             var ids = table.CandidatesFor(form);
             var groupByKey = new Dictionary<string, string>();
-            var displayAlias = new Dictionary<string, string>();
             var labels = new List<string>();
-            var candidates = ids.Select(id =>
+            // one union-find over the form's candidates, with two edge
+            // sources: equivalence same-verdicts and shared display
+            // headwords. The old display-alias map REPLACED an id's
+            // equivalence root instead of merging with it, so a chain like
+            // cheet.n ~display~ cheet.v ~same~ er-jeet.x broke apart and a
+            // settled pair was adjudicated again.
+            var local = new Dictionary<string, string>();
+            string Find(string x)
             {
-                var lemma = displayById.GetValueOrDefault(id, id);
-                var rootKey = equivalenceRoot(id);
-                var displayKey = AdjudicationCommon.DisplayKey(lemma);
-                // same display headword => same lexeme group, regardless of ids
-                if (displayAlias.TryGetValue(displayKey, out var aliased))
+                while (local.TryGetValue(x, out var p) && p != x)
                 {
-                    rootKey = aliased;
+                    x = p;
+                }
+                return x;
+            }
+            void Union(string a, string b)
+            {
+                var (ra, rb) = (Find(a), Find(b));
+                if (ra != rb)
+                {
+                    local[ra] = rb;
+                }
+            }
+            var byDisplay = new Dictionary<string, string>();
+            foreach (var id in ids)
+            {
+                var root = equivalenceRoot(id);
+                Union(id, root);
+                var displayKey = AdjudicationCommon.DisplayKey(displayById.GetValueOrDefault(id, id));
+                if (byDisplay.TryGetValue(displayKey, out var first))
+                {
+                    Union(root, first);
                 }
                 else
                 {
-                    displayAlias[displayKey] = rootKey;
+                    byDisplay[displayKey] = root;
                 }
+            }
+            var candidates = ids.Select(id =>
+            {
+                var lemma = displayById.GetValueOrDefault(id, id);
+                var rootKey = Find(id);
                 if (!groupByKey.TryGetValue(rootKey, out var label))
                 {
                     label = $"g{groupByKey.Count + 1}";

--- a/CorpusSearch.Test/LemmaTableTest.cs
+++ b/CorpusSearch.Test/LemmaTableTest.cs
@@ -366,4 +366,26 @@ public class LemmaTableTest
         Assert.That(table.CandidatesFor("doolish"), Is.EqualTo(new[] { "doolish.np" }));
         Assert.That(table.CandidatesFor("veg"), Is.EqualTo(new[] { "veg.x" }));
     }
+
+    /// <summary>An id's display is its self row's, however the book orders the
+    /// file: the demutated row for ghoan reaches goo.n through the variant
+    /// spelling "goan" and prints before goo's own entry, and first-row-wins
+    /// once showed kione.n as "king" this way.</summary>
+    [Test]
+    public void DisplayLemmaComesFromTheSelfRow()
+    {
+        var table = Table(
+            "ghoan\tgoo.n\tgoan\tdemutated\ts. m.\tghoan\t",
+            "goo\tgoo.n\tgoo\tself\ts. m.\tgoo\t");
+        Assert.That(table.DisplayLemmaOf("goo.n"), Is.EqualTo("goo"));
+    }
+
+    /// <summary>An id with no self row anywhere (the article yn) still displays
+    /// from whatever row names it.</summary>
+    [Test]
+    public void DisplayLemmaFallsBackWithoutASelfRow()
+    {
+        var table = Table("yn\tyn.x\tyn\tirregular\t\t\tclosed-class");
+        Assert.That(table.DisplayLemmaOf("yn.x"), Is.EqualTo("yn"));
+    }
 }

--- a/CorpusSearch/Dependencies/Lucene/LemmaTable.cs
+++ b/CorpusSearch/Dependencies/Lucene/LemmaTable.cs
@@ -371,6 +371,7 @@ public class LemmaTable
         var rootListsByForm = new Dictionary<string, List<string>>();
         var lemmaIds = new HashSet<string>();
         var displayLemmaById = new Dictionary<string, string>();
+        var selfDisplayById = new Dictionary<string, string>();
         var nameTypeById = new Dictionary<string, string>();
         var phillipsViaLists = new Dictionary<string, List<string>>();
         // (form, displayLemma) links seen by rule, and those the print attests:
@@ -391,7 +392,22 @@ public class LemmaTable
                 }
                 var (form, lemmaId, displayLemma) = (columns[0], columns[1], columns[2]);
                 lemmaIds.Add(lemmaId);
-                displayLemmaById.TryAdd(lemmaId, displayLemma);
+                // an id's display is its self row's: link rows carry the spelling
+                // that reached them (ghoan names goo.n as "goan", hrog names
+                // trog), and whichever the file orders first is an accident of
+                // the book — kione.n once displayed as "king" this way
+                if (columns.Length > 3 && columns[3] == "self")
+                {
+                    if (!selfDisplayById.ContainsKey(lemmaId))
+                    {
+                        selfDisplayById[lemmaId] = displayLemma;
+                        displayLemmaById[lemmaId] = displayLemma;
+                    }
+                }
+                else
+                {
+                    displayLemmaById.TryAdd(lemmaId, displayLemma);
+                }
                 // the names supplement's pos column: "np. personal", "np. place", ...
                 if (columns.Length > 4 && columns[4].StartsWith("np."))
                 {


### PR DESCRIPTION
## What the reader sees

**Word pages file entries under Cregeen's numbered readings.** One
block per lemma the word resolves to, the headword and its class
(`ooh n.`, `foddey a.`), then each reading as a numbered heading —
*1. egg · 2. udder* — with every book's entries filed under the
reading it defines and the block's ancestry indented within it. The
multi-sense warning names the readings, not the word classes. Where
the inventory is silent the page is exactly what it was. The
assignment is textual and admits it: entries go to the reading sharing
most content words, ties show under each with an unplaced mark, and
per-token verdicts can replace the heuristic without moving the
furniture.

**An id displays as its self row says.** Display lemmas came from
whichever table row the book ordered first, and link rows carry the
spelling that reached them — so `kione.n` could display as "king" (its
printed variant spelling), and the new homograph rows widened the
exposure to 17 ids (*goo* as "goan", *pardoon* as "bardoon").
Regression tests pin the fix.

## The data underneath

- The 327-reading Cregeen sense inventory, generated in cregeen-nvh,
  vendored via manx-lemma-data, and guarded by a round-trip test:
  every senseId must resolve to a table-known lemmaId, a live printed
  entry, and a non-empty gloss, or the build fails.
- Submodule to manx-lemma-data eb7c205: the complete Phase 3
  adjudication campaign — 4,495 tri-vote verdicts (2 Opus + 1 Sonnet
  per line) across all 723 POS-neutral multi-POS forms, 573 old
  single-vote rows superseded, every radical homograph offered as a
  candidate (+475 rows), and the audited equivalence layer (77 wrong
  cross-POS "same" verdicts refuted against the print).

## Fixes

- POS corrections in the editorial apparatus (`<v>[a].`) resolve to
  the corrected reading everywhere identity is decided.
- Adjudication-exporter candidates gloss from Cregeen's own entry
  (keyed by headword core and class) instead of a display-keyed merge
  that showed the noun's "plague" on the adjective.
- Candidate grouping is one union-find over equivalence same-verdicts
  and shared displays; the old alias map broke chains like
  cheet ~ er-jeet and re-adjudicated settled pairs.

## Verification

Backend 782/783 green (1 deliberately skipped) including the
round-trip guard and display-derivation regression tests; ClientApp
tests cover the reading blocks, ties, and unchanged single-sense pages.