### PR TITLE
fix(lemma): 'vondeish' and 'mac' (and similar entries)

### DIFF
--- a/CorpusSearch.Test/LemmaIndexServiceTest.cs
+++ b/CorpusSearch.Test/LemmaIndexServiceTest.cs
@@ -609,6 +609,34 @@ public class LemmaIndexServiceTest
         });
     }
 
+    /// <summary>Cregeen's entry for vac is the phrase 'dty vac' itself, so the
+    /// phrase's particle row is an undrawn echo of its own entry — and the
+    /// childless demutation guess must not be swallowed with it: it alone
+    /// says the bare form, and the phrase's print upgrades it from a guess
+    /// to a mutation. vac once vanished from mac's tree entirely.</summary>
+    [Test]
+    public void AMutationWhoseEntryIsItsPhraseStillStandsInTheTree()
+    {
+        var service = Service(Table(
+            "mac\tmac.n\tmac\tself\ts. m.\tmac\t",
+            "dty vac\tmac.n\tmac\tself\ts.\tdty vac\t",
+            "vac\tmac.n\tmac\tparticle\ts.\tdty vac\t",
+            "vac\tmac.n\tmac\tdemutated\ts. m.\tdty vac\t",
+            "dty vacs\tmac.n\tmac\tinflected\ts.\tdty vac\t"));
+
+        var phrase = service.Tree("mac")!
+            .Groups.Single(g => g.LinkType == "self")
+            .Forms.Single(f => f.Form == "dty vac");
+        Assert.Multiple(() =>
+        {
+            Assert.That(phrase.Groups!.Single(g => g.LinkType == "mutation")
+                .Forms.Single().Form, Is.EqualTo("vac"));
+            // the phrase's own row would only say the entry again: not drawn
+            Assert.That(phrase.Groups!.Select(g => g.LinkType),
+                Has.No.Member("particle"));
+        });
+    }
+
     /// <summary>The form column is normalized ('neu vondeish'): a derived row
     /// wears the member lexeme's own spelling instead</summary>
     [Test]

--- a/CorpusSearch.Test/LemmaIndexServiceTest.cs
+++ b/CorpusSearch.Test/LemmaIndexServiceTest.cs
@@ -580,4 +580,46 @@ public class LemmaIndexServiceTest
             Assert.That(byForm["gheiney"].Attested, Is.False);
         });
     }
+
+    /// <summary>The book's word-family edge: a derived row files the member
+    /// under the head, the member's own paradigm rides along (vondeish =>
+    /// vondeishagh => s'vondeishagh), and the member's tree names the head
+    /// upward</summary>
+    [Test]
+    public void ADerivedMemberCarriesItsOwnLexemeIntoTheTree()
+    {
+        var service = Service(Table(
+            "vondeish\tvondeish.n\tvondeish\tself\ts.\tvondeish\t",
+            "vondeishyn\tvondeish.n\tvondeish\tinflected\ts.\tvondeish\t",
+            "vondeishagh\tvondeishagh.a\tvondeishagh\tself\ta.\tvondeishagh\t",
+            "s'vondeishagh\tvondeishagh.a\tvondeishagh\tinflected\ta.\ts'vondeishagh\t",
+            "vondeishagh\tvondeish.n\tvondeish\tderived\ts.\tvondeish\t"));
+
+        var tree = service.Tree("vondeish")!;
+        var member = tree.Groups.Single(g => g.LinkType == "derived").Forms.Single();
+        var memberTree = service.Tree("vondeishagh")!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(member.Form, Is.EqualTo("vondeishagh"));
+            Assert.That(member.Groups!.Single(g => g.LinkType == "inflected")
+                    .Forms.Select(f => f.Form),
+                Is.EqualTo(new[] { "s'vondeishagh" }));
+            Assert.That(memberTree.Parents!.Single().Lemma, Is.EqualTo("vondeish"));
+            Assert.That(memberTree.Parents!.Single().LinkTypes, Is.EqualTo(new[] { "derived" }));
+        });
+    }
+
+    /// <summary>The form column is normalized ('neu vondeish'): a derived row
+    /// wears the member lexeme's own spelling instead</summary>
+    [Test]
+    public void ADerivedRowWearsTheMemberLexemesOwnSpelling()
+    {
+        var service = Service(Table(
+            "vondeish\tvondeish.n\tvondeish\tself\ts.\tvondeish\t",
+            "neu vondeish\tneu-vondeish.n\tneu-vondeish\tself\ts. f.\tneu-vondeish\t",
+            "neu vondeish\tvondeish.n\tvondeish\tderived\ts.\tvondeish\t"));
+
+        var derived = service.Tree("vondeish")!.Groups.Single(g => g.LinkType == "derived");
+        Assert.That(derived.Forms.Single().Form, Is.EqualTo("neu-vondeish"));
+    }
 }

--- a/CorpusSearch.Test/LemmaTableTest.cs
+++ b/CorpusSearch.Test/LemmaTableTest.cs
@@ -367,25 +367,27 @@ public class LemmaTableTest
         Assert.That(table.CandidatesFor("veg"), Is.EqualTo(new[] { "veg.x" }));
     }
 
-    /// <summary>An id's display is its self row's, however the book orders the
-    /// file: the demutated row for ghoan reaches goo.n through the variant
-    /// spelling "goan" and prints before goo's own entry, and first-row-wins
-    /// once showed kione.n as "king" this way.</summary>
+    /// <summary>A derived row is the book's word-family edge (vondeishagh prints
+    /// in vondeish's paragraph): a tree branch and a parent, nothing else. The
+    /// member is another lexeme's headword, not a spelling of the head's, so
+    /// searching or tapping vondeishagh must never answer with vondeish</summary>
     [Test]
-    public void DisplayLemmaComesFromTheSelfRow()
+    public void ADerivedRowDrawsATreeEdgeAndNothingElse()
     {
         var table = Table(
-            "ghoan\tgoo.n\tgoan\tdemutated\ts. m.\tghoan\t",
-            "goo\tgoo.n\tgoo\tself\ts. m.\tgoo\t");
-        Assert.That(table.DisplayLemmaOf("goo.n"), Is.EqualTo("goo"));
-    }
+            "vondeish\tvondeish.n\tvondeish\tself\ts.\tvondeish\t",
+            "vondeishagh\tvondeishagh.a\tvondeishagh\tself\ta.\tvondeishagh\t",
+            "vondeishagh\tvondeish.n\tvondeish\tderived\ts.\tvondeish\t");
 
-    /// <summary>An id with no self row anywhere (the article yn) still displays
-    /// from whatever row names it.</summary>
-    [Test]
-    public void DisplayLemmaFallsBackWithoutASelfRow()
-    {
-        var table = Table("yn\tyn.x\tyn\tirregular\t\t\tclosed-class");
-        Assert.That(table.DisplayLemmaOf("yn.x"), Is.EqualTo("yn"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(table.CandidatesFor("vondeishagh"), Is.EqualTo(new[] { "vondeishagh.a" }));
+            Assert.That(table.DisplayLemmasFor("vondeishagh"), Is.EqualTo(new[] { "vondeishagh" }));
+            Assert.That(table.RootDisplayLemmasFor("vondeishagh"), Is.Empty);
+            Assert.That(table.LinksOf("vondeish")!.Links.Select(x => (x.LinkType, x.Form)),
+                Does.Contain(("derived", "vondeishagh")));
+            Assert.That(table.DerivedParentsOf("vondeishagh"), Is.EqualTo(new[] { "vondeish" }));
+            Assert.That(table.DerivedParentsOf("vondeish"), Is.Empty);
+        });
     }
 }

--- a/CorpusSearch.Test/VendoredLemmaTreeTest.cs
+++ b/CorpusSearch.Test/VendoredLemmaTreeTest.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using CorpusSearch.Dependencies.Lucene;
+using CorpusSearch.Service;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+/// <summary>
+/// Regression pins over the vendored table (external/manx-lemma-data): the
+/// trees a reader actually gets, not fixtures. Each of these went missing
+/// once — from the data, or from the drawing — and the fixture tests alone
+/// would not have said so.
+/// </summary>
+[TestFixture]
+public class VendoredLemmaTreeTest
+{
+    private static LemmaTreePage TreeOf(string lemma)
+    {
+        var table = LemmaTable.Instance;
+        if (!table.AllDisplayLemmas.Any())
+        {
+            Assert.Ignore("cregeen.tsv not vendored (manx-lemma-data submodule not initialised)");
+        }
+        var tree = new LemmaIndexService(table, new CorpusVocabulary(table)).Tree(lemma);
+        Assert.That(tree, Is.Not.Null, $"the table names no lemma '{lemma}'");
+        return tree!;
+    }
+
+    private static IEnumerable<(string LinkType, string Form, LemmaTreeForm Node)> Flatten(
+        IEnumerable<LemmaTreeGroup>? groups)
+    {
+        foreach (var group in groups ?? [])
+        {
+            foreach (var form in group.Forms)
+            {
+                yield return (group.LinkType, form.Form, form);
+                foreach (var nested in Flatten(form.Groups))
+                {
+                    yield return nested;
+                }
+            }
+        }
+    }
+
+    /// <summary>Cregeen's entry for vac is the phrase 'dty vac', whose particle
+    /// row is an undrawn echo of its own entry: the demutation guess must
+    /// survive it, upgraded to a mutation by the phrase's print. vac — said
+    /// over a thousand times — once vanished from mac's tree entirely.</summary>
+    [Test]
+    public void MacCarriesItsMutationVac()
+    {
+        var rows = Flatten(TreeOf("mac").Groups).ToList();
+        Assert.That(rows.Where(x => x.Form == "vac").Select(x => x.LinkType),
+            Does.Contain("mutation"),
+            "vac must stand in mac's tree as a mutation");
+    }
+
+    /// <summary>The book's word family, whole: vondeish => vondeishagh =>
+    /// s'vondeishagh. The superlative once had no route from vondeish at all —
+    /// dropped from the letter index as a grammar row, and the noun and its
+    /// adjective unlinked in the tables.</summary>
+    [Test]
+    public void VondeishReachesItsSuperlativeThroughItsAdjective()
+    {
+        var member = TreeOf("vondeish").Groups
+            .Single(g => g.LinkType == "derived")
+            .Forms.SingleOrDefault(f => f.Form == "vondeishagh");
+        Assert.That(member, Is.Not.Null, "vondeishagh must file under vondeish as derived");
+        Assert.That(Flatten(member!.Groups).Select(x => x.Form),
+            Does.Contain("s'vondeishagh"),
+            "the member's own paradigm must ride along");
+    }
+}

--- a/CorpusSearch/ClientApp/src/components/LemmaTree.tsx
+++ b/CorpusSearch/ClientApp/src/components/LemmaTree.tsx
@@ -35,6 +35,7 @@ const GROUP_LABELS: Record<string, string> = {
     mutation: "Mutations",
     demutated: "Possible mutations",
     particle: "With a particle",
+    derived: "Derived words",
     univerbated: "Written as one word",
     phillips: "Phillips (c. 1610) spellings",
     prefixed: "Written with the prefix",
@@ -70,6 +71,14 @@ const ParentLine = ({ parent }: { parent: LemmaTreeParent }) => (
         {parent.linkTypes.includes("prefixed") ? (
             <>
                 {"Written with the prefix "}
+                <Link to={lemmaTreeUrl(parent.lemma)}>{parent.lemma}</Link>
+                {" ›"}
+            </>
+        ) : parent.linkTypes.includes("derived") ? (
+            // the book's word-family edge: this word is its own lexeme,
+            // printed in the head's paragraph. Never "a form of" the head.
+            <>
+                {"Derived from "}
                 <Link to={lemmaTreeUrl(parent.lemma)}>{parent.lemma}</Link>
                 {" ›"}
             </>

--- a/CorpusSearch/Dependencies/Lucene/LemmaTable.cs
+++ b/CorpusSearch/Dependencies/Lucene/LemmaTable.cs
@@ -24,6 +24,7 @@ public class LemmaTable
     private readonly Dictionary<string, string[]> phillipsViaByForm;
     private readonly HashSet<(string Form, string DisplayLemma)> unverifiedLinks;
     private readonly Dictionary<string, LemmaLinkSet> linkSetsByDisplay;
+    private readonly Dictionary<string, string[]> derivedParentsByForm;
     // built on first use: the history view walks lemma -> forms, the reverse
     // of every other lookup
     private readonly Lazy<Dictionary<string, string[]>> formsByDisplay;
@@ -38,7 +39,8 @@ public class LemmaTable
         Dictionary<string, string> displayLemmaById, Dictionary<string, string> nameTypeById,
         Dictionary<string, string[]> phillipsViaByForm,
         HashSet<(string, string)>? unverifiedLinks = null,
-        Dictionary<string, LemmaLinkSet>? linkSetsByDisplay = null)
+        Dictionary<string, LemmaLinkSet>? linkSetsByDisplay = null,
+        Dictionary<string, string[]>? derivedParentsByForm = null)
     {
         this.candidatesByForm = candidatesByForm;
         this.displayLemmasByForm = displayLemmasByForm;
@@ -49,6 +51,7 @@ public class LemmaTable
         this.phillipsViaByForm = phillipsViaByForm;
         this.unverifiedLinks = unverifiedLinks ?? [];
         this.linkSetsByDisplay = linkSetsByDisplay ?? [];
+        this.derivedParentsByForm = derivedParentsByForm ?? [];
         AllDisplayLemmas = this.linkSetsByDisplay.Values
             .Select(x => x.Lemma)
             .Order(StringComparer.Ordinal)
@@ -136,6 +139,13 @@ public class LemmaTable
             .Where(display => lemmaIds.Any(id => displayLemmaById.GetValueOrDefault(id) == display))
             .ToList();
     }
+
+    /// <summary>The family heads the book prints <paramref name="form"/> under
+    /// ("vondeishagh" -> vondeish): the `derived` rows read upward, for the
+    /// tree's Parents line. Empty for every other form — the derived rows
+    /// feed no other lookup.</summary>
+    public IReadOnlyList<string> DerivedParentsOf(string form) =>
+        derivedParentsByForm.TryGetValue(NormalizeForm(form), out var heads) ? heads : [];
 
     /// <summary>The classical spellings a Phillips 1610 form stands for
     /// ("dwyne" -> "dooinney"), from the phillips supplement's via column:
@@ -379,6 +389,7 @@ public class LemmaTable
         var unverifiedLinks = new HashSet<(string, string)>();
         var verifiedLinks = new HashSet<(string, string)>();
         var linkSets = new Dictionary<string, MutableLinkSet>();
+        var derivedParentsLists = new Dictionary<string, List<string>>();
 
         foreach (var (reader, source) in sources)
         {
@@ -391,6 +402,7 @@ public class LemmaTable
                     continue;
                 }
                 var (form, lemmaId, displayLemma) = (columns[0], columns[1], columns[2]);
+                var linkType = columns.Length > 3 ? columns[3] : "self";
                 lemmaIds.Add(lemmaId);
                 // an id's display is its self row's: link rows carry the spelling
                 // that reached them (ghoan names goo.n as "goan", hrog names
@@ -413,24 +425,43 @@ public class LemmaTable
                 {
                     nameTypeById.TryAdd(lemmaId, columns[4]["np.".Length..].Trim());
                 }
-                if (!listsByForm.TryGetValue(form, out var candidates))
+                // a derived row is the book's word-family edge (vondeishagh
+                // prints in vondeish's paragraph): it draws a lemma-tree branch
+                // and names a parent, nothing else. The member is another
+                // lexeme's headword, not a spelling of this one, so it joins no
+                // candidate set and no root chain — searching or tapping
+                // vondeishagh must never answer with vondeish.
+                if (linkType == "derived")
                 {
-                    listsByForm[form] = candidates = [];
-                    displayListsByForm[form] = [];
+                    if (!derivedParentsLists.TryGetValue(form, out var heads))
+                    {
+                        derivedParentsLists[form] = heads = [];
+                    }
+                    if (!heads.Contains(displayLemma))
+                    {
+                        heads.Add(displayLemma);
+                    }
                 }
-                // homographs repeat the (form, lemmaId) pair across rows: one candidate each
-                if (!candidates.Contains(lemmaId))
+                else
                 {
-                    candidates.Add(lemmaId);
-                }
-                var displays = displayListsByForm[form];
-                if (!displays.Contains(displayLemma))
-                {
-                    displays.Add(displayLemma);
+                    if (!listsByForm.TryGetValue(form, out var candidates))
+                    {
+                        listsByForm[form] = candidates = [];
+                        displayListsByForm[form] = [];
+                    }
+                    // homographs repeat the (form, lemmaId) pair across rows: one candidate each
+                    if (!candidates.Contains(lemmaId))
+                    {
+                        candidates.Add(lemmaId);
+                    }
+                    var displays = displayListsByForm[form];
+                    if (!displays.Contains(displayLemma))
+                    {
+                        displays.Add(displayLemma);
+                    }
                 }
                 // paradigm links (see RootDisplayLemmasFor): not the form's own entry,
                 // not a demutation guess
-                var linkType = columns.Length > 3 ? columns[3] : "self";
                 var note = columns.Length > 6 ? columns[6] : "";
                 var unverifiedRow = IsUnverifiedRow(note);
                 // a closed-class paradigm row (ta -> bee) is the treebank's
@@ -510,7 +541,7 @@ public class LemmaTable
                         vias.Add(columns[5]);
                     }
                 }
-                if (linkType is not ("self" or "demutated"))
+                if (linkType is not ("self" or "demutated" or "derived"))
                 {
                     if (!rootListsByForm.TryGetValue(form, out var roots))
                     {
@@ -555,7 +586,8 @@ public class LemmaTable
         return new LemmaTable(candidatesByForm, displayLemmasByForm, rootDisplayLemmasByForm, lemmaIds,
             displayLemmaById, nameTypeById,
             phillipsViaLists.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),
-            unverifiedLinks, linkSetsByDisplay);
+            unverifiedLinks, linkSetsByDisplay,
+            derivedParentsLists.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()));
     }
 
     /// <summary>Accumulates one display lemma's rows while <see cref="Load(IEnumerable{TextReader})"/> reads</summary>

--- a/CorpusSearch/Service/LemmaIndexService.cs
+++ b/CorpusSearch/Service/LemmaIndexService.cs
@@ -75,7 +75,7 @@ public class LemmaIndexService(LemmaTable lemmaTable, CorpusVocabulary vocabular
     [
         "self", "inflected", "plural", "compSup", "irregular", "emphatic",
         "contraction", "variant", "mutation", "demutated", "particle",
-        "univerbated", "phillips", "prefixed", "undecided", "override", "typo",
+        "derived", "univerbated", "phillips", "prefixed", "undecided", "override", "typo",
     ];
 
     /// <summary>
@@ -121,6 +121,16 @@ public class LemmaIndexService(LemmaTable lemmaTable, CorpusVocabulary vocabular
             {
                 parents.Add(new LemmaTreeParent { Lemma = display, LinkTypes = linkTypes });
             }
+        }
+        // the family heads the book prints this lemma under, upward: the
+        // derived rows' reverse reading. Not in DisplayLemmasFor — a derived
+        // row names no reading of the form — so the derived parents are
+        // asked for by name
+        foreach (var head in lemmaTable.DerivedParentsOf(links.Lemma)
+                     .Where(h => parents.All(p => p.Lemma != h))
+                     .OrderBy(DictionaryBrowse.CollationKey, StringComparer.Ordinal))
+        {
+            parents.Add(new LemmaTreeParent { Lemma = head, LinkTypes = ["derived"] });
         }
         var prefix = lemmaTable.AllDisplayLemmas
             .Where(x => (x.EndsWith('-') || x.EndsWith('‑'))
@@ -352,9 +362,15 @@ public class LemmaIndexService(LemmaTable lemmaTable, CorpusVocabulary vocabular
         // after any particle at once, and its count answers for all of them
         // together, not for this one
         var counted = particlePhrase ?? link.Form;
+        // a derived row names another lexeme's headword: the row wears that
+        // lexeme's own spelling ('neu-vondeish'), not the form column's
+        // normalization ('neu vondeish')
+        var display = link.LinkType == "derived"
+            ? lemmaTable.LinksOf(link.Form)?.Lemma ?? link.Form
+            : link.Form;
         return new LemmaTreeForm
         {
-            Form = link.Form,
+            Form = display,
             Attestations = vocabulary.AttestationsOf(counted),
             // an unread phrase is left un-greyed, as the browse leaves one:
             // greying is a claim

--- a/CorpusSearch/Service/LemmaIndexService.cs
+++ b/CorpusSearch/Service/LemmaIndexService.cs
@@ -262,8 +262,12 @@ public class LemmaIndexService(LemmaTable lemmaTable, CorpusVocabulary vocabular
             .Select(x => x.First())
             .ToList();
         // every particle link, echoes included: an undrawn phrase row still
-        // vouches for the form's mutation and still covers a childless guess
+        // vouches for the form's mutation
         var particles = all.Where(x => x.Link.LinkType == "particle").ToList();
+        // the phrase rows that will actually be drawn: one filing under its
+        // own entry ('dty vac' under Cregeen's entry 'dty vac') is not among
+        // them, and only a drawn row can cover a childless guess
+        var drawnParticles = particles.Where(x => !EchoesParent(x.Link, parentForm)).ToList();
         var rows = all
             .Where(x => x.Link.LinkType != "particle")
             .GroupBy(x => x.Link.Form)
@@ -282,29 +286,29 @@ public class LemmaIndexService(LemmaTable lemmaTable, CorpusVocabulary vocabular
                 return (Primary: links[0],
                     Also: links.Skip(1).Select(x => x.Link.LinkType).ToList());
             })
-            // a lone childless guess beside the form's particle row says
+            // a lone childless guess beside the form's drawn phrase row says
             // nothing the phrase does not: dropped. With a family to carry
-            // (gheiney holds the Phillips 'gene') it stays — the phrase
-            // cannot carry it.
+            // (gheiney holds the Phillips 'gene') it stays — and so does the
+            // guess whose only phrase row is the undrawn echo of the entry
+            // above: nothing else says the bare form (vac under Cregeen's
+            // entry 'dty vac')
             .Where(x => x.Primary.Link.LinkType != "demutated"
                         || x.Primary.ByParent[x.Primary.Link.Form].Any()
-                        || !particles.Any(p => p.Link.Form == x.Primary.Link.Form))
+                        || !drawnParticles.Any(p => p.Link.Form == x.Primary.Link.Form))
             // a mutation the book prints is not merely possible: the particle
-            // phrase ('e gheiney') attests it, so the surviving row files
-            // under Mutations — the hedge is kept for forms only the
-            // generator vouches for
+            // phrase ('e gheiney', 'dty vac') attests it, drawn or not, so
+            // the surviving row files under Mutations — the hedge is kept
+            // for forms only the generator vouches for
             .Select(x => x.Primary.Link.LinkType == "demutated"
                          && particles.Any(p => p.Link.Form == x.Primary.Link.Form)
                 ? (Primary: (Link: x.Primary.Link with { LinkType = "mutation" },
                         x.Primary.ByParent), x.Also)
                 : x)
             .ToList();
-        rows.AddRange(particles
-            // a particle row filing under its own phrase would say the entry
-            // above over again, count and all: not drawn — though it still
-            // counted above, as the mutation's voucher
-            .Where(x => !EchoesParent(x.Link, parentForm))
-            .Select(x => (Primary: x, Also: new List<string>())));
+        // an echoing particle row (its phrase is the entry above) said the
+        // entry over again, count and all: not drawn — though it counted
+        // above, as the mutation's voucher
+        rows.AddRange(drawnParticles.Select(x => (Primary: x, Also: new List<string>())));
         return rows
             .GroupBy(x => x.Primary.Link.LinkType)
             .OrderBy(g => GroupRank(g.Key))


### PR DESCRIPTION
Adds links of the style: 

* `mac` -> `vac`
* `vondeish` => `vondeishagh` => `s'vondeishagh`