### PR TITLE
feat: handle 'collection documents'

### DIFF
--- a/CorpusSearch.Test/DocumentLinePreparerTest.cs
+++ b/CorpusSearch.Test/DocumentLinePreparerTest.cs
@@ -137,12 +137,13 @@ public class DocumentLinePreparerTest
         const string json = """
             {"name": "n", "ident": "i", "translated": "Rob Teare 2021",
              "inlineSpeakerCodes": ["NM", "Q"], "manxColumnLanguage": "mixed",
-             "referenceBook": "Matthew"}
+             "referenceBook": "Matthew", "notesCitations": true}
             """;
         var document = JsonConvert.DeserializeObject<OpenSourceDocument>(json)!;
         Assert.That(document.InlineSpeakerCodes, Is.EqualTo(new[] { "NM", "Q" }));
         Assert.That(document.ManxColumnLanguage, Is.EqualTo("mixed"));
         Assert.That(document.ReferenceBook, Is.EqualTo("Matthew"));
+        Assert.That(document.NotesCitations, Is.True);
         // the new fields bind to properties, not the extension data shown to users
         Assert.That(document.ExtensionData.Keys, Is.EquivalentTo(new[] { "translated" }));
     }

--- a/CorpusSearch.Test/LineDateIndexTest.cs
+++ b/CorpusSearch.Test/LineDateIndexTest.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using CorpusSearch.Dependencies;
+using CorpusSearch.Model;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+/// <summary>
+/// Index-side half of the fragments-collection contract (<see cref="NotesCitationDates"/>):
+/// a line carrying its own date is indexed under it, and a scan reports the span of the
+/// *matched* lines - so a Brooillagh fragment attests its words in its citation's year,
+/// wherever it sits in the file. Documents whose lines share their date are unchanged.
+/// </summary>
+[TestFixture]
+public class LineDateIndexTest : QueryBase
+{
+    private const string DOC = "doc";
+
+    private void AddLines(params DocumentLine[] lines)
+    {
+        luceneIndex.Add(new TestDocument(DOC, DOC_DATE), lines);
+    }
+
+    private static DocumentLine Line(int lineNumber, string manx, DateTime? date = null)
+        => new() { Manx = manx, English = "", CsvLineNumber = lineNumber, Date = date };
+
+    private ScanResult Scan(string query) => new Searcher(luceneIndex, parser).Scan(query);
+
+    [Test]
+    public void AScanReportsTheSpanOfTheMatchedLines()
+    {
+        AddLines(
+            Line(2, "yn boggane mooar", new DateTime(1890, 3, 1)),
+            Line(3, "shenn boggane", new DateTime(1856, 11, 15)),
+            Line(4, "gyn boggane erbee", new DateTime(1872, 2, 21)));
+
+        var result = Scan("boggane").DocumentResults.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StartDate, Is.EqualTo(new DateTime(1856, 11, 15)));
+            Assert.That(result.EndDate, Is.EqualTo(new DateTime(1890, 3, 1)));
+        });
+    }
+
+    /// <summary>The fragments file is not chronological: the sample (the home page's
+    /// KWIC, the attestation walk's earliest form) is the earliest-dated matched
+    /// line, not the first in the file</summary>
+    [Test]
+    public void TheSampleIsTheEarliestDatedMatch()
+    {
+        AddLines(
+            Line(2, "yn boggane mooar", new DateTime(1890, 3, 1)),
+            Line(3, "shenn voggane", new DateTime(1856, 11, 15)));
+
+        var result = Scan("boggane or voggane").DocumentResults.Single();
+
+        Assert.That(result.Sample, Is.EqualTo("shenn voggane"));
+    }
+
+    /// <summary>Only the matched lines answer: a scan touching one fragment
+    /// reports that fragment's date, not the collection's whole span</summary>
+    [Test]
+    public void AnUnmatchedLinesDateDoesNotWiden()
+    {
+        AddLines(
+            Line(2, "yn boggane mooar", new DateTime(1890, 3, 1)),
+            Line(3, "red elley", new DateTime(1856, 11, 15)));
+
+        var result = Scan("boggane").DocumentResults.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StartDate, Is.EqualTo(new DateTime(1890, 3, 1)));
+            Assert.That(result.EndDate, Is.EqualTo(new DateTime(1890, 3, 1)));
+        });
+    }
+
+    /// <summary>Everything else in the corpus: lines without their own date index
+    /// under their document's, and the first match in the file stays the sample</summary>
+    [Test]
+    public void UndatedLinesKeepTheDocumentDateAndFirstLineSample()
+    {
+        AddLines(
+            Line(2, "yn boggane mooar"),
+            Line(3, "shenn voggane"));
+
+        var result = Scan("boggane or voggane").DocumentResults.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StartDate, Is.EqualTo(DOC_DATE));
+            Assert.That(result.EndDate, Is.EqualTo(DOC_DATE));
+            Assert.That(result.Sample, Is.EqualTo("yn boggane mooar"));
+        });
+    }
+
+    /// <summary>A document with no date at all still scans as undated</summary>
+    [Test]
+    public void AnUndatedDocumentScansAsUndated()
+    {
+        luceneIndex.Add(new TestDocument(DOC, null), new[] { Line(2, "yn boggane mooar") }.ToList());
+
+        var result = Scan("boggane").DocumentResults.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StartDate, Is.Null);
+            Assert.That(result.EndDate, Is.Null);
+        });
+    }
+}

--- a/CorpusSearch.Test/NotesCitationDatesTest.cs
+++ b/CorpusSearch.Test/NotesCitationDatesTest.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CorpusSearch.Model;
+using CorpusSearch.Services;
+using NUnit.Framework;
+
+namespace CorpusSearch.Test;
+
+/// <summary>
+/// The fragments-collection contract (Brooillagh): each line's Notes cell cites its
+/// real source and date, lines without a citation belong to the last cited fragment,
+/// and the collection's own date range is the span of its lines - so an 1858
+/// newspaper quotation never attests its words in the year the file was typed up.
+/// </summary>
+[TestFixture]
+public class NotesCitationDatesTest
+{
+    // the real formats of Brooillagh 2/document.csv
+    [TestCase("[M.H., 05/05/1858]", "1858-05-05")]
+    [TestCase("[M.A., 10/07/1802]", "1802-07-10")]
+    [TestCase("[M.S. 05/02/1881]", "1881-02-05")] // no comma
+    [TestCase("[M.S.16/02/1881]", "1881-02-16")] // no space at all
+    [TestCase("[IoMT, May 02/05/1868]", "1868-05-02")] // stray month name
+    [TestCase("[(Rev Radcliffe, Liverpool) M.H., 28/01/1885]", "1885-01-28")]
+    [TestCase("[9/3/1878]", "1878-03-09")] // single-digit day and month
+    [TestCase("M.S. 07/09/1889]", "1889-09-07")] // missing opening bracket
+    public void ACitationsFullDateParses(string note, string expected)
+    {
+        Assert.That(NotesCitationDates.Parse(note), Is.EqualTo(DateTime.Parse(expected)));
+    }
+
+    /// <summary>The transcriber's slips read as they were meant - the file is not
+    /// made to churn for the parser's benefit</summary>
+    [TestCase("[M.S., 23/051868]", "1868-05-23")] // second slash missing
+    [TestCase("[M.H., 17/101877]", "1877-10-17")]
+    [TestCase("[M.H., 03/071872]", "1872-07-03")]
+    [TestCase("[M.H., 07/01//1880]", "1880-01-07")] // doubled slash
+    public void ASlippedCitationStillParses(string note, string expected)
+    {
+        Assert.That(NotesCitationDates.Parse(note), Is.EqualTo(DateTime.Parse(expected)));
+    }
+
+    /// <summary>A book cites a year, not a day: the citation's last plausible year</summary>
+    [TestCase("[Mona Miscellany; Edited by W. Harrison: Manx Society Vol. XVI; 1869]", 1869)]
+    [TestCase("[A Tour Through the Isle of Man, D. Robertson. Pub. E. Hodson, London. 1794.", 1794)]
+    public void ABookCitationDatesToItsYear(string note, int expected)
+    {
+        Assert.That(NotesCitationDates.Parse(note), Is.EqualTo(new DateTime(expected, 1, 1)));
+    }
+
+    /// <summary>Prose may precede the citation: the last date wins</summary>
+    [Test]
+    public void TheLastDateInTheNoteWins()
+    {
+        const string note = "[Boat of this name is said to have run aground at " +
+                            "'Gob y Dagon', now known as Go-y-Deigan. [M.H., 01/01/1896]";
+        Assert.That(NotesCitationDates.Parse(note), Is.EqualTo(new DateTime(1896, 1, 1)));
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("[likely meaning; signing for the side opposing the lord]")]
+    [TestCase("What's the way to the vicarage of Kirk Andreas")]
+    public void AProseNoteHasNoDate(string? note)
+    {
+        Assert.That(NotesCitationDates.Parse(note), Is.Null);
+    }
+
+    /// <summary>A year outside 1500-2099 is not a date: a volume or page number</summary>
+    [Test]
+    public void AnImplausibleYearIsNotADate()
+    {
+        Assert.That(NotesCitationDates.Parse("[Manx Society Vol. 1211]"), Is.Null);
+    }
+
+    // unreadable citations: a day/month fragment with no valid full date. Parsing
+    // must not guess; the data repo's lint fails on these instead
+    [TestCase("[M.H., 31/02/1858]")] // no such calendar day
+    [TestCase("[M.H., 99/9/1858]")] // no such day at all
+    [TestCase("[M.H., 05/13]")] // no year
+    public void AnUnreadableCitationIsFlaggedForTheLint(string note)
+    {
+        Assert.That(NotesCitationDates.LooksDatedButUnparsed(note), Is.True, note);
+    }
+
+    [TestCase("[M.H., 05/05/1858]")]
+    [TestCase("[Mona Miscellany; 1869]")]
+    [TestCase("[likely meaning]")]
+    [TestCase("")]
+    [TestCase(null)]
+    public void AWellFormedOrProseNoteIsNotFlagged(string? note)
+    {
+        Assert.That(NotesCitationDates.LooksDatedButUnparsed(note), Is.False, note ?? "<null>");
+    }
+
+    private static OpenSourceDocument FragmentsManifest() => new()
+    {
+        Name = "doc",
+        Ident = "doc",
+        NotesCitations = true,
+    };
+
+    private static DocumentLine Line(string? note) => new() { Manx = "ta", English = "is", Notes = note };
+
+    [Test]
+    public void UncitedLinesBelongToTheLastCitedFragment()
+    {
+        var lines = new List<DocumentLine>
+        {
+            Line("[M.H., 05/05/1858]"),
+            Line(null), // the rest of the quoted song
+            Line("[a prose note on the fragment]"),
+            Line("[M.S., 15/11/1856]"), // the next fragment
+            Line(""),
+        };
+
+        DocumentLinePreparer.Prepare(FragmentsManifest(), lines);
+
+        Assert.That(lines.Select(x => x.Date), Is.EqualTo(new DateTime?[]
+        {
+            new DateTime(1858, 5, 5),
+            new DateTime(1858, 5, 5),
+            new DateTime(1858, 5, 5),
+            new DateTime(1856, 11, 15),
+            new DateTime(1856, 11, 15),
+        }));
+    }
+
+    [Test]
+    public void LinesBeforeTheFirstCitationStayUndated()
+    {
+        var lines = new List<DocumentLine> { Line(null), Line("[M.H., 05/05/1858]") };
+
+        DocumentLinePreparer.Prepare(FragmentsManifest(), lines);
+
+        Assert.That(lines[0].Date, Is.Null);
+        Assert.That(lines[1].Date, Is.EqualTo(new DateTime(1858, 5, 5)));
+    }
+
+    /// <summary>The collection spans its fragments - and the file need not be
+    /// chronological, so the span is min/max, not first/last</summary>
+    [Test]
+    public void TheCollectionsDateRangeIsTheSpanOfItsLines()
+    {
+        var document = FragmentsManifest();
+        var lines = new List<DocumentLine>
+        {
+            Line("[M.H., 05/05/1858]"),
+            Line("[IoMT, 02/05/1868]"),
+            Line("[M.A., 10/07/1802]"), // out of order, like the real file
+        };
+
+        DocumentLinePreparer.Prepare(document, lines);
+
+        Assert.That(document.CreatedCircaStart, Is.EqualTo(new DateTime(1802, 7, 10)));
+        Assert.That(document.CreatedCircaEnd, Is.EqualTo(new DateTime(1868, 5, 2)));
+    }
+
+    /// <summary>A manifest "created" is the transcription's date, not the
+    /// fragments': the lines' span replaces it</summary>
+    [Test]
+    public void TheLinesSpanReplacesAManifestDate()
+    {
+        var document = FragmentsManifest();
+        document.Created = new DateTime(2026, 7, 14);
+
+        DocumentLinePreparer.Prepare(document, [Line("[M.H., 05/05/1858]")]);
+
+        Assert.That(document.CreatedCircaStart, Is.EqualTo(new DateTime(1858, 5, 5)));
+        Assert.That(document.CreatedCircaEnd, Is.EqualTo(new DateTime(1858, 5, 5)));
+    }
+
+    [Test]
+    public void ACollectionWithoutParsableCitationsKeepsItsManifestDate()
+    {
+        var document = FragmentsManifest();
+        document.Created = new DateTime(1900, 1, 1);
+
+        DocumentLinePreparer.Prepare(document, [Line("[a prose note]")]);
+
+        Assert.That(document.CreatedCircaStart, Is.EqualTo(new DateTime(1900, 1, 1)));
+    }
+
+    /// <summary>Notes elsewhere in the corpus are annotations, not citations:
+    /// nothing happens without the manifest's opt-in</summary>
+    [Test]
+    public void WithoutTheManifestFlagNotesAreNotDates()
+    {
+        var document = new OpenSourceDocument { Name = "doc", Ident = "doc" };
+        var lines = new List<DocumentLine> { Line("[M.H., 05/05/1858]") };
+
+        DocumentLinePreparer.Prepare(document, lines);
+
+        Assert.That(lines[0].Date, Is.Null);
+        Assert.That(document.CreatedCircaStart, Is.Null);
+    }
+}

--- a/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
+++ b/CorpusSearch/Dependencies/Lucene/LuceneIndex.cs
@@ -170,8 +170,10 @@ public class LuceneIndex(IndexWriter indexWriter)
 
             AddField(DOCUMENT_ORIGINAL_ENGLISH, line.EnglishOriginal);
             AddField(DOCUMENT_ORIGINAL_MANX, line.ManxOriginal);
-            AddField(DOCUMENT_CREATED_START, document.CreatedCircaStart?.ToString());
-            AddField(DOCUMENT_CREATED_END, document.CreatedCircaEnd?.ToString());
+            // a line of a fragments collection carries its own date (NotesCitationDates):
+            // it attests its words in its citation's year, not the collection's span
+            AddField(DOCUMENT_CREATED_START, (line.Date ?? document.CreatedCircaStart)?.ToString());
+            AddField(DOCUMENT_CREATED_END, (line.Date ?? document.CreatedCircaEnd)?.ToString());
             AddField(DOCUMENT_NOTES, line.Notes);
             AddField(DOCUMENT_PAGE, line.Page.ToString());
             AddField(DOCUMENT_SPEAKER, line.Speaker);
@@ -221,14 +223,57 @@ public class LuceneIndex(IndexWriter indexWriter)
     }
 
     /// <summary>
-    /// docId -> (document ident, line number) for the whole index, so <see cref="Scan"/> can
-    /// group matched lines into corpus documents without loading each line's stored document
+    /// docId -> (document ident, line number, dates) for the whole index, so <see cref="Scan"/>
+    /// can group matched lines into corpus documents without loading each line's stored document
     /// (the dominant cost when a common word matches tens of thousands of lines).
     /// </summary>
-    private sealed class DocumentLookup(Ident[] idents, int[] lineNumbers)
+    private sealed class DocumentLookup(Ident[] idents, int[] lineNumbers, long[] startTicks, long[] endTicks)
     {
-        /// <summary>The corpus document ident and CsvLineNumber of the line with this docId</summary>
-        public (Ident Ident, int LineNumber) Get(DocId docId) => (idents[docId], lineNumbers[docId]);
+        /// <summary>The corpus document ident, CsvLineNumber and created dates of the line
+        /// with this docId. The dates are per line: a fragments collection's lines carry
+        /// their citations' dates, everything else its document's.</summary>
+        public (Ident Ident, int LineNumber, DateTime? Start, DateTime? End) Get(DocId docId) =>
+            (idents[docId], lineNumbers[docId], FromTicks(startTicks[docId]), FromTicks(endTicks[docId]));
+
+        // 0 = the line has no date: DateTime.MinValue.Ticks, unused by real dates
+        private static DateTime? FromTicks(long ticks) => ticks == 0 ? null : new DateTime(ticks);
+    }
+
+    /// <summary>
+    /// One corpus document's matched lines, folded as <see cref="Scan"/> meets them:
+    /// the match count, the date span of the matched lines, and the sample - the
+    /// earliest-dated line, ties broken by line number. For a document whose lines
+    /// all share its date the sample is simply the first match in the file, as before.
+    /// </summary>
+    private sealed class DocumentAggregate
+    {
+        public DocId SampleDocId { get; private set; }
+        private int sampleLineNumber = int.MaxValue;
+        // undated lines compare as MaxValue: any dated line makes a better sample
+        private DateTime sampleDate = DateTime.MaxValue;
+        public int Count { get; private set; }
+        public DateTime? StartDate { get; private set; }
+        public DateTime? EndDate { get; private set; }
+
+        public void Merge(DocId docId, int lineNumber, DateTime? startDate, DateTime? endDate, int count)
+        {
+            Count += count;
+            var date = startDate ?? DateTime.MaxValue;
+            if (date < sampleDate || date == sampleDate && lineNumber < sampleLineNumber)
+            {
+                SampleDocId = docId;
+                sampleLineNumber = lineNumber;
+                sampleDate = date;
+            }
+            if (startDate != null && (StartDate == null || startDate < StartDate))
+            {
+                StartDate = startDate;
+            }
+            if (endDate != null && (EndDate == null || endDate > EndDate))
+            {
+                EndDate = endDate;
+            }
+        }
     }
 
     private DocumentLookup? _documentLookup;
@@ -237,9 +282,12 @@ public class LuceneIndex(IndexWriter indexWriter)
     {
         var idents = new Ident[reader.MaxDoc];
         var lineNumbers = new int[reader.MaxDoc];
+        var startTicks = new long[reader.MaxDoc];
+        var endTicks = new long[reader.MaxDoc];
         // one shared string instance per document: ~800 idents across ~100k lines
         var identPool = new Dictionary<Ident, Ident>();
-        var fields = new HashSet<string> { DOCUMENT_IDENT, DOCUMENT_LINE_NUMBER };
+        var fields = new HashSet<string>
+            { DOCUMENT_IDENT, DOCUMENT_LINE_NUMBER, DOCUMENT_CREATED_START, DOCUMENT_CREATED_END };
         for (DocId docId = 0; docId < reader.MaxDoc; docId++)
         {
             var document = reader.Document(docId, fields);
@@ -255,9 +303,11 @@ public class LuceneIndex(IndexWriter indexWriter)
             }
             idents[docId] = ident;
             lineNumbers[docId] = document.GetInt32(DOCUMENT_LINE_NUMBER) ?? -1;
+            startTicks[docId] = document.GetDateTime(DOCUMENT_CREATED_START)?.Ticks ?? 0;
+            endTicks[docId] = document.GetDateTime(DOCUMENT_CREATED_END)?.Ticks ?? 0;
         }
 
-        return new DocumentLookup(idents, lineNumbers);
+        return new DocumentLookup(idents, lineNumbers, startTicks, endTicks);
     }
 
 
@@ -493,15 +543,17 @@ public class LuceneIndex(IndexWriter indexWriter)
         }
 
         // Group the matched lines into distinct Corpus Documents via the docId lookup. The
-        // sample is the first line by line number: docID order is merge-dependent, so it
-        // cannot be relied on (#303)
-        var corpusDocuments = new Dictionary<Ident, (DocId SampleDocId, int SampleLineNumber, int Count)>();
+        // sample is the earliest-dated matched line, ties broken by line number - one and
+        // the same for a document whose lines share its date, but a fragments collection's
+        // earliest evidence may sit anywhere in the file. docID order is merge-dependent,
+        // so it cannot be relied on (#303)
+        var corpusDocuments = new Dictionary<Ident, DocumentAggregate>();
         // the matched lines by corpus document, kept only when the timing
         // question will be asked of them: a big scan matches too many to hold
         var matchedLines = checkTranscriptTimings ? new Dictionary<Ident, List<DocId>>() : null;
         foreach (var docId in distinctDocuments.Concat(referenceCounts.Keys))
         {
-            var (ident, lineNumber) = lookup.Get(docId);
+            var (ident, lineNumber, startDate, endDate) = lookup.Get(docId);
             if (matchedLines != null)
             {
                 if (!matchedLines.TryGetValue(ident, out var lines))
@@ -515,16 +567,11 @@ public class LuceneIndex(IndexWriter indexWriter)
                 : CountsDistinctPositions(spanQuery.Field)
                     ? spanCollection.GetDistinctCount(docId)
                     : spanCollection.GetCount(docId);
-            if (corpusDocuments.TryGetValue(ident, out var existing))
+            if (!corpusDocuments.TryGetValue(ident, out var aggregate))
             {
-                corpusDocuments[ident] = lineNumber < existing.SampleLineNumber
-                    ? (docId, lineNumber, existing.Count + count)
-                    : (existing.SampleDocId, existing.SampleLineNumber, existing.Count + count);
+                corpusDocuments[ident] = aggregate = new DocumentAggregate();
             }
-            else
-            {
-                corpusDocuments[ident] = (docId, lineNumber, count);
-            }
+            aggregate.Merge(docId, lineNumber, startDate, endDate, count);
         }
 
         // The sample displayed on the Home page is always the Manx text: only highlight it when Manx was searched
@@ -535,12 +582,10 @@ public class LuceneIndex(IndexWriter indexWriter)
 
         var samples = corpusDocuments.Select(kvp =>
         {
-            var (sampleDocId, _, count) = kvp.Value;
+            var aggregate = kvp.Value;
+            var sampleDocId = aggregate.SampleDocId;
             // only the sample line's stored document is loaded: one per corpus document
             var doc = reader.Document(sampleDocId);
-
-            DateTime? startDate = doc.GetDateTime(DOCUMENT_CREATED_START);
-            DateTime? endDate = doc.GetDateTime(DOCUMENT_CREATED_END);
 
             var sample = doc.RequireString(DOCUMENT_REAL_MANX);
             var name = doc.RequireString(DOCUMENT_NAME);
@@ -552,10 +597,12 @@ public class LuceneIndex(IndexWriter indexWriter)
                 Sample = sample,
                 SampleHighlights = ComputeHighlights(reader, sampleDocId, spanQuery.Field, sample,
                     highlightTokenSpans.GetValueOrDefault(sampleDocId)),
-                EndDate = endDate,
-                StartDate = startDate,
+                // the span of the *matched* lines: a whole-document date for most
+                // documents, the matched fragments' for a citations collection
+                EndDate = aggregate.EndDate,
+                StartDate = aggregate.StartDate,
                 Timed = TimedOrNull(reader, name, matchedLines?[kvp.Key]),
-                Count = count
+                Count = aggregate.Count
             };
         });
 

--- a/CorpusSearch/Model/Document.cs
+++ b/CorpusSearch/Model/Document.cs
@@ -77,6 +77,15 @@ public abstract class Document : IDocument
     /// </summary>
     public string? ManxColumnLanguage { get; set; }
 
+    /// <summary>
+    /// The collection is fragments from many sources (Brooillagh), each line's
+    /// Notes cell citing its real source and date ("[M.H., 05/05/1858]"). Lines
+    /// date from their citations at load time - a line without one belongs to the
+    /// last cited fragment - and the collection's own date range becomes the span
+    /// of its lines. See <see cref="NotesCitationDates"/>.
+    /// </summary>
+    public bool NotesCitations { get; set; }
+
     [JsonExtensionData]
     public IDictionary<string, object> ExtensionData { get; set; } = new Dictionary<string, object>();
 

--- a/CorpusSearch/Model/DocumentLine.cs
+++ b/CorpusSearch/Model/DocumentLine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -58,6 +59,14 @@ public class DocumentLine
     /// at load time the collection default (the manifest field of the same name, else
     /// "gv") replaces an absent value.</summary>
     public string? Language { get; set; }
+
+    /// <summary>The line's own date, where it has one apart from its document's: in
+    /// a fragments collection (<see cref="NotesCitationDates"/>) each line dates
+    /// from its note's citation. Indexed per line (a Brooillagh line attests its
+    /// word in 1858, not when the collection was typed up); not serialized - the
+    /// note itself shows the reader the citation.</summary>
+    [JsonIgnore]
+    public DateTime? Date { get; set; }
 
     /// <summary>Value of <see cref="Language"/> meaning the Manx column is really Manx</summary>
     public const string ManxLanguageCode = "gv";

--- a/CorpusSearch/Model/DocumentLinePreparer.cs
+++ b/CorpusSearch/Model/DocumentLinePreparer.cs
@@ -15,6 +15,11 @@ public static class DocumentLinePreparer
 {
     public static void Prepare(Document document, List<DocumentLine> lines)
     {
+        if (document.NotesCitations)
+        {
+            NotesCitationDates.Apply(document, lines);
+        }
+
         var defaultLanguage = NormalizeLanguage(document.ManxColumnLanguage) ?? DocumentLine.ManxLanguageCode;
         var speakerCode = BuildSpeakerCodeRegex(document.InlineSpeakerCodes);
         var referenceFormats = BuildReferenceRegexes(document.InlineReferences);

--- a/CorpusSearch/Model/NotesCitationDates.cs
+++ b/CorpusSearch/Model/NotesCitationDates.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace CorpusSearch.Model;
+
+/// <summary>
+/// The dates of a fragments collection (<see cref="Document.NotesCitations"/>): a
+/// file like Brooillagh is one CSV of lines gleaned from many sources, each line's
+/// real source cited in its Notes cell ("[M.H., 05/05/1858]" - Mona's Herald;
+/// "[Mona Miscellany; ...; 1869]" for a book). The citation's date is the line's
+/// date; a line without one (the rest of a quoted song, or a prose note) belongs
+/// to the last cited fragment. The collection's own date range is then the span
+/// of its lines - without this, every 1794 attestation would carry the year the
+/// transcription was typed up.
+/// </summary>
+/// <remarks>Mirrored 1:1 in manx-search-data (TestUtil/NotesCitationDates.cs), so
+/// the data repo lints citations against the exact semantics production loads
+/// them with</remarks>
+public static class NotesCitationDates
+{
+    /// <summary>"05/05/1858" (day first) anywhere in the note: the citation's full
+    /// date. A doubled slash ("07/01//1880") reads the same: the citations are
+    /// parsed as their transcriber wrote them, slips included - the file is not
+    /// made to churn for the reader's benefit.</summary>
+    private static readonly Regex SlashedDate = new(@"\b(\d{1,2})/(\d{1,2})/{1,2}(\d{4})\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>The file's other slip: the second slash missing entirely, fusing
+    /// month and year ("23/051868", "17/101877" - 23/05/1868, 17/10/1877)</summary>
+    private static readonly Regex FusedDate = new(@"\b(\d{1,2})/(\d{2})(\d{4})\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>A plausible bare year ("... Manx Society Vol. XVI; 1869"): book
+    /// citations date to a year, not a day</summary>
+    private static readonly Regex BareYear = new(@"\b(1[5-9]\d\d|20\d\d)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>A day/month fragment: a note containing one means a full date was
+    /// intended, so <see cref="Parse"/> failing over it is a citation typo</summary>
+    private static readonly Regex DateFragment = new(@"\d{1,2}/\d{1,2}",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>The citation's date: the last full day/month/year in the note, else
+    /// the last bare year (a book cites no day), else null (a prose note, or none).
+    /// The last, not the first: prose may precede the citation
+    /// ("[... said to have run aground ... [M.H., 01/01/1896]").</summary>
+    public static DateTime? Parse(string? note)
+    {
+        if (string.IsNullOrWhiteSpace(note))
+        {
+            return null;
+        }
+
+        var fullDate = ParseFullDate(note);
+        if (fullDate != null)
+        {
+            return fullDate;
+        }
+
+        Match? lastYear = null;
+        foreach (Match match in BareYear.Matches(note))
+        {
+            lastYear = match;
+        }
+        return lastYear == null ? null : new DateTime(int.Parse(lastYear.Value), 1, 1);
+    }
+
+    /// <summary>The last day/month/year in the note which is a real calendar date;
+    /// 31/02/1858 is no date at all, and is left for the lint</summary>
+    private static DateTime? ParseFullDate(string note)
+    {
+        int lastIndex = -1;
+        DateTime? last = null;
+        foreach (var regex in new[] { SlashedDate, FusedDate })
+        {
+            foreach (Match match in regex.Matches(note))
+            {
+                int day = int.Parse(match.Groups[1].Value);
+                int month = int.Parse(match.Groups[2].Value);
+                int year = int.Parse(match.Groups[3].Value);
+                if (month is >= 1 and <= 12 && day >= 1 && day <= DateTime.DaysInMonth(year, month)
+                    && match.Index > lastIndex)
+                {
+                    lastIndex = match.Index;
+                    last = new DateTime(year, month, day);
+                }
+            }
+        }
+        return last;
+    }
+
+    /// <summary>Whether the note contains a day/month fragment yet no valid full
+    /// date: a mistyped citation ("23/051868", "07/01//1880") which would otherwise
+    /// silently date the line to the previous fragment, or fall back to its bare
+    /// year. The data repo's lint fails on these.</summary>
+    public static bool LooksDatedButUnparsed(string? note)
+    {
+        return !string.IsNullOrWhiteSpace(note)
+               && DateFragment.IsMatch(note)
+               && ParseFullDate(note) == null;
+    }
+
+    /// <summary>
+    /// Dates each line from its note's citation, lines without one inheriting the
+    /// last cited date, and settles the collection's own date range to the span of
+    /// its lines (a manifest "created" - the transcription date - is overridden:
+    /// the fragments are older than their typing-up).
+    /// </summary>
+    public static void Apply(Document document, IEnumerable<DocumentLine> lines)
+    {
+        DateTime? current = null;
+        DateTime? earliest = null;
+        DateTime? latest = null;
+        foreach (var line in lines)
+        {
+            current = Parse(line.Notes) ?? current;
+            line.Date = current;
+            if (current == null)
+            {
+                continue;
+            }
+            earliest = earliest == null || current < earliest ? current : earliest;
+            latest = latest == null || current > latest ? current : latest;
+        }
+
+        if (earliest != null)
+        {
+            document.CreatedCircaStart = earliest;
+            document.CreatedCircaEnd = latest;
+        }
+    }
+}


### PR DESCRIPTION
Rob was collecting fragments from the newspapers, and understandably didn't want a new document per fragment. This adds support for a similar formt which handles both dates and citations for the entries.

See `docs/Brooillagh` - words in this document are no longer shown as 2026. The document is now listed as 1794-1912

----

A fragments collection (manifest "notesCitations") is one CSV of lines gleaned from many sources, each line's real source cited in its Notes cell. Each line now dates from that citation - read as the transcriber wrote it, slips included - with uncited lines belonging to the last cited fragment. Lines index under their own dates, a scan reports the span of the matched lines (its sample the earliest evidence), and the collection's own range becomes the span of its lines: an 1856 boggane attests in 1856, not in the 2026 the file was typed up.