### PR TITLE
fix(dictionary): better handle conversion of hyphens to spaces

### DIFF
--- a/CorpusSearch.Test/CorpusVocabularyTest.cs
+++ b/CorpusSearch.Test/CorpusVocabularyTest.cs
@@ -156,6 +156,25 @@ public class CorpusVocabularyTest
         });
     }
 
+    /// <summary>A spaced headword is said by a hyphenated token: Cregeen prints
+    /// 'thie veaghee' and the Acts say 'thie-veaghee', which is the same saying —
+    /// <see cref="ASpacedFormIsCountedByItsHyphenatedTokens"/> counts it, and the
+    /// word page must not grey what its own attestation list finds</summary>
+    [Test]
+    public void ASpacedHeadwordIsAttestedByItsHyphenatedToken()
+    {
+        var vocabulary = Loaded("thie-veaghee");
+
+        Assert.Multiple(() =>
+        {
+            // the fold answers without waiting for the phrase scan
+            Assert.That(vocabulary.Attestation("thie veaghee"), Is.True);
+            // and the scan landing empty does not talk it back out
+            vocabulary.ScanPhrases(["thie veaghee"], ["yn thie-veaghee shoh"]);
+            Assert.That(vocabulary.IsAttested("thie veaghee"), Is.True);
+        });
+    }
+
     /// <summary>The phrase must be met whole and in order, not merely word by word
     /// within one line</summary>
     [Test]

--- a/CorpusSearch.Test/DictionaryHistoryServiceTest.cs
+++ b/CorpusSearch.Test/DictionaryHistoryServiceTest.cs
@@ -131,4 +131,23 @@ public class DictionaryHistoryScanTest : QueryBase
 
         Assert.That(history.TraditionalCount, Is.EqualTo(1));
     }
+
+    /// <summary>A form stands for every spelling that folds to it: Cregeen prints
+    /// 'thie veaghee' and the Acts say 'thie-veaghee', one token the strict scan
+    /// heard nothing of — the page listed the attestation while its timeline
+    /// stood empty</summary>
+    [Test]
+    public void AFoldedFormIsScannedThroughItsHyphenatedSpelling()
+    {
+        Add("Acts-1944", 1944, "yn thie-veaghee shoh");
+
+        var history = Service().History("gv", "thie veaghee");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(history.RevivedCount, Is.EqualTo(1));
+            Assert.That(history.Earliest!.EarliestYear, Is.EqualTo(1944));
+            Assert.That(history.Decades.Single().Decade, Is.EqualTo(1940));
+        });
+    }
 }

--- a/CorpusSearch/Service/CorpusVocabulary.cs
+++ b/CorpusSearch/Service/CorpusVocabulary.cs
@@ -146,7 +146,11 @@ public class CorpusVocabulary(LemmaTable lemmaTable)
     /// corpus, and only met a word at a time until that lands: 'aachummey eddin'
     /// is not said by a text saying 'aachummey' in one place and 'eddin' in
     /// another, and claiming so left a browse index un-greying 4,444 phrases on
-    /// one page whose word pages then had nothing to show.
+    /// one page whose word pages then had nothing to show. But a phrase the
+    /// corpus says as one hyphenated token is said: 'thie veaghee' by the Acts'
+    /// 'thie-veaghee', found through the fold <see cref="AttestationsOf"/>
+    /// counts with — leaving it grey put the word page at odds with its own
+    /// attestation list.
     ///
     /// The lemma hop is what saves a headword the corpus only ever writes
     /// mutated: 'yaagh' is 'jaagh' after a lenition, and a text that says the one
@@ -172,9 +176,18 @@ public class CorpusVocabulary(LemmaTable lemmaTable)
         var words = Words(word);
         if (words.Length > 1)
         {
-            // the corpus is read for a phrase, never guessed at: no lemma hop
-            // either — a phrase's mutations are not a paradigm the table holds,
-            // and the word page's own scan is as literal as this
+            // a spaced headword is said by a hyphenated token too: Cregeen's
+            // 'thie veaghee' is what the Acts say as 'thie-veaghee', and the
+            // count table has already folded the corpus the lemma table's way
+            // to know so — the same fold that answers AttestationsOf
+            if (formAttestations.GetValueOrDefault(LemmaTable.NormalizeForm(word)) > 0)
+            {
+                return true;
+            }
+            // otherwise the corpus is read for the phrase, never guessed at:
+            // no lemma hop either — a phrase's mutations are not a paradigm
+            // the table holds, and the word page's own scan is as literal as
+            // this
             return attestedPhrases == null
                 ? null
                 : attestedPhrases.GetValueOrDefault(string.Join(' ', words)) > 0;

--- a/CorpusSearch/Service/DictionaryHistoryService.cs
+++ b/CorpusSearch/Service/DictionaryHistoryService.cs
@@ -52,6 +52,16 @@ public class DictionaryHistoryService(
         var truncated = Math.Max(0, forms.Count - MaxForms);
         forms = forms.Take(MaxForms).ToList();
 
+        // the table's forms are folded — hyphens to spaces — and the corpus
+        // prints what it likes: 'thie veaghee' is said by the Acts' 'thie-
+        // veaghee', so a form is scanned for every spelling that folds to it.
+        // Never for an affix: its query is 'aa-*', whose hyphen is the very
+        // thing being asked about — split from its wildcard, the pieces would
+        // match the bare word beside anything at all.
+        var options = Affix.Is(word)
+            ? SearchOptions.Default
+            : SearchOptions.Default with { IgnoreHyphens = true };
+
         var attested = new List<HistoryForm>();
         // the timeline counts documents, not occurrences: the Bible is by far
         // the largest work and would otherwise dominate every graph
@@ -60,7 +70,7 @@ public class DictionaryHistoryService(
         {
             try
             {
-                var scanned = ScanForm(query, form);
+                var scanned = ScanForm(query, form, options);
                 if (scanned != null)
                 {
                     attested.Add(scanned.Value.Form);
@@ -146,8 +156,21 @@ public class DictionaryHistoryService(
         {
             forms = [LemmaTable.NormalizeForm(word)];
         }
+        // hyphen-agnostic scanning makes spellings differing only in their
+        // joins one query: 'thieveaghee' asks nothing 'thie veaghee' does not,
+        // and scanning both would count the Acts' one 'thie-veaghee' twice.
+        // One scan per join-blind key, through its most split spelling — the
+        // one whose regroupings cover the joined ones.
+        forms = forms
+            .GroupBy(form => LemmaTable.NormalizeForm(form).Replace(" ", ""))
+            .Select(joined => joined.OrderByDescending(WordCount).First())
+            .Order()
+            .ToList();
         return forms.Select(form => (form, form)).ToList();
     }
+
+    private static int WordCount(string form) =>
+        form.Split([' ', '-'], StringSplitOptions.RemoveEmptyEntries).Length;
 
     /// <summary>The cognates a definition cites: "(Ir. bile; S.G. bil.)" ->
     /// "Ir. bile; S.G. bil."</summary>
@@ -176,10 +199,12 @@ public class DictionaryHistoryService(
     /// <param name="query">what the corpus is asked. Usually the spelling itself;
     /// for an affix, the words carrying it, which is not a spelling</param>
     /// <param name="form">the spelling the uses belong to, as the page prints it</param>
+    /// <param name="options">how strictly the corpus is asked: hyphen-agnostic
+    /// for a folded form, literal for an affix query</param>
     private (HistoryForm Form, List<(string Ident, int Year)> DatedDocs)? ScanForm(
-        string query, string form)
+        string query, string form, SearchOptions options)
     {
-        var scan = searcher.Scan(query);
+        var scan = searcher.Scan(query, options);
         if (scan.NumberOfMatches == 0)
         {
             return null;


### PR DESCRIPTION
* collapse duplicate entries only differing by spaces: `thie veaghee` == `thie-veaghee`
  * also fix the timeline to include both entries